### PR TITLE
Implement Clip Inspector

### DIFF
--- a/src/opentimelineview/clip_inspector_widget.py
+++ b/src/opentimelineview/clip_inspector_widget.py
@@ -29,7 +29,7 @@ from PySide2.QtCore import Qt
 from PySide2.QtMultimediaWidgets import QGraphicsVideoItem
 
 import opentimelineio as otio
-from PySide2.QtWidgets import QWidget, QStackedLayout, QLabel,\
+from PySide2.QtWidgets import QWidget, QStackedLayout, QLabel, \
     QGraphicsScene, QGraphicsView, QGraphicsTextItem, QGraphicsRectItem
 
 
@@ -37,42 +37,65 @@ class ClipInspector(QWidget):
 
     def __init__(self, *args, **kwargs):
         super(ClipInspector, self).__init__(*args, **kwargs)
+        self.clipWidth = 640
+        self.clipHeight = 360
         self.scene = QGraphicsScene(self)
         self.graphicsView = QGraphicsView(self.scene)
         self.graphicsView.setBackgroundBrush(QBrush(Qt.black, Qt.SolidPattern))
         self.videoItem = QGraphicsVideoItem()
-        self.videoItem.setSize(QSizeF(640, 360))
+        self.videoItem.setSize(QSizeF(self.clipWidth, self.clipHeight))
         self.scene.addItem(self.videoItem)
         self.player = QMediaPlayer()
         self.player.setVideoOutput(self.videoItem)
         self.player.error.connect(self.handle_error)
         self.player.setVolume(100)
-        self.errorImage = QImage(QSize(640, 360), QImage.Format_RGB32)
-        self.create_error_image()
-        self.errorLabel = QLabel()
-        self.errorLabel.setPixmap(QPixmap.fromImage(self.errorImage))
+        self.unresolvedMediaErrorImage = QImage(QSize(self.clipWidth, self.clipHeight),
+                                                QImage.Format_RGB32)
+        self.unsupportedMediaErrorImage = QImage(QSize(self.clipWidth, self.clipHeight),
+                                                 QImage.Format_RGB32)
+        self.create_error_images()
+        # unresolved media error QLabel
+        self.unresolvedMediaErrorLabel = QLabel()
+        self.unresolvedMediaErrorLabel.setPixmap(
+            QPixmap.fromImage(self.unresolvedMediaErrorImage))
+        # unresolved media error QLabel
+        self.unsupportedMediaErrorLabel = QLabel()
+        self.unsupportedMediaErrorLabel.setPixmap(
+            QPixmap.fromImage(self.unsupportedMediaErrorImage))
+        # create stacked layout for video and error messages
         self.videoLayout = QStackedLayout()
-        # self.videoLayout.addWidget(self.videoWidget)
+        # Clip Inspector widget stack
+        # index 0 - video and banners
+        # index 1 - unresolved media error message
+        # index 2 - unsupported media error message
         self.videoLayout.addWidget(self.graphicsView)
-        self.videoLayout.addWidget(self.errorLabel)
+        self.videoLayout.addWidget(self.unresolvedMediaErrorLabel)
+        self.videoLayout.addWidget(self.unsupportedMediaErrorLabel)
         self.setLayout(self.videoLayout)
-        self.setFixedWidth(650)
-        self.setFixedHeight(370)
+        # TODO: find fix for constant widget size
+        self.setFixedWidth(self.clipWidth + 10)
+        self.setFixedHeight(self.clipHeight + 10)
+        # instance variables for effects banner
         self.effectTextItem = QGraphicsTextItem("effect")
         self.effectRectItem = QGraphicsRectItem(0, 0, 0, 0)
         self.effectRectItem.setBrush(QBrush(QColor(255, 255, 255, 40)))
+        # utility variables
+        self.effectsDisplayed = False
 
     def show(self):
         # self.videoWidget.show()
         pass
 
     def update_clip(self, clip):
-        self.videoLayout.setCurrentIndex(0)
-        self.player.stop()
-        self.scene.removeItem(self.effectTextItem)
-        self.scene.removeItem(self.effectRectItem)
+        self.videoLayout.setCurrentIndex(0)  # show video player widget
+        self.player.stop()  # stop player before changing media state
+        # remove effects banner in case displayed
+        if self.effectsDisplayed:
+            self.scene.removeItem(self.effectTextItem)
+            self.scene.removeItem(self.effectRectItem)
+            self.effectsDisplayed = False
         if isinstance(clip, otio.schema.Clip):
-            if len(clip.effects) != 0:
+            if len(clip.effects) != 0:  # show effects banner if effects present
                 self.effectTextItem = QGraphicsTextItem(clip.effects[0].effect_name +
                                                         " effect")
                 textFont = self.effectTextItem.font()
@@ -80,14 +103,16 @@ class ClipInspector(QWidget):
                 self.effectTextItem.setFont(textFont)
                 textWidth = self.effectTextItem.boundingRect().width()
                 textHeight = self.effectTextItem.boundingRect().height()
-                self.effectTextItem.setPos(320 - textWidth * 0.5,
-                                           180 - textHeight * 0.5)
-                self.effectRectItem = QGraphicsRectItem(0, 180 + textHeight * 0.5,
-                                                        640, -textHeight)
+                self.effectTextItem.setPos(self.clipWidth * 0.5 - textWidth * 0.5,
+                                           self.clipHeight * 0.5 - textHeight * 0.5)
+                self.effectRectItem = QGraphicsRectItem(0, self.clipHeight * 0.5
+                                                        + textHeight * 0.5,
+                                                        self.clipWidth, -textHeight)
                 self.effectRectItem.setBrush(QBrush(QColor(0, 0, 255, 100)))
                 self.effectRectItem.setPen(Qt.NoPen)
                 self.scene.addItem(self.effectRectItem)
                 self.scene.addItem(self.effectTextItem)
+                self.effectsDisplayed = True
             path = clip.media_reference.target_url
             if path.startswith('file://'):
                 path = path[7:]
@@ -107,17 +132,32 @@ class ClipInspector(QWidget):
     def set_clip_position(self, position):
         self.player.setPosition(position)
 
-    def create_error_image(self):
-        painter = QPainter(self.errorImage)
+    def create_error_images(self):
+        # painter for unresolved media error image
+        painter = QPainter(self.unresolvedMediaErrorImage)
         painter.setBrush(QBrush(Qt.green))
-        painter.fillRect(QRectF(0, 0, 640, 360), Qt.green)
+        painter.fillRect(QRectF(0, 0, self.clipWidth, self.clipHeight), Qt.green)
         painter.setPen(QPen(Qt.black))
+        # use larger font size
         font = painter.font()
         font.setPointSize(font.pointSize() * 3)
         painter.setFont(font)
-        painter.drawText(QRect(160, 90, 320, 180), "Media Reference can't be resolved.")
+        painter.drawText(QRectF(self.clipWidth * 0.25, self.clipHeight * 0.25,
+                                self.clipWidth * 0.5, self.clipHeight * 0.6),
+                         "Media Reference can't be resolved.")
+        # painter for unsupported media error image
+        painter = QPainter(self.unsupportedMediaErrorImage)
+        painter.setBrush(QBrush(Qt.green))
+        painter.fillRect(QRectF(0, 0, self.clipWidth, self.clipHeight), Qt.green)
+        painter.setPen(QPen(Qt.black))
+        painter.setFont(font)
+        painter.drawText(QRectF(self.clipWidth * 0.25, self.clipHeight * 0.25,
+                                self.clipWidth * 0.5, self.clipHeight * 0.6),
+                         "Unsupported Media format.")
 
     def handle_error(self):
-        if self.player.errorString() == 'Resource not found.' or\
+        if self.player.errorString() == 'Resource not found.' or \
                 self.player.errorString() == 'Not Found':
-            self.videoLayout.setCurrentIndex(1)
+            self.videoLayout.setCurrentIndex(1)  # display unresolved media error
+        elif self.player.errorString().startswith('Cannot play stream of type:'):
+            self.videoLayout.setCurrentIndex(2)  # display unsupported media error

--- a/src/opentimelineview/clip_inspector_widget.py
+++ b/src/opentimelineview/clip_inspector_widget.py
@@ -26,11 +26,11 @@ from PySide2.QtCore import QUrl, QSize, QRectF, QRect, QSizeF
 from PySide2.QtGui import QImage, QPainter, QBrush, QPen, QPixmap, QColor
 from PySide2.QtMultimedia import QMediaPlayer
 from PySide2.QtCore import Qt
-from PySide2.QtMultimediaWidgets import QVideoWidget, QGraphicsVideoItem
+from PySide2.QtMultimediaWidgets import QGraphicsVideoItem
 
 import opentimelineio as otio
-from PySide2.QtWidgets import QWidget, QStackedLayout, QLabel, QGraphicsScene, QGraphicsView, QGraphicsTextItem, \
-    QGraphicsRectItem
+from PySide2.QtWidgets import QWidget, QStackedLayout, QLabel,\
+    QGraphicsScene, QGraphicsView, QGraphicsTextItem, QGraphicsRectItem
 
 
 class ClipInspector(QWidget):
@@ -74,7 +74,8 @@ class ClipInspector(QWidget):
         if isinstance(clip, otio.schema.Clip):
             if len(clip.effects) != 0:
                 self.scene.addItem(self.effectRectItem)
-                self.effectTextItem = QGraphicsTextItem(clip.effects[0].effect_name + " effect")
+                self.effectTextItem = QGraphicsTextItem(clip.effects[0].effect_name +
+                                                        " effect")
                 textFont = self.effectTextItem.font()
                 textFont.setPointSize(textFont.pointSize() * 3)
                 self.effectTextItem.setFont(textFont)
@@ -110,6 +111,6 @@ class ClipInspector(QWidget):
         painter.drawText(QRect(160, 90, 320, 180), "Media Reference can't be resolved.")
 
     def handle_error(self):
-        if self.player.errorString() == 'Resource not found.' or self.player.errorString() == 'Not Found':
+        if self.player.errorString() == 'Resource not found.' or\
+                self.player.errorString() == 'Not Found':
             self.videoLayout.setCurrentIndex(1)
-

--- a/src/opentimelineview/clip_inspector_widget.py
+++ b/src/opentimelineview/clip_inspector_widget.py
@@ -59,7 +59,7 @@ class ClipInspector(QWidget):
         self.setFixedWidth(650)
         self.setFixedHeight(370)
         self.effectTextItem = QGraphicsTextItem("effect")
-        self.effectRectItem = QGraphicsRectItem(0, 0, 640, 360)
+        self.effectRectItem = QGraphicsRectItem(0, 0, 0, 0)
         self.effectRectItem.setBrush(QBrush(QColor(255, 255, 255, 40)))
 
     def show(self):
@@ -73,13 +73,20 @@ class ClipInspector(QWidget):
         self.scene.removeItem(self.effectRectItem)
         if isinstance(clip, otio.schema.Clip):
             if len(clip.effects) != 0:
-                self.scene.addItem(self.effectRectItem)
                 self.effectTextItem = QGraphicsTextItem(clip.effects[0].effect_name +
                                                         " effect")
                 textFont = self.effectTextItem.font()
                 textFont.setPointSize(textFont.pointSize() * 3)
                 self.effectTextItem.setFont(textFont)
-                self.effectTextItem.setPos(100, 150)
+                textWidth = self.effectTextItem.boundingRect().width()
+                textHeight = self.effectTextItem.boundingRect().height()
+                self.effectTextItem.setPos(320 - textWidth * 0.5,
+                                           180 - textHeight * 0.5)
+                self.effectRectItem = QGraphicsRectItem(0, 180 + textHeight * 0.5,
+                                                        640, -textHeight)
+                self.effectRectItem.setBrush(QBrush(QColor(0, 0, 255, 100)))
+                self.effectRectItem.setPen(Qt.NoPen)
+                self.scene.addItem(self.effectRectItem)
                 self.scene.addItem(self.effectTextItem)
             path = clip.media_reference.target_url
             if path.startswith('file://'):

--- a/src/opentimelineview/clip_inspector_widget.py
+++ b/src/opentimelineview/clip_inspector_widget.py
@@ -22,34 +22,72 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-from PySide2.QtCore import QUrl
-from PySide2.QtMultimedia import QMediaPlayer, QMediaPlaylist
-from PySide2.QtMultimediaWidgets import QVideoWidget
+from PySide2.QtCore import QUrl, QSize, QRectF, QRect, QSizeF
+from PySide2.QtGui import QImage, QPainter, QBrush, QPen, QPixmap, QColor
+from PySide2.QtMultimedia import QMediaPlayer
+from PySide2.QtCore import Qt
+from PySide2.QtMultimediaWidgets import QVideoWidget, QGraphicsVideoItem
 
 import opentimelineio as otio
+from PySide2.QtWidgets import QWidget, QStackedLayout, QLabel, QGraphicsScene, QGraphicsView, QGraphicsTextItem, \
+    QGraphicsRectItem
 
 
-class ClipInspector(QVideoWidget):
+class ClipInspector(QWidget):
 
     def __init__(self, *args, **kwargs):
         super(ClipInspector, self).__init__(*args, **kwargs)
+        self.scene = QGraphicsScene(self)
+        self.graphicsView = QGraphicsView(self.scene)
+        self.graphicsView.setBackgroundBrush(QBrush(Qt.black, Qt.SolidPattern))
+        self.videoItem = QGraphicsVideoItem()
+        self.videoItem.setSize(QSizeF(640, 360))
+        self.scene.addItem(self.videoItem)
         self.player = QMediaPlayer()
-        self.player.setVideoOutput(self)
-        # self.setScaleMode()
-        # self.show()
+        self.player.setVideoOutput(self.videoItem)
+        self.player.error.connect(self.handle_error)
+        self.player.setVolume(100)
+        self.errorImage = QImage(QSize(640, 360), QImage.Format_RGB32)
+        self.create_error_image()
+        self.errorLabel = QLabel()
+        self.errorLabel.setPixmap(QPixmap.fromImage(self.errorImage))
+        self.videoLayout = QStackedLayout()
+        # self.videoLayout.addWidget(self.videoWidget)
+        self.videoLayout.addWidget(self.graphicsView)
+        self.videoLayout.addWidget(self.errorLabel)
+        self.setLayout(self.videoLayout)
+        self.setFixedWidth(650)
+        self.setFixedHeight(370)
+        self.effectTextItem = QGraphicsTextItem("effect")
+        self.effectRectItem = QGraphicsRectItem(0, 0, 640, 360)
+        self.effectRectItem.setBrush(QBrush(QColor(255, 255, 255, 40)))
+
+    def show(self):
+        # self.videoWidget.show()
+        pass
 
     def update_clip(self, clip):
+        self.videoLayout.setCurrentIndex(0)
         self.player.stop()
+        self.scene.removeItem(self.effectTextItem)
+        self.scene.removeItem(self.effectRectItem)
         if isinstance(clip, otio.schema.Clip):
+            if len(clip.effects) != 0:
+                self.scene.addItem(self.effectRectItem)
+                self.effectTextItem = QGraphicsTextItem(clip.effects[0].effect_name + " effect")
+                textFont = self.effectTextItem.font()
+                textFont.setPointSize(textFont.pointSize() * 3)
+                self.effectTextItem.setFont(textFont)
+                self.effectTextItem.setPos(100, 150)
+                self.scene.addItem(self.effectTextItem)
             path = clip.media_reference.target_url
             if path.startswith('file://'):
                 path = path[7:]
-            self.player.setMedia(QUrl.fromLocalFile(path))
-            self.player.setVolume(100)
-            # self.player.play()
+                self.player.setMedia(QUrl.fromLocalFile(path))
+            elif path.startswith('http'):
+                self.player.setMedia(QUrl(path))
 
     def play_clip(self):
-        print('here')
         self.player.play()
 
     def pause_clip(self):
@@ -60,3 +98,18 @@ class ClipInspector(QVideoWidget):
 
     def set_clip_position(self, position):
         self.player.setPosition(position)
+
+    def create_error_image(self):
+        painter = QPainter(self.errorImage)
+        painter.setBrush(QBrush(Qt.green))
+        painter.fillRect(QRectF(0, 0, 640, 360), Qt.green)
+        painter.setPen(QPen(Qt.black))
+        font = painter.font()
+        font.setPointSize(font.pointSize() * 3)
+        painter.setFont(font)
+        painter.drawText(QRect(160, 90, 320, 180), "Media Reference can't be resolved.")
+
+    def handle_error(self):
+        if self.player.errorString() == 'Resource not found.' or self.player.errorString() == 'Not Found':
+            self.videoLayout.setCurrentIndex(1)
+

--- a/src/opentimelineview/clip_inspector_widget.py
+++ b/src/opentimelineview/clip_inspector_widget.py
@@ -31,6 +31,10 @@ import opentimelineio as otio
 from PySide2.QtWidgets import QWidget, QStackedLayout, QLabel, \
     QGraphicsScene, QGraphicsView, QVBoxLayout, QHBoxLayout, QComboBox
 
+RANGE_TYPE_TRIMMED = 'trimmed'
+RANGE_TYPE_SOURCE = 'source'
+RANGE_TYPE_AVAILABLE = 'available'
+
 
 class ClipInspector(QWidget):
 
@@ -99,15 +103,20 @@ class ClipInspector(QWidget):
         # utility variables
         self.clip_start_duration = 0.0
         self.clip_end_duration = 0.0
-        self.range_type = 0
+        self.range_type = RANGE_TYPE_TRIMMED
         self.clip = None
 
     def combobox_selection_changed(self, i):
-        self.range_type = i
+        if i == 0:
+            self.range_type = RANGE_TYPE_TRIMMED
+        elif i == 1:
+            self.range_type = RANGE_TYPE_SOURCE
+        elif i == 2:
+            self.range_type = RANGE_TYPE_AVAILABLE
         self.update_clip(self.clip)
 
     def update_duration(self, duration):
-        if self.range_type == 0:
+        if self.range_type is RANGE_TYPE_TRIMMED:
             self.clip_start_duration = (self.clip.trimmed_range().start_time.value /
                                         self.clip.trimmed_range().start_time.rate)
             self.clip_end_duration = (self.clip_start_duration +
@@ -115,7 +124,7 @@ class ClipInspector(QWidget):
                                        self.clip.trimmed_range().duration.rate))
             self.clip_start_duration *= 1000
             self.clip_end_duration *= 1000
-        elif self.range_type == 1:
+        elif self.range_type is RANGE_TYPE_SOURCE:
             self.clip_start_duration = (self.clip.source_range.start_time.value /
                                         self.clip.source_range.start_time.rate)
             self.clip_end_duration = (self.clip_start_duration +
@@ -123,7 +132,7 @@ class ClipInspector(QWidget):
                                        self.clip.source_range.duration.rate))
             self.clip_start_duration *= 1000
             self.clip_end_duration *= 1000
-        elif self.range_type == 2:
+        elif self.range_type is RANGE_TYPE_AVAILABLE:
             self.clip_start_duration = (self.clip.available_range().start_time.value /
                                         self.clip.available_range().start_time.rate)
             self.clip_end_duration = (self.clip_start_duration +
@@ -201,8 +210,8 @@ class ClipInspector(QWidget):
                          "Unsupported Media format.")
 
     def handle_error(self):
-        if self.player.errorString() == 'Resource not found.' or \
-                self.player.errorString() == 'Not Found':
+        if (self.player.errorString() == 'Resource not found.'
+                or self.player.errorString() == 'Not Found'):
             self.videoLayout.setCurrentIndex(1)  # display unresolved media error
         elif self.player.errorString().startswith('Cannot play stream of type:'):
             self.videoLayout.setCurrentIndex(2)  # display unsupported media error

--- a/src/opentimelineview/clip_inspector_widget.py
+++ b/src/opentimelineview/clip_inspector_widget.py
@@ -22,10 +22,41 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-# flake8: noqa
+from PySide2.QtCore import QUrl
+from PySide2.QtMultimedia import QMediaPlayer, QMediaPlaylist
+from PySide2.QtMultimediaWidgets import QVideoWidget
 
-from . import (
-    details_widget,
-    timeline_widget,
-    clip_inspector_widget,
-)
+import opentimelineio as otio
+
+
+class ClipInspector(QVideoWidget):
+
+    def __init__(self, *args, **kwargs):
+        super(ClipInspector, self).__init__(*args, **kwargs)
+        self.player = QMediaPlayer()
+        self.player.setVideoOutput(self)
+        # self.setScaleMode()
+        # self.show()
+
+    def update_clip(self, clip):
+        self.player.stop()
+        if isinstance(clip, otio.schema.Clip):
+            path = clip.media_reference.target_url
+            if path.startswith('file://'):
+                path = path[7:]
+            self.player.setMedia(QUrl.fromLocalFile(path))
+            self.player.setVolume(100)
+            # self.player.play()
+
+    def play_clip(self):
+        print('here')
+        self.player.play()
+
+    def pause_clip(self):
+        self.player.pause()
+
+    def stop_clip(self):
+        self.player.stop()
+
+    def set_clip_position(self, position):
+        self.player.setPosition(position)

--- a/src/opentimelineview/console.py
+++ b/src/opentimelineview/console.py
@@ -166,6 +166,7 @@ class Main(QtWidgets.QMainWindow):
         self.controlLayout.addWidget(self.positionSlider)
         self.controlWidget = QWidget(self)
         self.controlWidget.setLayout(self.controlLayout)
+        self.controlWidget.setFixedHeight(50)
 
         root = QtWidgets.QWidget(parent=self)
         layout = QtWidgets.QVBoxLayout(root)

--- a/src/opentimelineview/console.py
+++ b/src/opentimelineview/console.py
@@ -223,10 +223,19 @@ class Main(QtWidgets.QMainWindow):
         self.setStyleSheet(settings.VIEW_STYLESHEET)
 
     def clip_duration_changed(self, duration):
-        self.positionSlider.setRange(0, duration)
+        self.positionSlider.setRange(self.clip_inspector_widget.clip_start_duration,
+                                     self.clip_inspector_widget.clip_end_duration)
 
     def clip_position_changed(self, position):
-        self.positionSlider.setValue(position)
+        if position < self.clip_inspector_widget.clip_start_duration:
+            self.clip_inspector_widget.stop_clip()
+            self.positionSlider.setValue(self.clip_inspector_widget.clip_start_duration)
+        elif position > self.clip_inspector_widget.clip_end_duration:
+            self.clip_inspector_widget.stop_clip()
+            self.positionSlider.setValue(self.clip_inspector_widget.clip_end_duration)
+            self.positionSlider.setValue(self.clip_inspector_widget.clip_end_duration)
+        else:
+            self.positionSlider.setValue(position)
 
     def _file_load(self):
         start_folder = None

--- a/src/opentimelineview/console.py
+++ b/src/opentimelineview/console.py
@@ -56,8 +56,8 @@ def _parsed_args():
         default=[],
         action='append',
         help='Extra arguments to be passed to adapter in the form of '
-        'key=value. Values are strings, numbers or Python literals: True, '
-        'False, etc. Can be used multiple times: -a burrito="bar" -a taco=12.'
+             'key=value. Values are strings, numbers or Python literals: True, '
+             'False, etc. Can be used multiple times: -a burrito="bar" -a taco=12.'
     )
     parser.add_argument(
         '-H',
@@ -66,8 +66,8 @@ def _parsed_args():
         default=[],
         action='append',
         help='Extra arguments to be passed to the hook functions in the form of '
-        'key=value. Values are strings, numbers or Python literals: True, '
-        'False, etc. Can be used multiple times: -H burrito="bar" -H taco=12.'
+             'key=value. Values are strings, numbers or Python literals: True, '
+             'False, etc. Can be used multiple times: -H burrito="bar" -H taco=12.'
     )
     parser.add_argument(
         '-m',
@@ -88,8 +88,8 @@ def _parsed_args():
         default=[],
         action='append',
         help='Extra arguments to be passed to the media linker in the form of '
-        'key=value. Values are strings, numbers or Python literals: True, '
-        'False, etc. Can be used multiple times: -M burrito="bar" -M taco=12.'
+             'key=value. Values are strings, numbers or Python literals: True, '
+             'False, etc. Can be used multiple times: -M burrito="bar" -M taco=12.'
     )
 
     return parser.parse_args()
@@ -124,7 +124,8 @@ class Main(QtWidgets.QMainWindow):
         self.resize(1900, 1200)
 
         # widgets
-        self.clip_inspector_widget = otioViewWidget.clip_inspector_widget.ClipInspector(self)
+        self.clip_inspector_widget = otioViewWidget.clip_inspector_widget.ClipInspector(
+            self)
         self.clip_inspector_widget.show()
 
         self.tracks_widget = QtWidgets.QListWidget(
@@ -152,9 +153,12 @@ class Main(QtWidgets.QMainWindow):
 
         self.positionSlider = QSlider(Qt.Horizontal)
         self.positionSlider.setRange(0, 0)
-        self.positionSlider.sliderMoved.connect(self.clip_inspector_widget.set_clip_position)
-        self.clip_inspector_widget.player.durationChanged.connect(self.clip_duration_changed)
-        self.clip_inspector_widget.player.positionChanged.connect(self.clip_position_changed)
+        self.positionSlider.sliderMoved.connect(
+            self.clip_inspector_widget.set_clip_position)
+        self.clip_inspector_widget.player.durationChanged.connect(
+            self.clip_duration_changed)
+        self.clip_inspector_widget.player.positionChanged.connect(
+            self.clip_position_changed)
 
         self.controlLayout.addWidget(self.playButton)
         self.controlLayout.addWidget(self.pauseButton)
@@ -261,8 +265,8 @@ class Main(QtWidgets.QMainWindow):
             self.timeline_widget.set_timeline(file_contents)
             self.tracks_widget.setVisible(False)
         elif isinstance(
-            file_contents,
-            otio.schema.SerializableCollection
+                file_contents,
+                otio.schema.SerializableCollection
         ):
             for s in file_contents:
                 TimelineWidgetItem(s, s.name, self.tracks_widget)
@@ -280,6 +284,7 @@ class Main(QtWidgets.QMainWindow):
 
         def __callback():
             self._navigation_filter_callback(actions)
+
         navigation_menu.triggered[[QtWidgets.QAction]].connect(__callback)
 
     def _navigation_filter_callback(self, filters):

--- a/src/opentimelineview/console.py
+++ b/src/opentimelineview/console.py
@@ -125,7 +125,7 @@ class Main(QtWidgets.QMainWindow):
 
         # widgets
         self.clip_inspector_widget = otioViewWidget.clip_inspector_widget.ClipInspector(
-            self)
+            clip_duration_callback=self.clip_duration_changed)
         self.clip_inspector_widget.show()
 
         self.tracks_widget = QtWidgets.QListWidget(
@@ -155,8 +155,6 @@ class Main(QtWidgets.QMainWindow):
         self.positionSlider.setRange(0, 0)
         self.positionSlider.sliderMoved.connect(
             self.clip_inspector_widget.set_clip_position)
-        self.clip_inspector_widget.player.durationChanged.connect(
-            self.clip_duration_changed)
         self.clip_inspector_widget.player.positionChanged.connect(
             self.clip_position_changed)
 
@@ -222,9 +220,9 @@ class Main(QtWidgets.QMainWindow):
 
         self.setStyleSheet(settings.VIEW_STYLESHEET)
 
-    def clip_duration_changed(self, duration):
-        self.positionSlider.setRange(self.clip_inspector_widget.clip_start_duration,
-                                     self.clip_inspector_widget.clip_end_duration)
+    def clip_duration_changed(self, clip_start_duration, clip_end_duration):
+        self.positionSlider.setRange(clip_start_duration,
+                                     clip_end_duration)
 
     def clip_position_changed(self, position):
         if position < self.clip_inspector_widget.clip_start_duration:


### PR DESCRIPTION
Closes #280 

As discussed in the TSC meeting, I've implemented a Clip Inspector that allows you to play the clip you've clicked on.

For now I show the complete range of the clip. I'll try implementing an option to view the `source_range`.

It looks something like this:
![player](https://user-images.githubusercontent.com/35020024/79699417-2e8a7380-82ad-11ea-87ea-8cf614d1fb57.gif)

To show an effect in case it exists I've drawn a translucent rectangle and shown the effect-name on top. Something like this:
![Screenshot from 2020-04-20 02-07-01](https://user-images.githubusercontent.com/35020024/79699450-5548aa00-82ad-11ea-9e1c-7f1eb5426223.png)

In case a Media Reference cannot be resolved I've show a message saying the same:
![image](https://user-images.githubusercontent.com/35020024/79699547-d011c500-82ad-11ea-9f67-2616f32f7183.png)

There are a few things to clarify/improve:
- In case there are multiple effects on a clip, what do we want to do? At the moment I've just shown the name of the first effect.
- Right now, the size of the Clip Inspector is constant. I had to do this because the size of the widget is very large at startup, which I'm not sure but might be because of the way I'm showing the error message. But this does seem to work alright.
- Also, In case I do not set a constant widget size, I'm having trouble maintaining the aspect ratio of the video upon resizing.

@ssteinbach @reinecke @jminor I look forward to hearing your thoughts on this!

