### PR TITLE
Import _opentime before actually creating the bindings for _otio

### DIFF
--- a/src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp
@@ -167,7 +167,7 @@ static SerializableObject* instance_from_schema(std::string schema_name,
 
 PYBIND11_MODULE(_otio, m) {
     // Import _opentime before actually creating the bindings
-    // for _otio. This allows to import _otio without
+    // for _otio. This allows the import of _otio without
     // manually importing _opentime before. For example: python -c 'import opentimelineio._otio'
     py::module_::import("opentimelineio._opentime");
 

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp
@@ -166,7 +166,13 @@ static SerializableObject* instance_from_schema(std::string schema_name,
 }
 
 PYBIND11_MODULE(_otio, m) {
+    // Import _opentime before actually creating the bindings
+    // for _otio. This allows to import _otio without
+    // manually importing _opentime before. For example: python -c 'import opentimelineio._otio'
+    py::module_::import("opentimelineio._opentime");
+
     m.doc() = "Bindings to C++ OTIO implementation";
+
     otio_exception_bindings(m);
     otio_any_dictionary_bindings(m);
     otio_any_vector_bindings(m);


### PR DESCRIPTION
I noticed that doing `python -c 'import opentimelineio._otio'` was not working. It was resulting in an import error:
```
ImportError: arg(): could not convert default argument 'marked_range: opentime::v1_0::TimeRange' in method '<class 'opentimelineio._otio.Marker'>.__init__' into a Python object (type not registered yet?)
```

This error doesn't normally happen because we usually go through `opentimelineio/__init__.py` which imports `_opentime` before importing `_otio`.

After some searching, I found https://pybind11.readthedocs.io/en/stable/advanced/misc.html#partitioning-code-over-multiple-extension-modules which describes some options to fix this. This PR implements the simplest option out there, which is to import `_opentime` before actually creating the `_otio` bindings.

This should be harmless because it is going to be a no-op when importing OTIO normally (via `import opentimelineio`). It will be a no-op in this case bacause Python doesn't re-import a package if imported twice.