### PR TITLE
Cancel in-progress CI jobs for the same branch

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,6 +15,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cpp_build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This PR adds a concurrency group to the builds so that only one build for a branch can run at the same time. When pushing a new commit on a branch and a job is already running on that branch, the build will be cancelled to allow to build the new commit.

That's becoming more important now that we have DCO in place. It's quite easy to forget to sign-off a commit and have to rebase commits. That would trigger "useless" builds.

This PR fixes that problem.

The concurrency group is per workflow + branch WHIch means builds on other branches won't be affected.

As an example, I initially pushed without signing my commit, then had to sign + push again. That triggered two builds. The first one (https://github.com/AcademySoftwareFoundation/OpenTimelineIO/actions/runs/2521514987) as automatically cancelled and it says `Canceling since a higher priority waiting request for 'OpenTimelineIO-refs/pull/1329/merge' exists`. The second build won't have to wait as long as before to get runners.