### PR TITLE
Python3 fixes for the shot_detect example

### DIFF
--- a/examples/shot_detect.py
+++ b/examples/shot_detect.py
@@ -216,7 +216,15 @@ def _ffprobe_fps(name, full_path, dryrun=False):
     if dryrun:
         return 1.0
 
-    for line in err.split('\n'):
+    try:
+        # python3
+        # if its bytes (python3+)
+        err_str = err.decode("utf-8")
+    except AttributeError:
+        # if its a string (python <3)
+        err_str = err
+
+    for line in err_str.split('\n'):
         if not ("Stream" in line and "Video" in line):
             continue
 


### PR DESCRIPTION
The python bytes vs str issue is present in the `shot_detect.py` example.  This should fix that and make it usable again.