### PR TITLE
Close Temporary file handles in tests

### DIFF
--- a/tests/test_otiod.py
+++ b/tests/test_otiod.py
@@ -102,7 +102,8 @@ class OTIODTester(unittest.TestCase, otio_test_utils.OTIOAssertions):
             self.assertEqual(len(manifest[fname]), count)
 
     def test_round_trip(self):
-        tmp_path = tempfile.NamedTemporaryFile(suffix=".otiod").name
+        with tempfile.NamedTemporaryFile(suffix=".otiod") as bogusfile:
+            tmp_path = bogusfile.name
         otio.adapters.write_to_file(self.tl, tmp_path)
         self.assertTrue(os.path.exists(tmp_path))
 
@@ -132,7 +133,8 @@ class OTIODTester(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertJsonEqual(result, self.tl)
 
     def test_round_trip_all_missing_references(self):
-        tmp_path = tempfile.NamedTemporaryFile(suffix=".otiod").name
+        with tempfile.NamedTemporaryFile(suffix=".otiod") as bogusfile:
+            tmp_path = bogusfile.name
         otio.adapters.write_to_file(
             self.tl,
             tmp_path,
@@ -154,7 +156,8 @@ class OTIODTester(unittest.TestCase, otio_test_utils.OTIOAssertions):
             )
 
     def test_round_trip_absolute_paths(self):
-        tmp_path = tempfile.NamedTemporaryFile(suffix=".otiod").name
+        with tempfile.NamedTemporaryFile(suffix=".otiod") as bogusfile:
+            tmp_path = bogusfile.name
         otio.adapters.write_to_file(self.tl, tmp_path)
 
         # ...but can be optionally told to generate absolute paths

--- a/tests/test_otioz.py
+++ b/tests/test_otioz.py
@@ -124,7 +124,8 @@ class OTIOZTester(unittest.TestCase, otio_test_utils.OTIOAssertions):
         shutil.rmtree(tempdir)
 
     def test_round_trip(self):
-        tmp_path = tempfile.NamedTemporaryFile(suffix=".otioz").name
+        with tempfile.NamedTemporaryFile(suffix=".otioz") as bogusfile:
+            tmp_path = bogusfile.name
         otio.adapters.write_to_file(self.tl, tmp_path)
         self.assertTrue(os.path.exists(tmp_path))
 
@@ -155,7 +156,8 @@ class OTIOZTester(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertJsonEqual(result, self.tl)
 
     def test_round_trip_with_extraction(self):
-        tmp_path = tempfile.NamedTemporaryFile(suffix=".otioz").name
+        with tempfile.NamedTemporaryFile(suffix=".otioz") as bogusfile:
+            tmp_path = bogusfile.name
         otio.adapters.write_to_file(self.tl, tmp_path)
         self.assertTrue(os.path.exists(tmp_path))
 
@@ -213,7 +215,8 @@ class OTIOZTester(unittest.TestCase, otio_test_utils.OTIOAssertions):
         )
 
     def test_round_trip_with_extraction_no_media(self):
-        tmp_path = tempfile.NamedTemporaryFile(suffix=".otioz").name
+        with tempfile.NamedTemporaryFile(suffix=".otioz") as bogusfile:
+            tmp_path = bogusfile.name
         otio.adapters.write_to_file(
             self.tl,
             tmp_path,


### PR DESCRIPTION
I noticed these file handles were leaking when running tests on mingw64.  
I matched the style that's in the files, but I think it would be better to use a `TemporaryDirectory` and cleanup when the test is done.  Some tests are doing that, but it is a bit mixed.