### PR TITLE
Draft: Fix a time string parsing bug

### DIFF
--- a/src/opentime/rationalTime.cpp
+++ b/src/opentime/rationalTime.cpp
@@ -222,11 +222,41 @@ RationalTime::from_time_string(
 
     // split the fields
     int last_pos = 0;
+    std::string colon = ":";
+    size_t separator_pos = time_string.find(colon);
+
+    if(std::string::npos == separator_pos)
+    {
+        if (error_status)
+        {
+            *error_status = ErrorStatus(ErrorStatus::INVALID_TIME_STRING);
+        }
+        return RationalTime::_invalid_time;
+    }
 
     for (int i = 0; i < 2; i++)
     {
-        fields[i] = time_string.substr(last_pos, 2);
-        last_pos  = last_pos + 3;
+        size_t field_length = separator_pos - last_pos;
+        fields[i] = time_string.substr(last_pos, field_length);
+
+        // Prepare for the next iteration
+        last_pos = last_pos + field_length + 1;
+
+        if (i == 0)
+        {
+            separator_pos = time_string.substr(last_pos, std::string::npos).find(colon);
+
+            if (std::string::npos == separator_pos)
+            {
+                if (error_status)
+                {
+                    *error_status = ErrorStatus(ErrorStatus::INVALID_TIME_STRING);
+                }
+                return RationalTime::_invalid_time;
+            }
+
+            separator_pos = separator_pos + field_length + 1;
+        }
     }
 
     fields[2] = time_string.substr(last_pos, time_string.length());

--- a/tests/test_opentime.cpp
+++ b/tests/test_opentime.cpp
@@ -38,6 +38,13 @@ main(int argc, char** argv)
         assertFalse(t1 != t3);
     });
 
+    tests.add_test("test_from_time_string", [] {
+        std::string time_string = "0:12:04";
+        auto t = otime::RationalTime(24 * (12 * 60 + 4), 24);
+        auto time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        assertTrue(t.almost_equal(time_obj, 0.001));
+    });
+
     tests.run(argc, argv);
     return 0;
 }

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -407,6 +407,11 @@ class TestTime(unittest.TestCase):
         time_obj = otio.opentime.from_time_string(time_string, 24)
         self.assertTrue(t.almost_equal(time_obj, delta=0.001))
 
+        time_string = "0:12:04"
+        t = otio.opentime.RationalTime(value=24 * (12 * 60 + 4), rate=24)
+        time_obj = otio.opentime.from_time_string(time_string, 24)
+        self.assertTrue(t.almost_equal(time_obj, delta=0.001))
+
     def test_time_string_25(self):
         time_string = "00:00:01"
         t = otio.opentime.RationalTime(value=25, rate=25)


### PR DESCRIPTION
With ffprobe version

`ffprobe version 3.4.1-tessus Copyright (c) 2007-2017 the FFmpeg developers
  built with Apple LLVM version 8.0.0 (clang-800.0.42.1)`

It prints media duration string like `0:12:04.829792`. Its hour field has only one digit.
If you put the string through `from_time_string()` to `to_time_string()`, you would get a different string out at the end.

```
Python 3.10.4 | packaged by conda-forge | (main, Mar 24 2022, 17:45:10) [Clang 12.0.1 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import opentimelineio as otio
>>> s = "0:12:04.829792"
>>> t = otio.opentime.from_time_string(s, 24.0)
>>> t
otio.opentime.RationalTime(value=2995.92, rate=24)
>>> otio.opentime.to_timecode(t, 24.0)
'00:02:04:19'
>>> otio.opentime.to_time_string(t)
'00:02:04.829792'
>>> 
```

The fix should be detect the colon separator and determine the field string length accordingly.
