### PR TITLE
add .envrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ htmlcov
 xcuserdata/
 .venv/
 .cache
+.envrc
 
 # Pycharm metadata
 .idea/


### PR DESCRIPTION

Signed-off-by: Mark Sisson <5761292+marksisson@users.noreply.github.com>

**Link the Issue(s) this Pull Request is related to.**

Fixes #1401

**Summarize your change.**

direnv (https://github.com/direnv/direnv) can be used for local developer workflow enhancements.  direnv uses .envrc file for configuration.  Because .envrc is usually specific to a developer workflow, it is generally not committed.

**Reference associated tests.**

If no new tests are introduced as part of this PR, note the tests that are providing coverage.

I think all tests provide coverage.  This change prevents .envrc file from being added to repository.

<!--
Important: If this is your first contribution to OpenTimelineIO, you will need to submit a Contributor License Agreement. For a step-by-step instructions on the pull request process, see
https://github.com/AcademySoftwareFoundation/OpenTimelineIO/tree/main/CONTRIBUTING.md
-->
