### PR TITLE
Update links in readme to point to new ASWF url

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@ OpenTimelineIO
 
 [![Supported VFX Platform Versions](https://img.shields.io/badge/vfx%20platform-2018--2021-lightgrey.svg)](http://www.vfxplatform.com/)
 ![Supported Versions](https://img.shields.io/badge/python-2.7%2C%203.7%2C%203.8%2C%203.9%2C%203.10-blue)
-[![Build Status](https://github.com/PixarAnimationStudios/OpenTimelineIO/actions/workflows/python-package.yml/badge.svg)](https://github.com/PixarAnimationStudios/OpenTimelineIO/actions/workflows/python-package.yml)
-[![codecov](https://codecov.io/gh/PixarAnimationStudios/OpenTimelineIO/branch/main/graph/badge.svg)](https://codecov.io/gh/PixarAnimationStudios/OpenTimelineIO)
+[![Build Status](https://github.com/AcademySoftwareFoundation/OpenTimelineIO/actions/workflows/python-package.yml/badge.svg)](https://github.com/AcademySoftwareFoundation/OpenTimelineIO/actions/workflows/python-package.yml)
+[![codecov](https://codecov.io/gh/AcademySoftwareFoundation/OpenTimelineIO/branch/main/graph/badge.svg)](https://codecov.io/gh/AcademySoftwareFoundation/OpenTimelineIO)
 [![docs](https://readthedocs.org/projects/opentimelineio/badge/?version=latest)](https://opentimelineio.readthedocs.io/en/latest/index.html)
 
 Main web site: http://opentimeline.io/
 
 Documentation: https://opentimelineio.readthedocs.io/
 
-GitHub: https://github.com/PixarAnimationStudios/OpenTimelineIO
+GitHub: https://github.com/AcademySoftwareFoundation/OpenTimelineIO
 
 Discussion group: https://lists.aswf.io/g/otio-discussion
 
@@ -95,10 +95,10 @@ for clip in timeline.each_clip():
   print(clip.name, clip.duration())
 ```
 
-There are more code examples here: https://github.com/PixarAnimationStudios/OpenTimelineIO/tree/main/examples
+There are more code examples here: https://github.com/AcademySoftwareFoundation/OpenTimelineIO/tree/main/examples
 
 Also, looking through the unit tests is a great way to see what OTIO can do:
-https://github.com/PixarAnimationStudios/OpenTimelineIO/tree/main/tests
+https://github.com/AcademySoftwareFoundation/OpenTimelineIO/tree/main/tests
 
 OTIO includes a viewer program as well (see the quickstart section for instructions on installing it):
 
@@ -111,7 +111,7 @@ If you want to contribute to the project, please see: https://opentimelineio.rea
 
 You can get the latest development version via:
 
-`git clone git@github.com:PixarAnimationStudios/OpenTimelineIO.git --recursive `
+`git clone git@github.com:AcademySoftwareFoundation/OpenTimelineIO.git --recursive `
 
 You can install development dependencies with `python -m pip install .[dev]`
 
@@ -160,6 +160,6 @@ Contact
 -------
 
 For more information, please visit http://opentimeline.io/
-or https://github.com/PixarAnimationStudios/OpenTimelineIO
+or https://github.com/AcademySoftwareFoundation/OpenTimelineIO
 or join our discussion forum: https://lists.aswf.io/g/otio-discussion
 


### PR DESCRIPTION
- project has switched organizations on github, this updates the urls in the README to point at the new location.
