### PR TITLE
Fixes #1188 BREAKING CHANGE: change "effect" argument to Gap constructor to "effects"

### DIFF
--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -390,7 +390,7 @@ static void define_items_and_compositions(py::module m) {
                                          py_to_any_dictionary(metadata)); }),
              py::arg_v("name"_a = std::string()),
              "source_range"_a = TimeRange(),
-             "effect"_a = py::none(),
+             "effects"_a = py::none(),
              "markers"_a = py::none(),
              py::arg_v("metadata"_a = py::none()))
        .def(py::init([](std::string name, RationalTime duration, py::object effects,
@@ -401,7 +401,7 @@ static void define_items_and_compositions(py::module m) {
                                          py_to_any_dictionary(metadata)); }),
              py::arg_v("name"_a = std::string()),
              "duration"_a = RationalTime(),
-             "effect"_a = py::none(),
+             "effects"_a = py::none(),
              "markers"_a = py::none(),
              py::arg_v("metadata"_a = py::none()));
 


### PR DESCRIPTION
This PR fixes #1188.

The argument `effect` in the Gap constructor has been changed to `effects`.