### PR TITLE
Fix parsing of time_strings lacking leading zeroes

### DIFF
--- a/src/opentime/rationalTime.cpp
+++ b/src/opentime/rationalTime.cpp
@@ -311,8 +311,9 @@ set_error(std::string const& time_string,
         *err = ErrorStatus(
             code,
             string_printf(
-                "Input time string '%s' is an invalid time string",
-                time_string.c_str()));
+                "Error: '%s' - %s",
+                time_string.c_str(),
+                ErrorStatus::outcome_to_string(code).c_str()));
     }
 }
 

--- a/src/opentime/rationalTime.cpp
+++ b/src/opentime/rationalTime.cpp
@@ -128,10 +128,16 @@ parseFloat(char const* pCurr, char const* pEnd, bool allow_negative, double* res
 
     ret = (double) uintPart;
 
-    // check for fractional part
-    if (pCurr == pEnd || *pCurr != '.') {
+    // check for end of string or delimiter
+    if (pCurr == pEnd || *pCurr == '\0') {
         *result = sign * ret;
-        return true;   // no decimal, not a float, stop parsing
+        return true;
+    }
+
+    // if the next character is not a decimal point, the string is malformed.
+    if (*pCurr != '.') {
+        *result = 0.f; // zero consistent with earlier error condition
+        return false;
     }
 
     ++pCurr; // skip decimal

--- a/src/opentime/rationalTime.cpp
+++ b/src/opentime/rationalTime.cpp
@@ -148,8 +148,8 @@ parseFloat(char const* pCurr, char const* pEnd, bool allow_negative, double* res
         ++pCurr;
     }
 
-    ret = (double) uintPart;
-    if (uintPart != (uint64_t) ret)
+    ret = static_cast<double>(uintPart);
+    if (uintPart != static_cast<uint64_t>(ret))
     {
         // if the double cannot be casted precisely back to uint64_t, fail
         // A double has 15 digits of precision, but a uint64_t can encode more.
@@ -181,7 +181,7 @@ parseFloat(char const* pCurr, char const* pEnd, bool allow_negative, double* res
         {
             break;
         }
-        ret = ret + (double)(c - '0') * position_scale;
+        ret = ret + static_cast<double>(c - '0') * position_scale;
         ++pCurr;
         position_scale *= 0.1;
     }

--- a/src/opentime/rationalTime.h
+++ b/src/opentime/rationalTime.h
@@ -127,6 +127,11 @@ public:
         std::string const& timecode,
         double             rate,
         ErrorStatus*       error_status = nullptr);
+
+    // parse a string in the form
+    // hours:minutes:seconds
+    // which may have a leading negative sign. seconds may have up to
+    // microsecond precision.
     static RationalTime from_time_string(
         std::string const& time_string,
         double             rate,
@@ -154,9 +159,13 @@ public:
         return to_timecode(_rate, IsDropFrameRate::InferFromRate, error_status);
     }
 
+    // produce a string in the form
+    // hours:minutes:seconds
+    // which may have a leading negative sign. seconds may have up to
+    // microsecond precision.
     std::string to_time_string() const;
 
-   RationalTime const& operator+=(RationalTime other) noexcept
+    RationalTime const& operator+=(RationalTime other) noexcept
     {
         if (_rate < other._rate)
         {
@@ -170,7 +179,7 @@ public:
         return *this;
     }
 
-   RationalTime const& operator-=(RationalTime other) noexcept
+    RationalTime const& operator-=(RationalTime other) noexcept
     {
         if (_rate < other._rate)
         {

--- a/tests/test_opentime.cpp
+++ b/tests/test_opentime.cpp
@@ -38,6 +38,75 @@ main(int argc, char** argv)
         assertFalse(t1 != t3);
     });
 
+    tests.add_test("test_from_time_string", [] {
+         std::string time_string = "0:12:04";
+         auto t = otime::RationalTime(24 * (12 * 60 + 4), 24);
+         auto time_obj = otime::RationalTime::from_time_string(time_string, 24);
+         assertTrue(t.almost_equal(time_obj, 0.001));
+     });
+
+    tests.add_test("test_from_time_string24", [] {
+        std::string time_string = "00:00:00.041667";
+        auto t = otime::RationalTime(1, 24);
+        auto time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        assertTrue(t.almost_equal(time_obj, 0.001));
+        time_string = "00:00:01";
+        t = otime::RationalTime(24, 24);
+        time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        assertTrue(t.almost_equal(time_obj, 0.001));
+        time_string = "00:01:00";
+        t = otime::RationalTime(60 * 24, 24);
+        time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        assertTrue(t.almost_equal(time_obj, 0.001));
+        time_string = "01:00:00";
+        t = otime::RationalTime(60 * 60 * 24, 24);
+        time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        assertTrue(t.almost_equal(time_obj, 0.001));
+        time_string = "24:00:00";
+        t = otime::RationalTime(24 * 60 * 60 * 24, 24);
+        time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        assertTrue(t.almost_equal(time_obj, 0.001));
+        time_string = "23:59:59.92";
+        t = otime::RationalTime((23 * 60 * 60 + 59 * 60 + 59.92) * 24, 24);
+        time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        assertTrue(t.almost_equal(time_obj, 0.001));
+    });
+
+    tests.add_test("test_from_time_string25", [] {
+        std::string time_string = "0:12:04.929792";
+        auto t = otime::RationalTime((12 * 60 + 4.929792) * 25, 25);
+        auto time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        assertTrue(t.almost_equal(time_obj, 0.001));
+        time_string = "00:00:01";
+        t = otime::RationalTime(25, 25);
+        time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        assertTrue(t.almost_equal(time_obj, 0.001));
+        time_string = "0:1";
+        t = otime::RationalTime(25, 25);
+        time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        assertTrue(t.almost_equal(time_obj, 0.001));
+        time_string = "1";
+        t = otime::RationalTime(25, 25);
+        time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        assertTrue(t.almost_equal(time_obj, 0.001));
+        time_string = "00:01:00";
+        t = otime::RationalTime(60 * 25, 25);
+        time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        assertTrue(t.almost_equal(time_obj, 0.001));
+        time_string = "01:00:00";
+        t = otime::RationalTime(60 * 60 * 25, 25);
+        time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        assertTrue(t.almost_equal(time_obj, 0.001));
+        time_string = "24:00:00";
+        t = otime::RationalTime(24 * 60 * 60 * 25, 25);
+        time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        assertTrue(t.almost_equal(time_obj, 0.001));
+        time_string = "23:59:59.92";
+        t = otime::RationalTime((23 * 60 * 60 + 59 * 60 + 59.92) * 25, 25);
+        time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        assertTrue(t.almost_equal(time_obj, 0.001));
+    });
+
     tests.run(argc, argv);
     return 0;
 }

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -17,6 +17,11 @@ class TestTime(unittest.TestCase):
         self.assertIsNotNone(t)
         self.assertEqual(t.value, t_val)
 
+        t_val = -30.2
+        t = otio.opentime.RationalTime(t_val)
+        self.assertIsNotNone(t)
+        self.assertEqual(t.value, t_val)
+
         t = otio.opentime.RationalTime()
         self.assertEqual(t.value, 0)
         self.assertEqual(t.rate, 1.0)
@@ -73,7 +78,6 @@ class TestTime(unittest.TestCase):
         self.assertEqual(t2, otio.opentime.RationalTime(18, 24))
 
     def test_base_conversion(self):
-
         # from a number
         t = otio.opentime.RationalTime(10, 24)
         with self.assertRaises(TypeError):
@@ -92,6 +96,14 @@ class TestTime(unittest.TestCase):
         timecode = "00:06:56:17"
         t = otio.opentime.from_timecode(timecode, 24)
         self.assertEqual(timecode, otio.opentime.to_timecode(t))
+
+    def test_negative_timecode(self):
+        with self.assertRaises(ValueError) as exception_manager:
+            otio.opentime.from_timecode('-01:00:13:13', 24)
+
+    def test_bogus_timecode(self):
+        with self.assertRaises(ValueError) as exception_manager:
+            otio.opentime.from_timecode('pink elephants', 13)
 
     def test_time_timecode_convert_bad_rate(self):
         with self.assertRaises(ValueError) as exception_manager:

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -98,11 +98,11 @@ class TestTime(unittest.TestCase):
         self.assertEqual(timecode, otio.opentime.to_timecode(t))
 
     def test_negative_timecode(self):
-        with self.assertRaises(ValueError) as exception_manager:
+        with self.assertRaises(ValueError):
             otio.opentime.from_timecode('-01:00:13:13', 24)
 
     def test_bogus_timecode(self):
-        with self.assertRaises(ValueError) as exception_manager:
+        with self.assertRaises(ValueError):
             otio.opentime.from_timecode('pink elephants', 13)
 
     def test_time_timecode_convert_bad_rate(self):


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**

#1293

@jchen9 Hi Julian, here's a rework of the existing routine to address the problem you found, and introduce a little more rigor to what is or is not a well-formed time string.

```Fixes #1293```

**Summarize your change.**

Describe the reason for the change.

- fixes parsing of time strings without leading zeroes.
- enforces that a negative sign can only appear in the left most position
- implementation does not allocate memory or copy strings
- implementation does not allow exponential notation and other things that std does allow but are inappropriate for time strings
-  compatible with strings produced by ffprobe

**Reference associated tests.**

adds C based tests corresponding to the existing Python based tests.
