### PR TITLE
Python bindings: raise proper exceptions for IO operations

### DIFF
--- a/src/py-opentimelineio/opentimelineio-bindings/otio_errorStatusHandler.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_errorStatusHandler.cpp
@@ -50,9 +50,11 @@ ErrorStatusHandler::~ErrorStatusHandler() noexcept(false) {
     case ErrorStatus::JSON_PARSE_ERROR:
         throw py::value_error("JSON parse error while reading: " + details());
     case ErrorStatus::FILE_OPEN_FAILED:
-        throw py::value_error("failed to open file for reading: " + details());
+        PyErr_SetFromErrnoWithFilename(PyExc_OSError, details().c_str());
+        throw py::error_already_set();
     case ErrorStatus::FILE_WRITE_FAILED:
-        throw py::value_error("failed to open file for writing: " + details());
+        PyErr_SetFromErrnoWithFilename(PyExc_OSError, details().c_str());
+        throw py::error_already_set();
     case ErrorStatus::SCHEMA_VERSION_UNSUPPORTED:
         throw _UnsupportedSchemaException(full_details());
     case ErrorStatus::NOT_A_CHILD_OF:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the OpenTimelineIO project
+
+import sys
+import shutil
+import tempfile
+import unittest
+
+import opentimelineio as otio
+
+
+class TestCoreFunctions(unittest.TestCase):
+    def setUp(self):
+        self.tmpDir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpDir)
+
+    def test_deserialize_json_from_file_errors(self):
+        """Verify that the bindings return the correct errors based on the errno"""
+        if sys.version_info[0] < 3:
+            excType = OSError
+        else:
+            excType = FileNotFoundError  # noqa: F821
+
+        with self.assertRaises(excType) as exc:
+            otio.core.deserialize_json_from_file('non-existent-file-here')
+        self.assertIsInstance(exc.exception, excType)
+
+    @unittest.skipUnless(not sys.platform.startswith("win"), "requires non Windows sytem")  # noqa
+    def test_serialize_json_to_file_errors_non_windows(self):
+        """Verify that the bindings return the correct errors based on the errno"""
+        if sys.version_info[0] < 3:
+            excType = OSError
+        else:
+            excType = IsADirectoryError  # noqa: F821
+
+        with self.assertRaises(excType) as exc:
+            otio.core.serialize_json_to_file({}, self.tmpDir)
+        self.assertIsInstance(exc.exception, excType)
+
+    @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
+    def test_serialize_json_to_file_errors_windows(self):
+        """Verify that the bindings return the correct errors based on the errno"""
+        if sys.version_info[0] < 3:
+            excType = OSError
+        else:
+            excType = PermissionError  # noqa: F821
+
+        with self.assertRaises(excType) as exc:
+            otio.core.serialize_json_to_file({}, self.tmpDir)
+        self.assertIsInstance(exc.exception, excType)


### PR DESCRIPTION
Fixes #1307.

**Summarize your change.**

This PR modifies the IO exceptions raised when using serializing and de-serializing functions from the bindings.

Previously the exceptions raised were of type `ValueError`. With this change, the error type is determined based on `errno`. Which means it will now raise the same exceptions as the built-in python IO functions.

I also added unit tests to make sure the changes are indeed working and to get coverage in an area that wasn't covered before. The tests also show different exception types being raised.

Using @reinecke 's example:
```
>>> opentimelineio.adapters.read_from_file("/tmp/doesnotexist.otio")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jcmorin/jcmenv/aswf/OpenTimelineIO/.venv/lib/python3.10/site-packages/opentimelineio/adapters/__init__.py", line 122, in read_from_file
    return adapter.read_from_file(
  File "/home/jcmorin/jcmenv/aswf/OpenTimelineIO/.venv/lib/python3.10/site-packages/opentimelineio/adapters/adapter.py", line 124, in read_from_file
    result = self._execute_function(
  File "/home/jcmorin/jcmenv/aswf/OpenTimelineIO/.venv/lib/python3.10/site-packages/opentimelineio/plugins/python_plugin.py", line 153, in _execute_function
    return (getattr(self.module(), func_name)(**kwargs))
  File "/home/jcmorin/jcmenv/aswf/OpenTimelineIO/.venv/lib/python3.10/site-packages/opentimelineio/adapters/otio_json.py", line 24, in read_from_file
    return core.deserialize_json_from_file(filepath)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/doesnotexist.otio'
```

The [PyErr_SetFromErrnoWithFilename](https://docs.python.org/3/c-api/exceptions.html#c.PyErr_SetFromErrnoWithFilename) function gives us the exception type and the exception message for free.