### PR TITLE
Fix setuptools deprecation warnings

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ include README.md CHANGELOG.md LICENSE.txt NOTICE.txt CMakeLists.txt
 recursive-include examples *
 recursive-include contrib *
 recursive-include src *
-
+recursive-include tests *
 prune .github
 prune docs
 prune doxygen
@@ -22,10 +22,9 @@ exclude contrib/opentimelineio_contrib/adapters/Makefile
 exclude Makefile
 exclude */.DS_Store
 exclude .clang-format
+global-exclude *.pyc
 
-prune contrib/opentimelineio_contrib/adapters/tests
 prune maintainers
-prune tests
 prune tsc
 prune src/deps/pybind11/tools/clang
 prune src/deps/rapidjson/thirdparty

--- a/setup.py
+++ b/setup.py
@@ -315,12 +315,12 @@ setup(
         ],
     },
 
-    include_package_data=True,
     packages=(
-        find_packages(where="src/py-opentimelineio") +
-        find_packages(where="src") +
-        find_packages(where="contrib")
+        find_packages(where="src/py-opentimelineio") +  # opentimelineio
+        find_packages(where="src") +  # opentimelineview
+        find_packages(where="contrib", exclude=["opentimelineio_contrib.adapters.tests"])  # opentimelineio_contrib # noqa
     ),
+
     ext_modules=[
         CMakeExtension('_opentimelineio'),
         CMakeExtension('_opentime'),


### PR DESCRIPTION
Fix setuptools deprecation warnings related to importable files considered as data files. Such a warning can be seen at https://github.com/AcademySoftwareFoundation/OpenTimelineIO/runs/6563968215?check_suite_focus=true#step:8:414.

```
  /tmp/pip-build-env-tkhu7fyq/overlay/lib/python3.10/site-packages/setuptools/command/build_py.py:153: SetuptoolsDeprecationWarning:     Installing 'opentimelineio_contrib.application_plugins.rv.example_otio_reader' as data is deprecated, please list it in `packages`.
      !!


      ############################
      # Package would be ignored #
      ############################
      Python recognizes 'opentimelineio_contrib.application_plugins.rv.example_otio_reader' as an importable package, however it is
      included in the distribution as "data".
      This behavior is likely to change in future versions of setuptools (and
      therefore is considered deprecated).

      Please make sure that 'opentimelineio_contrib.application_plugins.rv.example_otio_reader' is included as a package by using
      setuptools' `packages` configuration field or the proper discovery methods
      (for example by using `find_namespace_packages(...)`/`find_namespace:`
      instead of `find_packages(...)`/`find:`).

      You can read more about "package discovery" and "data files" on setuptools
      documentation page.


  !!
```

To fix this, I had to unset `include_package_data` which is not necessary to be set in our case.

Changes:
* Tests are now included in the sdist
* `opentimelineio_contrib/adapters/tests` and `opentimelineio_contrib/application_plugins` are no more included in thw built wheels.

How to test:
1. Without these changes, run `SOURCE_DATE_EPOCH=315532800 python -m build -w .` and then rename `dist/OpenTimelineIO-0.15.0.dev1-cp310-cp310-linux_x86_64.whl` to `dist/OpenTimelineIO-0.15.0.dev1-cp310-cp310-linux_x86_64.whl_before`.
2. `rm -rf build/ OpenTimelineIO.egg-info/` (Important!)
3. Now with the changes, run `SOURCE_DATE_EPOCH=315532800 python -m build -w .`.
4. `diff <(unzip -l dist/OpenTimelineIO-0.15.0.dev1-cp310-cp310-linux_x86_64.whl_before) <(unzip -l dist/OpenTimelineIO-0.15.0.dev1-cp310-cp310-linux_x86_64.whl)`

```
< Archive:  dist/OpenTimelineIO-0.15.0.dev1-cp310-cp310-linux_x86_64.whl_before
---
> Archive:  dist/OpenTimelineIO-0.15.0.dev1-cp310-cp310-linux_x86_64.whl
78,92d77
<        95  1980-01-01 00:00   opentimelineio_contrib/adapters/tests/__init__.py
<     82275  1980-01-01 00:00   opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
<      8832  1980-01-01 00:00   opentimelineio_contrib/adapters/tests/test_ale_adapter.py
<      6462  1980-01-01 00:00   opentimelineio_contrib/adapters/tests/test_burnins.py
<      5841  1980-01-01 00:00   opentimelineio_contrib/adapters/tests/test_fcpx_adapter.py
<     24592  1980-01-01 00:00   opentimelineio_contrib/adapters/tests/test_hls_playlist_adapter.py
<      2403  1980-01-01 00:00   opentimelineio_contrib/adapters/tests/test_kdenlive_adapter.py
<      2081  1980-01-01 00:00   opentimelineio_contrib/adapters/tests/test_maya_sequencer.py
<     22576  1980-01-01 00:00   opentimelineio_contrib/adapters/tests/test_rvsession.py
<    116066  1980-01-01 00:00   opentimelineio_contrib/adapters/tests/tests_xges_adapter.py
<       618  1980-01-01 00:00   opentimelineio_contrib/application_plugins/rv/example_otio_reader/PACKAGE
<      4745  1980-01-01 00:00   opentimelineio_contrib/application_plugins/rv/example_otio_reader/example_otio_reader_plugin.py
<     12881  1980-01-01 00:00   opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
<        95  1980-01-01 00:00   opentimelineio_contrib/application_plugins/tests/__init__.py
<      9388  1980-01-01 00:00   opentimelineio_contrib/application_plugins/tests/test_rv_reader.py
106c91
<     10164  1980-01-01 00:00   OpenTimelineIO-0.15.0.dev1.dist-info/RECORD
---
>      8358  1980-01-01 00:00   OpenTimelineIO-0.15.0.dev1.dist-info/RECORD
108c93
<   2737411                     103 files
---
>   2436655                     88 files
```

The same can be done for the sdist:
1. Without the changes, run `SOURCE_DATE_EPOCH=315532800 python -m build -s .` and rename `dist/OpenTimelineIO-0.15.0.dev1.tar.gz` to `dist/OpenTimelineIO-0.15.0.dev1.tar.gz_before`
2. `rm -rf build/ OpenTimelineIO.egg-info/` (Important!)
3. Now with the changes, run `SOURCE_DATE_EPOCH=315532800 python -m build -s .`
4. `diff <(tar tf dist/OpenTimelineIO-0.15.0.dev1.tar.gz_before) <(tar tf dist/OpenTimelineIO-0.15.0.dev1.tar.gz)`

<details>
  <summary>Show sdist diff</summary>

```
35a36,104
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/__init__.py
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/2997fps-DFTC.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/2997fps.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/30fps.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/composite.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/duplicates.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/essence_group.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/fcpx_clips.fcpxml
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/fcpx_event.fcpxml
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/fcpx_example.fcpxml
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/fcpx_library.fcpxml
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/fcpx_project.fcpxml
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/gaps.otio
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/image_sequence_example.otio
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/kdenlive_example.kdenlive
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/kdenlive_example_from_fcp.xml
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/keyframed_properties.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/linear_speed_effects.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/linear_speed_effects_aaf.mov
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/marker-over-audio.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/marker-over-transition.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/misc_speed_effects.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/misc_speed_effects_aaf.mov
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/multiple_markers.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/multiple_timecode_objects.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/multiple_top_level_mobs.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/multitrack.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/nested_stack.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/nesting_test.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/nesting_test_preflattened.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/no_metadata.otio
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/normalclip_sourceclip_references_compositionmob_has_also_mastermob_usercomments.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/normalclip_sourceclip_references_compositionmob_with_usercomments_no_mastermob_usercomments.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/not_aaf.otio
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/one_audio_clip.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/one_clip.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/precheckfail.otio
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/preflattened.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/rv_metadata.otio
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/rv_metadata.rv
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/sample.ale
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/sample2.ale
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/sampleUHD.ale
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/sample_cdl.ale
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/screening_example.edl
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/screening_example.ma
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/screening_example.rv
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/simple.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/subclip_sourceclip_references_compositionmob_with_mastermob.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/test_muted_clip.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/timecode_test.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/transition_test.otio
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/transition_test.rv
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/transitions.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/trims.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/utf8.aaf
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/v1_prog_index.m3u8
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/sample_data/xges_example.xges
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/test_ale_adapter.py
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/test_burnins.py
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/test_fcpx_adapter.py
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/test_hls_playlist_adapter.py
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/test_kdenlive_adapter.py
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/test_maya_sequencer.py
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/test_rvsession.py
> OpenTimelineIO-0.15.0.dev1/contrib/opentimelineio_contrib/adapters/tests/tests_xges_adapter.py
248a318,444
> OpenTimelineIO-0.15.0.dev1/tests/
> OpenTimelineIO-0.15.0.dev1/tests/CMakeLists.txt
> OpenTimelineIO-0.15.0.dev1/tests/__init__.py
> OpenTimelineIO-0.15.0.dev1/tests/baseline_reader.py
> OpenTimelineIO-0.15.0.dev1/tests/baselines/
> OpenTimelineIO-0.15.0.dev1/tests/baselines/adapter_example.json
> OpenTimelineIO-0.15.0.dev1/tests/baselines/adapter_plugin_manifest.plugin_manifest.json
> OpenTimelineIO-0.15.0.dev1/tests/baselines/empty_clip.json
> OpenTimelineIO-0.15.0.dev1/tests/baselines/empty_external_reference.json
> OpenTimelineIO-0.15.0.dev1/tests/baselines/empty_gap.json
> OpenTimelineIO-0.15.0.dev1/tests/baselines/empty_generator_reference.json
> OpenTimelineIO-0.15.0.dev1/tests/baselines/empty_marker.json
> OpenTimelineIO-0.15.0.dev1/tests/baselines/empty_missingreference.json
> OpenTimelineIO-0.15.0.dev1/tests/baselines/empty_rationaltime.json
> OpenTimelineIO-0.15.0.dev1/tests/baselines/empty_serializable_collection.json
> OpenTimelineIO-0.15.0.dev1/tests/baselines/empty_stack.json
> OpenTimelineIO-0.15.0.dev1/tests/baselines/empty_timeline.json
> OpenTimelineIO-0.15.0.dev1/tests/baselines/empty_timerange.json
> OpenTimelineIO-0.15.0.dev1/tests/baselines/empty_timetransform.json
> OpenTimelineIO-0.15.0.dev1/tests/baselines/empty_track.json
> OpenTimelineIO-0.15.0.dev1/tests/baselines/empty_transition.json
> OpenTimelineIO-0.15.0.dev1/tests/baselines/example.py
> OpenTimelineIO-0.15.0.dev1/tests/baselines/example_schemadef.py
> OpenTimelineIO-0.15.0.dev1/tests/baselines/hookscript_example.json
> OpenTimelineIO-0.15.0.dev1/tests/baselines/media_linker_example.json
> OpenTimelineIO-0.15.0.dev1/tests/baselines/plugin_module/
> OpenTimelineIO-0.15.0.dev1/tests/baselines/plugin_module/otio_jsonplugin/
> OpenTimelineIO-0.15.0.dev1/tests/baselines/plugin_module/otio_jsonplugin/__init__.py
> OpenTimelineIO-0.15.0.dev1/tests/baselines/plugin_module/otio_jsonplugin/plugin_manifest.json
> OpenTimelineIO-0.15.0.dev1/tests/baselines/plugin_module/otio_jsonplugin.egg-info/
> OpenTimelineIO-0.15.0.dev1/tests/baselines/plugin_module/otio_jsonplugin.egg-info/PKG-INFO
> OpenTimelineIO-0.15.0.dev1/tests/baselines/plugin_module/otio_jsonplugin.egg-info/entry_points.txt
> OpenTimelineIO-0.15.0.dev1/tests/baselines/plugin_module/otio_mockplugin/
> OpenTimelineIO-0.15.0.dev1/tests/baselines/plugin_module/otio_mockplugin/__init__.py
> OpenTimelineIO-0.15.0.dev1/tests/baselines/plugin_module/otio_mockplugin/unusually_named_plugin_manifest.json
> OpenTimelineIO-0.15.0.dev1/tests/baselines/plugin_module/otio_mockplugin.egg-info/
> OpenTimelineIO-0.15.0.dev1/tests/baselines/plugin_module/otio_mockplugin.egg-info/PKG-INFO
> OpenTimelineIO-0.15.0.dev1/tests/baselines/plugin_module/otio_mockplugin.egg-info/entry_points.txt
> OpenTimelineIO-0.15.0.dev1/tests/baselines/post_write_example.py
> OpenTimelineIO-0.15.0.dev1/tests/baselines/post_write_hookscript_example.json
> OpenTimelineIO-0.15.0.dev1/tests/baselines/schemadef_example.json
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/25fps.edl
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/OpenTimelineIO@3xDark.png
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/OpenTimelineIO@3xLight.png
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/big_int.otio
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/cdl.edl
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/clip_example.otio
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/dissolve_test.edl
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/dissolve_test_2.edl
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/dissolve_test_3.edl
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/dissolve_test_4.edl
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/empty_name_tags.xml
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/enabled.otio
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/gap_test.edl
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/generator_reference_test.otio
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/hiero_xml_export.xml
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/multi_audio.edl
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/multiple_track.otio
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/multiple_track.svg
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/multitrack.otio
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/nested_example.otio
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/no_spaces_test.edl
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/nucoda_example.edl
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/preflattened.otio
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/premiere_example.xml
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/premiere_example_filter.json
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/premiere_example_filter.xml
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/premiere_generators.xml
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/sample_just_track.xml
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/screening_example.edl
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/simple_cut.otio
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/simple_cut.svg
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/speed_effects.edl
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/speed_effects_small.edl
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/timecode_mismatch.edl
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/transition.otio
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/transition.svg
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/transition_duration.edl
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/transition_test.otio
> OpenTimelineIO-0.15.0.dev1/tests/sample_data/wipe_test.edl
> OpenTimelineIO-0.15.0.dev1/tests/test_adapter_plugin.py
> OpenTimelineIO-0.15.0.dev1/tests/test_box2d.py
> OpenTimelineIO-0.15.0.dev1/tests/test_builtin_adapters.py
> OpenTimelineIO-0.15.0.dev1/tests/test_cdl.py
> OpenTimelineIO-0.15.0.dev1/tests/test_clip.cpp
> OpenTimelineIO-0.15.0.dev1/tests/test_clip.py
> OpenTimelineIO-0.15.0.dev1/tests/test_cmx_3600_adapter.py
> OpenTimelineIO-0.15.0.dev1/tests/test_composable.py
> OpenTimelineIO-0.15.0.dev1/tests/test_composition.py
> OpenTimelineIO-0.15.0.dev1/tests/test_console.py
> OpenTimelineIO-0.15.0.dev1/tests/test_cxx_sdk_bindings.py
> OpenTimelineIO-0.15.0.dev1/tests/test_documentation.py
> OpenTimelineIO-0.15.0.dev1/tests/test_effect.py
> OpenTimelineIO-0.15.0.dev1/tests/test_examples.py
> OpenTimelineIO-0.15.0.dev1/tests/test_fcp7_xml_adapter.py
> OpenTimelineIO-0.15.0.dev1/tests/test_filter_algorithms.py
> OpenTimelineIO-0.15.0.dev1/tests/test_generator_reference.py
> OpenTimelineIO-0.15.0.dev1/tests/test_hooks_plugins.py
> OpenTimelineIO-0.15.0.dev1/tests/test_image_sequence_reference.py
> OpenTimelineIO-0.15.0.dev1/tests/test_item.py
> OpenTimelineIO-0.15.0.dev1/tests/test_json_backend.py
> OpenTimelineIO-0.15.0.dev1/tests/test_marker.py
> OpenTimelineIO-0.15.0.dev1/tests/test_media_linker.py
> OpenTimelineIO-0.15.0.dev1/tests/test_media_reference.py
> OpenTimelineIO-0.15.0.dev1/tests/test_multithreading.py
> OpenTimelineIO-0.15.0.dev1/tests/test_opentime.cpp
> OpenTimelineIO-0.15.0.dev1/tests/test_opentime.py
> OpenTimelineIO-0.15.0.dev1/tests/test_otiod.py
> OpenTimelineIO-0.15.0.dev1/tests/test_otioz.py
> OpenTimelineIO-0.15.0.dev1/tests/test_plugin_detection.py
> OpenTimelineIO-0.15.0.dev1/tests/test_schemadef_plugin.py
> OpenTimelineIO-0.15.0.dev1/tests/test_serializable_collection.py
> OpenTimelineIO-0.15.0.dev1/tests/test_serializable_object.py
> OpenTimelineIO-0.15.0.dev1/tests/test_serialized_schema.py
> OpenTimelineIO-0.15.0.dev1/tests/test_stack_algo.py
> OpenTimelineIO-0.15.0.dev1/tests/test_svg_adapter.py
> OpenTimelineIO-0.15.0.dev1/tests/test_timeline.py
> OpenTimelineIO-0.15.0.dev1/tests/test_timeline_algo.py
> OpenTimelineIO-0.15.0.dev1/tests/test_track_algo.py
> OpenTimelineIO-0.15.0.dev1/tests/test_transition.py
> OpenTimelineIO-0.15.0.dev1/tests/test_unknown_schema.py
> OpenTimelineIO-0.15.0.dev1/tests/test_url_conversions.py
> OpenTimelineIO-0.15.0.dev1/tests/test_v2d.py
> OpenTimelineIO-0.15.0.dev1/tests/utils.cpp
> OpenTimelineIO-0.15.0.dev1/tests/utils.h
> OpenTimelineIO-0.15.0.dev1/tests/utils.py
```
</details>