### PR TITLE
Initial setup of stale action. Nudging or closing stale issues …

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+name: 'Nudge or close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          exempt-issue-label: 'needs discussion'
+          exempt-pr-label: 'WIP,draft'
+          stale-issue-message: 'This issue has been open 30 days with no activity and will be closed automatically in 5 days if left unattended. Simply remove the "stale" label or update the issue to keep it open.'
+          stale-pr-message: 'This PR has been open 45 days with no activity and will be closed automatically in 10 days if left unattended. Simply remove the "stale" label or leave a comment to keep it open.'
+          close-issue-message: 'This issue was closed automatically due to inactivity.'
+          close-pr-message: 'This PR was closed automatically due to inactivity.'
+          days-before-issue-stale: 30
+          days-before-pr-stale: 45
+          days-before-issue-close: 5
+          days-before-pr-close: 10


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**

Closes #959

**Summarize your change.**

This PR adds an initial setup of the [stale](https://github.com/actions/stale) github action which nudges or closes stale issues and PRs.
The action is set to run every night at 01:30 am

* Issues 30 days old get marked as "stale" and OP gets a notification; 5 days with no action closes the issue
* PRs 45 days old get marked as "stale" and OP gets a notification; 10 days with no action closes the PR
* PR's labeled "WIP" are left alone
* Issues labeled "needs discussion" are left alone

The timeouts, notification messages and labels are all editable and up for discussion. There's also an option to ignore issues/PRs older that a given date if we want to draw a line in the sand for when we implement the action. 

**Reference associated tests.**

No tests, but it has a the option to run action manually. 