### PR TITLE
Add basic mingw_x86_64 build support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -131,6 +131,36 @@ jobs:
         name: py-opentimelineio-codecov
         fail_ci_if_error: true
 
+  py_build_test_mingw64:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
+    - name: Setup MSYS2
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: mingw64
+        install: >-
+          mingw-w64-x86_64-python
+          mingw-w64-x86_64-python-setuptools
+          mingw-w64-x86_64-python-pip
+          mingw-w64-x86_64-python-wheel
+          mingw-w64-x86_64-python-build
+          mingw-w64-x86_64-gcc
+          mingw-w64-x86_64-cmake
+          make
+    - name: Build Wheel
+      shell: msys2 {0}
+      run: |
+        python --version
+        python -m build -w .
+    - name: Install and Test
+      shell: msys2 {0}
+      run: |
+        python -m pip install -I dist/*.whl
+        make test
+
   package_wheels:
     needs: py_build_test
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -88,6 +88,15 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['2.7', '3.7', '3.8', '3.9', '3.10']
+        include:
+          - { os: ubuntu-latest, shell: bash }
+          - { os: macos-latest, shell: bash }
+          - { os: windows-latest, shell: pwsh }
+          - { os: windows-latest, shell: msys2, python-version: 'mingw64' }
+
+    defaults:
+      run:
+        shell: '${{ matrix.shell }} {0}'
 
     env:
       OTIO_CXX_COVERAGE_BUILD: ON
@@ -97,7 +106,20 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
+    - name: Set up MSYS2
+      if: matrix.python-version == 'mingw64'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: mingw64
+        install: >-
+          mingw-w64-x86_64-python
+          mingw-w64-x86_64-python-pip
+          mingw-w64-x86_64-gcc
+          mingw-w64-x86_64-cmake
+          make
+          git
     - name: Set up Python ${{ matrix.python-version }}
+      if: matrix.python-version != 'mingw64'
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
@@ -130,36 +152,6 @@ jobs:
         flags: py-unittests
         name: py-opentimelineio-codecov
         fail_ci_if_error: true
-
-  py_build_test_mingw64:
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: 'recursive'
-    - name: Setup MSYS2
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: mingw64
-        install: >-
-          mingw-w64-x86_64-python
-          mingw-w64-x86_64-python-setuptools
-          mingw-w64-x86_64-python-pip
-          mingw-w64-x86_64-python-wheel
-          mingw-w64-x86_64-python-build
-          mingw-w64-x86_64-gcc
-          mingw-w64-x86_64-cmake
-          make
-    - name: Build Wheel
-      shell: msys2 {0}
-      run: |
-        python --version
-        python -m build -w .
-    - name: Install and Test
-      shell: msys2 {0}
-      run: |
-        python -m pip install -I dist/*.whl
-        make test
 
   package_wheels:
     needs: py_build_test

--- a/tests/test_plugin_detection.py
+++ b/tests/test_plugin_detection.py
@@ -40,7 +40,7 @@ class TestSetuptoolsPlugin(unittest.TestCase):
     def setUp(self):
         # Get the location of the mock plugin module metadata
         mock_module_path = os.path.join(
-            baseline_reader.path_to_baseline_directory(),
+            os.path.normpath(baseline_reader.path_to_baseline_directory()),
             'plugin_module',
         )
         self.mock_module_manifest_path = os.path.join(

--- a/tests/test_url_conversions.py
+++ b/tests/test_url_conversions.py
@@ -49,7 +49,7 @@ class TestConversions(unittest.TestCase):
         result = otio.url_utils.filepath_from_url(MEDIA_EXAMPLE_PATH_URL_REL)
 
         # should have reconstructed it by this point
-        self.assertEqual(result, MEDIA_EXAMPLE_PATH_REL)
+        self.assertEqual(os.path.normpath(result), MEDIA_EXAMPLE_PATH_REL)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is the minimal amount of changes required to add mingw_x86_64 support on windows and pass all the tests.

This pull request is mainly for discussion as to if this is a platform OTIO wishes to support. I haven't looked into adding the platform to CI yet, but feels like it might be a bit of a headache to get working. 

I also haven't been able to get it to build in 32-bit mode yet, just in 64-bit.

Not being able to build on mingw has been mentioned here https://github.com/AcademySoftwareFoundation/OpenTimelineIO/discussions/1342#discussioncomment-3088730
