### PR TITLE
Updated URLs to new AcademySofwareFoundation GitHub org.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,5 +18,5 @@ If no new tests are introduced as part of this PR, note the tests that are provi
 
 <!--
 Important: If this is your first contribution to OpenTimelineIO, you will need to submit a Contributor License Agreement. For a step-by-step instructions on the pull request process, see
-https://github.com/PixarAnimationStudios/OpenTimelineIO/tree/main/CONTRIBUTING.md
+https://github.com/AcademySoftwareFoundation/OpenTimelineIO/tree/main/CONTRIBUTING.md
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,8 @@ If you are unable to use the EasyCLA system, you can send a signed CLA to `opent
 
 Here are the two possible CLAs:
 
-* [OTIO_CLA_Corporate.pdf](https://github.com/PixarAnimationStudios/OpenTimelineIO/raw/main/OTIO_CLA_Corporate.pdf): please sign this one for corporate use
-* [OTIO_CLA_Individual.pdf](https://github.com/PixarAnimationStudios/OpenTimelineIO/raw/main/OTIO_CLA_Individual.pdf): please sign this one if you're an individual contributor
+* [OTIO_CLA_Corporate.pdf](https://github.com/AcademySoftwareFoundation/OpenTimelineIO/raw/main/OTIO_CLA_Corporate.pdf): please sign this one for corporate use
+* [OTIO_CLA_Individual.pdf](https://github.com/AcademySoftwareFoundation/OpenTimelineIO/raw/main/OTIO_CLA_Individual.pdf): please sign this one if you're an individual contributor
 
 ## Coding Conventions
 Please follow the coding convention and style in each file and in each library when adding new files.
@@ -52,7 +52,7 @@ Add the primary OpenTimelineIO repo as upstream to make it easier to update your
 
 ```bash
 cd OpenTimelineIO
-git remote add upstream https://github.com/PixarAnimationStudios/OpenTimelineIO.git
+git remote add upstream https://github.com/AcademySoftwareFoundation/OpenTimelineIO.git
 ```
 
 Now you fetch the latest changes from the OpenTimelineIO repo like this:

--- a/docs/tutorials/adapters.md
+++ b/docs/tutorials/adapters.md
@@ -30,7 +30,7 @@ Final Cut Pro X XML Format:
 
 - Status: Reads and writes AAF compositions
   - includes clip, gaps, transitions but not markers or effects
-  - This adapter is still in progress, see the ongoing work here: <a href="https://github.com/PixarAnimationStudios/OpenTimelineIO/projects/1" target="_blank">AAF Project</a>
+  - This adapter is still in progress, see the ongoing work here: <a href="https://github.com/AcademySoftwareFoundation/OpenTimelineIO/projects/1" target="_blank">AAF Project</a>
 - <a href="https://static.amwa.tv/ms-01-aaf-object-spec.pdf" target="_blank">Spec</a>
 - <a href="https://static.amwa.tv/as-01-aaf-edit-protocol-spec.pdf" target="_blank">Protocol</a>
 

--- a/docs/tutorials/architecture.md
+++ b/docs/tutorials/architecture.md
@@ -134,4 +134,4 @@ For more information about writing media linkers, see <a href="write-a-media-lin
 Example Scripts
 ----------------
 
-Example scripts are located in the <a href="https://github.com/PixarAnimationStudios/OpenTimelineIO/tree/main/examples" target="_blank">examples subdirectory</a>.
+Example scripts are located in the <a href="https://github.com/AcademySoftwareFoundation/OpenTimelineIO/tree/main/examples" target="_blank">examples subdirectory</a>.

--- a/docs/tutorials/contributing.md
+++ b/docs/tutorials/contributing.md
@@ -12,8 +12,8 @@ If you are unable to use the EasyCLA system, you can send a signed CLA to `opent
 
 Here are the two possible CLAs:
 
-* [OTIO_CLA_Corporate.pdf](https://github.com/PixarAnimationStudios/OpenTimelineIO/raw/main/OTIO_CLA_Corporate.pdf): please sign this one for corporate use
-* [OTIO_CLA_Individual.pdf](https://github.com/PixarAnimationStudios/OpenTimelineIO/raw/main/OTIO_CLA_Individual.pdf): please sign this one if you're an individual contributor
+* [OTIO_CLA_Corporate.pdf](https://github.com/AcademySoftwareFoundation/OpenTimelineIO/raw/main/OTIO_CLA_Corporate.pdf): please sign this one for corporate use
+* [OTIO_CLA_Individual.pdf](https://github.com/AcademySoftwareFoundation/OpenTimelineIO/raw/main/OTIO_CLA_Individual.pdf): please sign this one if you're an individual contributor
 
 ## Coding Conventions
 Please follow the coding convention and style in each file and in each library when adding new files.
@@ -38,7 +38,7 @@ Add the primary OpenTimelineIO repo as upstream to make it easier to update your
 
 ```bash
 cd OpenTimelineIO
-git remote add upstream https://github.com/PixarAnimationStudios/OpenTimelineIO.git
+git remote add upstream https://github.com/AcademySoftwareFoundation/OpenTimelineIO.git
 ```
 
 Now you fetch the latest changes from the OpenTimelineIO repo like this:

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -31,7 +31,7 @@ Once you have pip installed OpenTimelineIO, you should be able to run:
 # Developer Quickstart
 
 Get the source and submodules:
-+ `git clone git@github.com:PixarAnimationStudios/OpenTimelineIO.git`
++ `git clone git@github.com:AcademySoftwareFoundation/OpenTimelineIO.git`
 
 Before reading further, it is good to note that there is two parts to the
 C++ code: the OTIO C++ library that you can use in your C++ projects,

--- a/docs/use-cases/animation-shot-frame-ranges.md
+++ b/docs/use-cases/animation-shot-frame-ranges.md
@@ -35,8 +35,8 @@ those shots is now longer.
 - EDL reading
     - Clip names for video track
     - Source frame range for each clip
-    - <a href="https://github.com/PixarAnimationStudios/OpenTimelineIO/issues/39" target="_blank">Timing effects</a>
-- <a href="https://github.com/PixarAnimationStudios/OpenTimelineIO/issues/1" target="_blank">AAF reading</a>
+    - <a href="https://github.com/AcademySoftwareFoundation/OpenTimelineIO/issues/39" target="_blank">Timing effects</a>
+- <a href="https://github.com/AcademySoftwareFoundation/OpenTimelineIO/issues/1" target="_blank">AAF reading</a>
     - Clip names across all video tracks, subclips, etc.
     - Source frame range for each clip
     - Timing effects
@@ -48,7 +48,7 @@ those shots is now longer.
     - Name
     - Metadata
     - Timing effects
-- <a href="https://github.com/PixarAnimationStudios/OpenTimelineIO/issues/39" target="_blank">Timing effects</a>
+- <a href="https://github.com/AcademySoftwareFoundation/OpenTimelineIO/issues/39" target="_blank">Timing effects</a>
     - Source frame range of each clip as effected by timing effects.
 - Composition
     - Clips in lower tracks that are obscured (totally or partially) by overlapping clips in higher tracks are considered trimmed or hidden.

--- a/docs/use-cases/shots-added-removed-from-cut.md
+++ b/docs/use-cases/shots-added-removed-from-cut.md
@@ -36,7 +36,7 @@ deliver the new shot to editorial when it is ready.
 
 - EDL reading (done)
     - Clip names across all tracks
-- <a href="https://github.com/PixarAnimationStudios/OpenTimelineIO/issues/1" target="_blank">AAF reading</a>
+- <a href="https://github.com/AcademySoftwareFoundation/OpenTimelineIO/issues/1" target="_blank">AAF reading</a>
     - Clip names across all tracks, subclips, etc.
 - Timeline should include (done)
     -  a Stack of tracks, each of which is a Sequence

--- a/maintainers/download_gha_artifact.py
+++ b/maintainers/download_gha_artifact.py
@@ -57,7 +57,7 @@ if not os.path.exists(args.directory):
     os.makedirs(args.directory)
 
 request = urllib.request.Request(
-    "https://api.github.com/repos/PixarAnimationStudios/OpenTimelineIO/actions/runs?status=success",  # noqa: E501
+    "https://api.github.com/repos/AcademySoftwareFoundation/OpenTimelineIO/actions/runs?status=success",  # noqa: E501
     headers=headers,
 )
 response = urllib.request.urlopen(request).read()

--- a/maintainers/fetch_contributors.py
+++ b/maintainers/fetch_contributors.py
@@ -15,7 +15,8 @@ def parse_args():
     parser.add_argument(
         '--repo',
         required=True,
-        help='GitHub Project/Repo name. (e.g. "AcademySoftwareFoundation/OpenTimelineIO")'
+        help='GitHub Project/Repo name.'
+        ' (e.g. "AcademySoftwareFoundation/OpenTimelineIO")'
     )
     parser.add_argument(
         '--token',

--- a/maintainers/fetch_contributors.py
+++ b/maintainers/fetch_contributors.py
@@ -15,7 +15,7 @@ def parse_args():
     parser.add_argument(
         '--repo',
         required=True,
-        help='GitHub Project/Repo name. (e.g. "PixarAnimationStudios/OpenTimelineIO")'
+        help='GitHub Project/Repo name. (e.g. "AcademySoftwareFoundation/OpenTimelineIO")'
     )
     parser.add_argument(
         '--token',

--- a/setup.py
+++ b/setup.py
@@ -276,11 +276,11 @@ setup(
     url='http://opentimeline.io',
     project_urls={
         'Source':
-            'https://github.com/PixarAnimationStudios/OpenTimelineIO',
+            'https://github.com/AcademySoftwareFoundation/OpenTimelineIO',
         'Documentation':
             'https://opentimelineio.readthedocs.io/',
         'Issues':
-            'https://github.com/PixarAnimationStudios/OpenTimelineIO/issues',
+            'https://github.com/AcademySoftwareFoundation/OpenTimelineIO/issues',
     },
 
     classifiers=[

--- a/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
@@ -392,7 +392,7 @@ class ClipHandler(object):
 
         # BLACK/BL and BARS are called out as "Special Source Identifiers" in
         # the documents referenced here:
-        # https://github.com/PixarAnimationStudios/OpenTimelineIO#cmx3600-edl
+        # https://github.com/AcademySoftwareFoundation/OpenTimelineIO#cmx3600-edl
         if self.reel in ['BL', 'BLACK']:
             clip.media_reference = schema.GeneratorReference()
             # TODO: Replace with enum, once one exists


### PR DESCRIPTION
OTIO has moved to the AcademySoftwareFoundation GitHub org. This PR updates all links that pointed to the old repo.