### PR TITLE
Use py::module_local() for Imath bindings

### DIFF
--- a/src/py-opentimelineio/opentimelineio-bindings/otio_imath.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_imath.cpp
@@ -24,7 +24,10 @@ CLASS _type_checked(py::object const& rhs, char const* op) {
 }
 
 static void define_imath_2d(py::module m) {
-    py::class_<Imath::V2d>(m, "V2d")
+    // Note that module_local is used to avoid issues when
+    // Imath classes are binded with Pybind11 more than once.
+    // Using module_local will avoid conflicts in such cases.
+    py::class_<Imath::V2d>(m, "V2d", py::module_local())
         .def(py::init<>())
         .def(py::init<double>())
         .def(py::init<double, double>())
@@ -97,7 +100,7 @@ static void define_imath_2d(py::module m) {
                 return Imath::V2d::dimensions();
             });
 
-    py::class_<Imath::Box2d>(m, "Box2d")
+    py::class_<Imath::Box2d>(m, "Box2d", py::module_local())
         .def(py::init<>())
         .def(py::init<Imath::V2d>())
         .def(py::init<Imath::V2d, Imath::V2d>())
@@ -127,4 +130,3 @@ static void define_imath_2d(py::module m) {
 void otio_imath_bindings(py::module m) {
     define_imath_2d(m);
 }
-


### PR DESCRIPTION
This PR fixes an issue reported in Slack (see https://academysoftwarefdn.slack.com/archives/CMQ9J4BQC/p1654121088621319).

The issue in question is that importing OpenTImelineIO in Katana would raise an import error like `ImportError: generic_type: type "V2d" is already registered!`.

The issue comes from the fact that Katana ships Python bindings for Imath made with Pybind11 and OTIO also provides parts of Imath using Pybind11.

The solution to this problem is to make the classes provided by OTIO module-local (see https://pybind11.readthedocs.io/en/stable/advanced/classes.html#module-local-class-bindings).

To quote the documentation:

>When creating a binding for a class, pybind11 by default makes that binding “global” across modules. What this means is that a type defined in one module can be returned from any module resulting in the same Python type. For example, this allows the following:
>
>```
> // In the module1.cpp binding code for module1:
>py::class_<Pet>(m, "Pet")
>    .def(py::init<std::string>())
>    .def_readonly("name", &Pet::name);
>```
>```
>// In the module2.cpp binding code for module2:
>m.def("create_pet", [](std::string name) { return new Pet(name); });
>```
>```
>from module1 import Pet
>from module2 import create_pet
>pet1 = Pet("Kitty")
>pet2 = create_pet("Doggy")
>pet2.name()
>'Doggy'
>```
>When writing binding code for a library, this is usually desirable: this allows, for example, splitting up a complex library into multiple Python modules.
>
>In some cases, however, this can cause conflicts. For example, suppose two unrelated modules make use of an external C++ library and each provide custom bindings for one of that library’s classes. This will result in an error when a Python program attempts to import both modules (directly or indirectly) because of conflicting definitions on the external type:
>
>```
>// dogs.cpp
>
>// Binding for external library class:
>py::class<pets::Pet>(m, "Pet")
>    .def("name", &pets::Pet::name);
>
>// Binding for local extension class:
>py::class<Dog, pets::Pet>(m, "Dog")
>    .def(py::init<std::string>());
>```
>```
>// cats.cpp, in a completely separate project from the above dogs.cpp.
>
>// Binding for external library class:
>py::class<pets::Pet>(m, "Pet")
>    .def("get_name", &pets::Pet::name);
>
>// Binding for local extending class:
>py::class<Cat, pets::Pet>(m, "Cat")
>    .def(py::init<std::string>());
>```
>```
>import cats
>import dogs
>Traceback (most recent call last):
>  File "<stdin>", line 1, in <module>
>ImportError: generic_type: type "Pet" is already registered!
>```

Using `py::module_local()` fixes that for us.