### PR TITLE
Fix for SerializableCollection::children_if

### DIFF
--- a/src/opentimelineio/serializableCollection.h
+++ b/src/opentimelineio/serializableCollection.h
@@ -99,8 +99,8 @@ SerializableCollection::children_if(
             out.push_back(valid_child);
         }
 
-        // if not a shallow_search, for children that are serialiable collections, compositions,
-        // or timelines, recurse into their children
+        // if not a shallow_search, for children that are serializable collections,
+        // compositions, or timelines, recurse into their children
         if (!shallow_search)
         {
             if (auto collection =

--- a/src/opentimelineio/serializableCollection.h
+++ b/src/opentimelineio/serializableCollection.h
@@ -5,6 +5,7 @@
 
 #include "opentimelineio/composition.h"
 #include "opentimelineio/serializableObjectWithMetadata.h"
+#include "opentimelineio/timeline.h"
 #include "opentimelineio/version.h"
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
@@ -98,8 +99,8 @@ SerializableCollection::children_if(
             out.push_back(valid_child);
         }
 
-        // if not a shallow_search, for children that are serialiable collections or compositions,
-        // recurse into their children
+        // if not a shallow_search, for children that are serialiable collections, compositions,
+        // or timelines, recurse into their children
         if (!shallow_search)
         {
             if (auto collection =
@@ -120,6 +121,19 @@ SerializableCollection::children_if(
             {
                 const auto valid_children =
                     composition->children_if<T>(error_status, search_range);
+                if (is_error(error_status))
+                {
+                    return out;
+                }
+                for (const auto& valid_child: valid_children)
+                {
+                    out.push_back(valid_child);
+                }
+            }
+            else if (auto timeline = dynamic_cast<Timeline*>(child.value))
+            {
+                const auto valid_children =
+                    timeline->children_if<T>(error_status, search_range);
                 if (is_error(error_status))
                 {
                     return out;

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -289,12 +289,12 @@ A :class:`~SerializableCollection` is useful for serializing multiple timelines,
         .def("__iter__", [](SerializableCollection* c) {
                 return new SerializableCollectionIterator(c);
             })
-        .def("clip_if", [](SerializableCollection* t, optional<TimeRange> const& search_range) {
-                return clip_if(t, search_range);
-            }, "search_range"_a = nullopt)
-        .def("children_if", [](SerializableCollection* t, py::object descended_from_type, optional<TimeRange> const& search_range) {
-                return children_if(t, descended_from_type, search_range);
-            }, "descended_from_type"_a = py::none(), "search_range"_a = nullopt);
+        .def("clip_if", [](SerializableCollection* t, optional<TimeRange> const& search_range, bool shallow_search) {
+                return clip_if(t, search_range, shallow_search);
+            }, "search_range"_a = nullopt, "shallow_search"_a = false)
+        .def("children_if", [](SerializableCollection* t, py::object descended_from_type, optional<TimeRange> const& search_range, bool shallow_search) {
+                return children_if(t, descended_from_type, search_range, shallow_search);
+            }, "descended_from_type"_a = py::none(), "search_range"_a = nullopt, "shallow_search"_a = false);
 
 }
 
@@ -611,9 +611,9 @@ Should be subclassed (for example by :class:`.Track` and :class:`.Stack`), not u
              "markers"_a = py::none(),
              "effects"_a = py::none(),
              py::arg_v("metadata"_a = py::none()))
-        .def("clip_if", [](Stack* t, optional<TimeRange> const& search_range) {
-                return clip_if(t, search_range);
-            }, "search_range"_a = nullopt);
+        .def("clip_if", [](Stack* t, optional<TimeRange> const& search_range, bool shallow_search) {
+                return clip_if(t, search_range, shallow_search);
+            }, "search_range"_a = nullopt, "shallow_search"_a = false);
 
     py::class_<Timeline, SerializableObjectWithMetadata, managing_ptr<Timeline>>(m, "Timeline", py::dynamic_attr())
         .def(py::init([](std::string name,
@@ -641,12 +641,12 @@ Should be subclassed (for example by :class:`.Track` and :class:`.Stack`), not u
             })
         .def("video_tracks", &Timeline::video_tracks)
         .def("audio_tracks", &Timeline::audio_tracks)
-        .def("clip_if", [](Timeline* t, optional<TimeRange> const& search_range) {
-                return clip_if(t, search_range);
-            }, "search_range"_a = nullopt)
-        .def("children_if", [](Timeline* t, py::object descended_from_type, optional<TimeRange> const& search_range) {
-                return children_if(t, descended_from_type, search_range);
-            }, "descended_from_type"_a = py::none(), "search_range"_a = nullopt);
+        .def("clip_if", [](Timeline* t, optional<TimeRange> const& search_range, bool shallow_search) {
+                return clip_if(t, search_range, shallow_search);
+            }, "search_range"_a = nullopt, "shallow_search"_a = false)
+        .def("children_if", [](Timeline* t, py::object descended_from_type, optional<TimeRange> const& search_range, bool shallow_search) {
+                return children_if(t, descended_from_type, search_range, shallow_search);
+            }, "descended_from_type"_a = py::none(), "search_range"_a = nullopt, "shallow_search"_a = false);
 }
 
 static void define_effects(py::module m) {

--- a/src/py-opentimelineio/opentimelineio/schema/serializable_collection.py
+++ b/src/py-opentimelineio/opentimelineio/schema/serializable_collection.py
@@ -32,7 +32,7 @@ def __repr__(self):
 
 @add_method(_otio.SerializableCollection)
 def each_child(self, search_range=None, descended_from_type=_otio.Composable,
-    shallow_search=False):
+               shallow_search=False):
     """ Generator that returns each child contained in the serializable
     collection in the order in which it is found.
 

--- a/src/py-opentimelineio/opentimelineio/schema/serializable_collection.py
+++ b/src/py-opentimelineio/opentimelineio/schema/serializable_collection.py
@@ -31,7 +31,7 @@ def __repr__(self):
 
 
 @add_method(_otio.SerializableCollection)
-def each_child(self, search_range=None, descended_from_type=_otio.Composable):
+def each_child(self, search_range=None, descended_from_type=_otio.Composable, shallow_search=False):
     """ Generator that returns each child contained in the serializable
     collection in the order in which it is found.
 
@@ -42,13 +42,15 @@ def each_child(self, search_range=None, descended_from_type=_otio.Composable):
                                    with the search range will be yielded.
     :param type descended_from_type: if specified, only children who are a descendent
                                      of the descended_from_type will be yielded.
+    :param bool shallow_search: if True, will only search children of self and not recurse
+                                into children of children.
     """
-    for child in self.children_if(descended_from_type, search_range):
+    for child in self.children_if(descended_from_type, search_range, shallow_search):
         yield child
 
 
 @add_method(_otio.SerializableCollection)
-def each_clip(self, search_range=None):
+def each_clip(self, search_range=None, shallow_search=False):
     """ Generator that returns each clip contained in the serializable
     collection in the order in which it is found.
 
@@ -57,6 +59,8 @@ def each_clip(self, search_range=None):
 
     :param TimeRange search_range: if specified, only children whose range overlaps
                                    with the search range will be yielded.
+    :param bool shallow_search: if True, will only search children of self and not recurse
+                                into children of children.
     """
-    for child in self.clip_if(search_range):
+    for child in self.clip_if(search_range, shallow_search):
         yield child

--- a/src/py-opentimelineio/opentimelineio/schema/serializable_collection.py
+++ b/src/py-opentimelineio/opentimelineio/schema/serializable_collection.py
@@ -31,7 +31,8 @@ def __repr__(self):
 
 
 @add_method(_otio.SerializableCollection)
-def each_child(self, search_range=None, descended_from_type=_otio.Composable, shallow_search=False):
+def each_child(self, search_range=None, descended_from_type=_otio.Composable,
+    shallow_search=False):
     """ Generator that returns each child contained in the serializable
     collection in the order in which it is found.
 
@@ -42,8 +43,8 @@ def each_child(self, search_range=None, descended_from_type=_otio.Composable, sh
                                    with the search range will be yielded.
     :param type descended_from_type: if specified, only children who are a descendent
                                      of the descended_from_type will be yielded.
-    :param bool shallow_search: if True, will only search children of self and not recurse
-                                into children of children.
+    :param bool shallow_search: if True, will only search children of self and not
+                                recurse into children of children.
     """
     for child in self.children_if(descended_from_type, search_range, shallow_search):
         yield child
@@ -59,8 +60,8 @@ def each_clip(self, search_range=None, shallow_search=False):
 
     :param TimeRange search_range: if specified, only children whose range overlaps
                                    with the search range will be yielded.
-    :param bool shallow_search: if True, will only search children of self and not recurse
-                                into children of children.
+    :param bool shallow_search: if True, will only search children of self and not
+                                recurse into children of children.
     """
     for child in self.clip_if(search_range, shallow_search):
         yield child

--- a/src/py-opentimelineio/opentimelineio/schema/stack.py
+++ b/src/py-opentimelineio/opentimelineio/schema/stack.py
@@ -6,7 +6,7 @@ from .. import _otio
 
 
 @add_method(_otio.Stack)
-def each_clip(self, search_range=None):
+def each_clip(self, search_range=None, shallow_search=False):
     """Generator that returns each clip contained in the stack
     in the order in which it is found.
 
@@ -15,6 +15,8 @@ def each_clip(self, search_range=None):
 
     :param TimeRange search_range: if specified, only children whose range overlaps
                                    with the search range will be yielded.
+    :param bool shallow_search: if True, will only search children of self and not recurse
+                                into children of children.
     """
-    for child in self.clip_if(search_range):
+    for child in self.clip_if(search_range, shallow_search):
         yield child

--- a/src/py-opentimelineio/opentimelineio/schema/stack.py
+++ b/src/py-opentimelineio/opentimelineio/schema/stack.py
@@ -15,8 +15,8 @@ def each_clip(self, search_range=None, shallow_search=False):
 
     :param TimeRange search_range: if specified, only children whose range overlaps
                                    with the search range will be yielded.
-    :param bool shallow_search: if True, will only search children of self and not recurse
-                                into children of children.
+    :param bool shallow_search: if True, will only search children of self and not
+                                recurse into children of children.
     """
     for child in self.clip_if(search_range, shallow_search):
         yield child

--- a/src/py-opentimelineio/opentimelineio/schema/timeline.py
+++ b/src/py-opentimelineio/opentimelineio/schema/timeline.py
@@ -21,7 +21,8 @@ def __repr__(self):
 
 
 @add_method(_otio.Timeline)
-def each_child(self, search_range=None, descended_from_type=_otio.Composable, shallow_search=False):
+def each_child(self, search_range=None, descended_from_type=_otio.Composable,
+    shallow_search=False):
     """Generator that returns each child contained in the timeline
     in the order in which it is found.
 
@@ -32,8 +33,8 @@ def each_child(self, search_range=None, descended_from_type=_otio.Composable, sh
                                    with the search range will be yielded.
     :param type descended_from_type: if specified, only children who are a descendent
                                      of the descended_from_type will be yielded.
-    :param bool shallow_search: if True, will only search children of self and not recurse
-                                into children of children.
+    :param bool shallow_search: if True, will only search children of self and not
+                                recurse into children of children.
     """
     for child in self.children_if(descended_from_type, search_range, shallow_search):
         yield child
@@ -49,8 +50,8 @@ def each_clip(self, search_range=None, shallow_search=False):
 
     :param TimeRange search_range: if specified, only children whose range overlaps
                                    with the search range will be yielded.
-    :param bool shallow_search: if True, will only search children of self and not recurse
-                                into children of children.
+    :param bool shallow_search: if True, will only search children of self and not
+                                recurse into children of children.
     """
     for child in self.clip_if(search_range, shallow_search):
         yield child

--- a/src/py-opentimelineio/opentimelineio/schema/timeline.py
+++ b/src/py-opentimelineio/opentimelineio/schema/timeline.py
@@ -22,7 +22,7 @@ def __repr__(self):
 
 @add_method(_otio.Timeline)
 def each_child(self, search_range=None, descended_from_type=_otio.Composable,
-    shallow_search=False):
+               shallow_search=False):
     """Generator that returns each child contained in the timeline
     in the order in which it is found.
 

--- a/src/py-opentimelineio/opentimelineio/schema/timeline.py
+++ b/src/py-opentimelineio/opentimelineio/schema/timeline.py
@@ -21,7 +21,7 @@ def __repr__(self):
 
 
 @add_method(_otio.Timeline)
-def each_child(self, search_range=None, descended_from_type=_otio.Composable):
+def each_child(self, search_range=None, descended_from_type=_otio.Composable, shallow_search=False):
     """Generator that returns each child contained in the timeline
     in the order in which it is found.
 
@@ -32,13 +32,15 @@ def each_child(self, search_range=None, descended_from_type=_otio.Composable):
                                    with the search range will be yielded.
     :param type descended_from_type: if specified, only children who are a descendent
                                      of the descended_from_type will be yielded.
+    :param bool shallow_search: if True, will only search children of self and not recurse
+                                into children of children.
     """
-    for child in self.children_if(descended_from_type, search_range):
+    for child in self.children_if(descended_from_type, search_range, shallow_search):
         yield child
 
 
 @add_method(_otio.Timeline)
-def each_clip(self, search_range=None):
+def each_clip(self, search_range=None, shallow_search=False):
     """Generator that returns each clip contained in the timeline
     in the order in which it is found.
 
@@ -47,6 +49,8 @@ def each_clip(self, search_range=None):
 
     :param TimeRange search_range: if specified, only children whose range overlaps
                                    with the search range will be yielded.
+    :param bool shallow_search: if True, will only search children of self and not recurse
+                                into children of children.
     """
-    for child in self.clip_if(search_range):
+    for child in self.clip_if(search_range, shallow_search):
         yield child

--- a/src/py-opentimelineio/opentimelineio/schema/track.py
+++ b/src/py-opentimelineio/opentimelineio/schema/track.py
@@ -15,8 +15,8 @@ def each_clip(self, search_range=None, shallow_search=False):
 
     :param TimeRange search_range: if specified, only children whose range overlaps with
                                    the search range will be yielded.
-    :param bool shallow_search: if True, will only search children of self and not recurse
-                                into children of children.
+    :param bool shallow_search: if True, will only search children of self and not
+                                recurse into children of children.
     """
     for child in self.clip_if(search_range, shallow_search):
         yield child

--- a/src/py-opentimelineio/opentimelineio/schema/track.py
+++ b/src/py-opentimelineio/opentimelineio/schema/track.py
@@ -14,9 +14,9 @@ def each_clip(self, search_range=None, shallow_search=False):
         Use :meth:`clip_if` instead.
 
     :param TimeRange search_range: if specified, only children whose range overlaps with
-                      the search range will be yielded.
-    :param bool shallow_search: if True, will only search children of self, not
-                        and not recurse into children of children.
+                                   the search range will be yielded.
+    :param bool shallow_search: if True, will only search children of self and not recurse
+                                into children of children.
     """
-    for child in self.clip_if(search_range):
+    for child in self.clip_if(search_range, shallow_search):
         yield child

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,7 +15,7 @@ foreach(test ${tests_opentime})
            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endforeach()
 
-list(APPEND tests_opentimelineio test_clip)
+list(APPEND tests_opentimelineio test_clip test_serializableCollection test_timeline test_track)
 foreach(test ${tests_opentimelineio})
     add_executable(${test} utils.h utils.cpp ${test}.cpp)
 

--- a/tests/test_clip.cpp
+++ b/tests/test_clip.cpp
@@ -223,32 +223,6 @@ main(int argc, char** argv)
         assertEqual(clip->media_reference(), ref4.value);
     });
 
-    tests.add_test(
-        "test_children_if", [] {
-        using namespace otio;
-
-        // Find a clip in a track.
-        otio::SerializableObject::Retainer<otio::Clip> cl = new otio::Clip();
-        otio::SerializableObject::Retainer<otio::Track> tr = new otio::Track();
-        tr->append_child(cl);
-        opentimelineio::v1_0::ErrorStatus err;
-        auto result = tr->children_if<otio::Clip>(&err);
-        assertEqual(result.size(), 1);
-
-        // Find a clip in a timeline.
-        otio::SerializableObject::Retainer<otio::Timeline> tl = new otio::Timeline();
-        tl->tracks()->append_child(tr);
-        result = tl->children_if<otio::Clip>(&err);
-        assertEqual(result.size(), 1);
-
-        // Find a clip in a serializable collection.
-        otio::SerializableObject::Retainer<otio::SerializableCollection> sc =
-            new otio::SerializableCollection();
-        sc->insert_child(0, tl);
-        result = sc->children_if<otio::Clip>(&err, {}, false);
-        assertEqual(result.size(), 1);
-    });
-
     tests.run(argc, argv);
     return 0;
 }

--- a/tests/test_clip.cpp
+++ b/tests/test_clip.cpp
@@ -7,6 +7,7 @@
 #include <opentimelineio/deserialization.h>
 #include <opentimelineio/externalReference.h>
 #include <opentimelineio/missingReference.h>
+#include <opentimelineio/serializableCollection.h>
 #include <opentimelineio/timeline.h>
 
 #include <iostream>
@@ -220,6 +221,32 @@ main(int argc, char** argv)
         // should work
         clip->set_media_references({ { "cloud", ref4 } }, "cloud");
         assertEqual(clip->media_reference(), ref4.value);
+    });
+
+    tests.add_test(
+        "test_children_if", [] {
+        using namespace otio;
+
+        // Find a clip in a track.
+        otio::SerializableObject::Retainer<otio::Clip> cl = new otio::Clip();
+        otio::SerializableObject::Retainer<otio::Track> tr = new otio::Track();
+        tr->append_child(cl);
+        opentimelineio::v1_0::ErrorStatus err;
+        auto result = tr->children_if<otio::Clip>(&err);
+        assertEqual(result.size(), 1);
+
+        // Find a clip in a timeline.
+        otio::SerializableObject::Retainer<otio::Timeline> tl = new otio::Timeline();
+        tl->tracks()->append_child(tr);
+        result = tl->children_if<otio::Clip>(&err);
+        assertEqual(result.size(), 1);
+
+        // Find a clip in a serializable collection.
+        otio::SerializableObject::Retainer<otio::SerializableCollection> sc =
+            new otio::SerializableCollection();
+        sc->insert_child(0, tl);
+        result = sc->children_if<otio::Clip>(&err, {}, false);
+        assertEqual(result.size(), 1);
     });
 
     tests.run(argc, argv);

--- a/tests/test_serializableCollection.cpp
+++ b/tests/test_serializableCollection.cpp
@@ -21,73 +21,69 @@ main(int argc, char** argv)
     tests.add_test(
         "test_children_if", [] {
         using namespace otio;
-        {
-            // Find a clip in a serializable collection.
-            otio::SerializableObject::Retainer<otio::Clip> cl =
-                new otio::Clip();
-            otio::SerializableObject::Retainer<otio::Track> tr =
-                new otio::Track();
-            tr->append_child(cl);
-            otio::SerializableObject::Retainer<otio::Timeline> tl =
-                new otio::Timeline();
-            tl->tracks()->append_child(tr);
-            otio::SerializableObject::Retainer<otio::SerializableCollection>
-                sc = new otio::SerializableCollection();
-            sc->insert_child(0, tl);
-            opentimelineio::v1_0::ErrorStatus err;
-            auto result = sc->children_if<otio::Clip>(&err, {}, false);
-            assertEqual(result.size(), 1);
-        }
-        {
-            // Test the search range parameter.
-            TimeRange range(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0));
-            otio::SerializableObject::Retainer<otio::Clip> cl0 =
-                new otio::Clip();
-            cl0->set_source_range(range);
-            otio::SerializableObject::Retainer<otio::Clip> cl1 =
-                new otio::Clip();
-            cl1->set_source_range(range);
-            otio::SerializableObject::Retainer<otio::Clip> cl2 =
-                new otio::Clip();
-            cl2->set_source_range(range);
-            otio::SerializableObject::Retainer<otio::Track> tr =
-                new otio::Track();
-            tr->append_child(cl0);
-            tr->append_child(cl1);
-            tr->append_child(cl2);
-            otio::SerializableObject::Retainer<otio::Timeline> tl =
-                new otio::Timeline();
-            tl->tracks()->append_child(tr);
-            otio::SerializableObject::Retainer<otio::SerializableCollection>
-                sc = new otio::SerializableCollection();
-            sc->insert_child(0, tl);
-            opentimelineio::v1_0::ErrorStatus err;
-            auto result = sc->children_if<otio::Clip>(
-                &err,
-                TimeRange(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0)));
-            assertEqual(result.size(), 1);
-            assertTrue(result[0] = cl0);
-        }
-        {
-            // Test the shallow search parameter.
-            otio::SerializableObject::Retainer<otio::Clip> cl =
-                new otio::Clip();
-            otio::SerializableObject::Retainer<otio::Track> tr =
-                new otio::Track();
-            tr->append_child(cl);
-            otio::SerializableObject::Retainer<otio::Timeline> tl =
-                new otio::Timeline();
-            tl->tracks()->append_child(tr);
-            otio::SerializableObject::Retainer<otio::SerializableCollection>
-                sc = new otio::SerializableCollection();
-            sc->insert_child(0, tl);
-            opentimelineio::v1_0::ErrorStatus err;
-            auto result = sc->children_if<otio::Clip>(&err, nullopt, true);
-            assertEqual(result.size(), 0);
-            result = sc->children_if<otio::Clip>(&err, nullopt, false);
-            assertEqual(result.size(), 1);
-            assertTrue(result[0] = cl);
-        }
+        otio::SerializableObject::Retainer<otio::Clip> cl =
+            new otio::Clip();
+        otio::SerializableObject::Retainer<otio::Track> tr =
+            new otio::Track();
+        tr->append_child(cl);
+        otio::SerializableObject::Retainer<otio::Timeline> tl =
+            new otio::Timeline();
+        tl->tracks()->append_child(tr);
+        otio::SerializableObject::Retainer<otio::SerializableCollection>
+            sc = new otio::SerializableCollection();
+        sc->insert_child(0, tl);
+        opentimelineio::v1_0::ErrorStatus err;
+        auto result = sc->children_if<otio::Clip>(&err, {}, false);
+        assertEqual(result.size(), 1);
+        assertTrue(result[0] = cl);
+    });
+    tests.add_test(
+        "test_children_if_search_range", [] {
+        const TimeRange range(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0));
+        otio::SerializableObject::Retainer<otio::Clip> cl0 =
+            new otio::Clip();
+        cl0->set_source_range(range);
+        otio::SerializableObject::Retainer<otio::Clip> cl1 =
+            new otio::Clip();
+        cl1->set_source_range(range);
+        otio::SerializableObject::Retainer<otio::Clip> cl2 =
+            new otio::Clip();
+        cl2->set_source_range(range);
+        otio::SerializableObject::Retainer<otio::Track> tr =
+            new otio::Track();
+        tr->append_child(cl0);
+        tr->append_child(cl1);
+        tr->append_child(cl2);
+        otio::SerializableObject::Retainer<otio::Timeline> tl =
+            new otio::Timeline();
+        tl->tracks()->append_child(tr);
+        otio::SerializableObject::Retainer<otio::SerializableCollection>
+            sc = new otio::SerializableCollection();
+        sc->insert_child(0, tl);
+        opentimelineio::v1_0::ErrorStatus err;
+        auto result = sc->children_if<otio::Clip>(&err, range);
+        assertEqual(result.size(), 1);
+        assertTrue(result[0] = cl0);
+    });
+    tests.add_test(
+        "test_children_if_shallow_search", [] {
+        otio::SerializableObject::Retainer<otio::Clip> cl =
+            new otio::Clip();
+        otio::SerializableObject::Retainer<otio::Track> tr =
+            new otio::Track();
+        tr->append_child(cl);
+        otio::SerializableObject::Retainer<otio::Timeline> tl =
+            new otio::Timeline();
+        tl->tracks()->append_child(tr);
+        otio::SerializableObject::Retainer<otio::SerializableCollection>
+            sc = new otio::SerializableCollection();
+        sc->insert_child(0, tl);
+        opentimelineio::v1_0::ErrorStatus err;
+        auto result = sc->children_if<otio::Clip>(&err, nullopt, true);
+        assertEqual(result.size(), 0);
+        result = sc->children_if<otio::Clip>(&err, nullopt, false);
+        assertEqual(result.size(), 1);
+        assertTrue(result[0] = cl);
     });
 
     tests.run(argc, argv);

--- a/tests/test_serializableCollection.cpp
+++ b/tests/test_serializableCollection.cpp
@@ -39,6 +39,7 @@ main(int argc, char** argv)
     });
     tests.add_test(
         "test_children_if_search_range", [] {
+        using namespace otio;
         const TimeRange range(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0));
         otio::SerializableObject::Retainer<otio::Clip> cl0 =
             new otio::Clip();
@@ -67,6 +68,7 @@ main(int argc, char** argv)
     });
     tests.add_test(
         "test_children_if_shallow_search", [] {
+        using namespace otio;
         otio::SerializableObject::Retainer<otio::Clip> cl =
             new otio::Clip();
         otio::SerializableObject::Retainer<otio::Track> tr =

--- a/tests/test_serializableCollection.cpp
+++ b/tests/test_serializableCollection.cpp
@@ -35,7 +35,7 @@ main(int argc, char** argv)
         opentimelineio::v1_0::ErrorStatus err;
         auto result = sc->children_if<otio::Clip>(&err, {}, false);
         assertEqual(result.size(), 1);
-        assertTrue(result[0] = cl);
+        assertEqual(result[0].value, cl.value);
     });
     tests.add_test(
         "test_children_if_search_range", [] {
@@ -64,7 +64,7 @@ main(int argc, char** argv)
         opentimelineio::v1_0::ErrorStatus err;
         auto result = sc->children_if<otio::Clip>(&err, range);
         assertEqual(result.size(), 1);
-        assertTrue(result[0] = cl0);
+        assertEqual(result[0].value, cl0.value);
     });
     tests.add_test(
         "test_children_if_shallow_search", [] {
@@ -85,7 +85,7 @@ main(int argc, char** argv)
         assertEqual(result.size(), 0);
         result = sc->children_if<otio::Clip>(&err, nullopt, false);
         assertEqual(result.size(), 1);
-        assertTrue(result[0] = cl);
+        assertEqual(result[0].value, cl.value);
     });
 
     tests.run(argc, argv);

--- a/tests/test_serializableCollection.cpp
+++ b/tests/test_serializableCollection.cpp
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Contributors to the OpenTimelineIO project
+
+#include "utils.h"
+
+#include <opentimelineio/clip.h>
+#include <opentimelineio/serializableCollection.h>
+#include <opentimelineio/timeline.h>
+#include <opentimelineio/track.h>
+
+#include <iostream>
+
+namespace otime = opentime::OPENTIME_VERSION;
+namespace otio  = opentimelineio::OPENTIMELINEIO_VERSION;
+
+int
+main(int argc, char** argv)
+{
+    Tests tests;
+
+    tests.add_test(
+        "test_children_if", [] {
+        using namespace otio;
+
+        // Find a clip in a serializable collection.
+        otio::SerializableObject::Retainer<otio::Clip>  cl = new otio::Clip();
+        otio::SerializableObject::Retainer<otio::Track> tr = new otio::Track();
+        tr->append_child(cl);
+        otio::SerializableObject::Retainer<otio::Timeline> tl = new otio::Timeline();
+        tl->tracks()->append_child(tr);
+        otio::SerializableObject::Retainer<otio::SerializableCollection> sc =
+            new otio::SerializableCollection();
+        sc->insert_child(0, tl);
+        opentimelineio::v1_0::ErrorStatus err;
+        auto result = sc->children_if<otio::Clip>(&err, {}, false);
+        assertEqual(result.size(), 1);
+    });
+
+    tests.run(argc, argv);
+    return 0;
+}

--- a/tests/test_serializableCollection.cpp
+++ b/tests/test_serializableCollection.cpp
@@ -21,19 +21,73 @@ main(int argc, char** argv)
     tests.add_test(
         "test_children_if", [] {
         using namespace otio;
-
-        // Find a clip in a serializable collection.
-        otio::SerializableObject::Retainer<otio::Clip>  cl = new otio::Clip();
-        otio::SerializableObject::Retainer<otio::Track> tr = new otio::Track();
-        tr->append_child(cl);
-        otio::SerializableObject::Retainer<otio::Timeline> tl = new otio::Timeline();
-        tl->tracks()->append_child(tr);
-        otio::SerializableObject::Retainer<otio::SerializableCollection> sc =
-            new otio::SerializableCollection();
-        sc->insert_child(0, tl);
-        opentimelineio::v1_0::ErrorStatus err;
-        auto result = sc->children_if<otio::Clip>(&err, {}, false);
-        assertEqual(result.size(), 1);
+        {
+            // Find a clip in a serializable collection.
+            otio::SerializableObject::Retainer<otio::Clip> cl =
+                new otio::Clip();
+            otio::SerializableObject::Retainer<otio::Track> tr =
+                new otio::Track();
+            tr->append_child(cl);
+            otio::SerializableObject::Retainer<otio::Timeline> tl =
+                new otio::Timeline();
+            tl->tracks()->append_child(tr);
+            otio::SerializableObject::Retainer<otio::SerializableCollection>
+                sc = new otio::SerializableCollection();
+            sc->insert_child(0, tl);
+            opentimelineio::v1_0::ErrorStatus err;
+            auto result = sc->children_if<otio::Clip>(&err, {}, false);
+            assertEqual(result.size(), 1);
+        }
+        {
+            // Test the search range parameter.
+            TimeRange range(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0));
+            otio::SerializableObject::Retainer<otio::Clip> cl0 =
+                new otio::Clip();
+            cl0->set_source_range(range);
+            otio::SerializableObject::Retainer<otio::Clip> cl1 =
+                new otio::Clip();
+            cl1->set_source_range(range);
+            otio::SerializableObject::Retainer<otio::Clip> cl2 =
+                new otio::Clip();
+            cl2->set_source_range(range);
+            otio::SerializableObject::Retainer<otio::Track> tr =
+                new otio::Track();
+            tr->append_child(cl0);
+            tr->append_child(cl1);
+            tr->append_child(cl2);
+            otio::SerializableObject::Retainer<otio::Timeline> tl =
+                new otio::Timeline();
+            tl->tracks()->append_child(tr);
+            otio::SerializableObject::Retainer<otio::SerializableCollection>
+                sc = new otio::SerializableCollection();
+            sc->insert_child(0, tl);
+            opentimelineio::v1_0::ErrorStatus err;
+            auto result = sc->children_if<otio::Clip>(
+                &err,
+                TimeRange(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0)));
+            assertEqual(result.size(), 1);
+            assertTrue(result[0] = cl0);
+        }
+        {
+            // Test the shallow search parameter.
+            otio::SerializableObject::Retainer<otio::Clip> cl =
+                new otio::Clip();
+            otio::SerializableObject::Retainer<otio::Track> tr =
+                new otio::Track();
+            tr->append_child(cl);
+            otio::SerializableObject::Retainer<otio::Timeline> tl =
+                new otio::Timeline();
+            tl->tracks()->append_child(tr);
+            otio::SerializableObject::Retainer<otio::SerializableCollection>
+                sc = new otio::SerializableCollection();
+            sc->insert_child(0, tl);
+            opentimelineio::v1_0::ErrorStatus err;
+            auto result = sc->children_if<otio::Clip>(&err, nullopt, true);
+            assertEqual(result.size(), 0);
+            result = sc->children_if<otio::Clip>(&err, nullopt, false);
+            assertEqual(result.size(), 1);
+            assertTrue(result[0] = cl);
+        }
     });
 
     tests.run(argc, argv);

--- a/tests/test_serializable_collection.py
+++ b/tests/test_serializable_collection.py
@@ -71,6 +71,54 @@ class SerializableColTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             ")"
         )
 
+    def test_children_if(self):
+        cl = otio.schema.Clip()
+        tr = otio.schema.Track()
+        tr.append(cl)
+        tl = otio.schema.Timeline()
+        tl.tracks.append(tr)
+        sc = otio.schema.SerializableCollection()
+        sc.append(tl)
+        result = sc.children_if(otio.schema.Clip)
+        self.assertEqual(len(result), 1)
+        self.assertTrue(result[0], cl)
+        
+    def test_children_if_search_range(self):
+        range = otio.opentime.TimeRange(
+            otio.opentime.RationalTime(0.0, 24.0),
+            otio.opentime.RationalTime(24.0, 24.0))
+        cl0 = otio.schema.Clip()
+        cl0.source_range = range
+        cl1 = otio.schema.Clip()
+        cl1.source_range = range
+        cl2 = otio.schema.Clip()
+        cl2.source_range = range
+        tr = otio.schema.Track()
+        tr.append(cl0)
+        tr.append(cl1)
+        tr.append(cl2)
+        tl = otio.schema.Timeline()
+        tl.tracks.append(tr)
+        sc = otio.schema.SerializableCollection()
+        sc.append(tl)
+        result = sc.children_if(otio.schema.Clip, range)
+        self.assertEqual(len(result), 1)
+        self.assertTrue(result[0], cl0)
+    
+    def test_children_if_shallow_search(self):
+        cl = otio.schema.Clip()
+        tr = otio.schema.Track()
+        tr.append(cl)
+        tl = otio.schema.Timeline()
+        tl.tracks.append(tr)
+        sc = otio.schema.SerializableCollection()
+        sc.append(tl)
+        result = sc.children_if(otio.schema.Clip, shallow_search=True)
+        self.assertEqual(len(result), 0)
+        result = sc.children_if(otio.schema.Clip, shallow_search=False)
+        self.assertEqual(len(result), 1)
+        self.assertTrue(result[0], cl)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_serializable_collection.py
+++ b/tests/test_serializable_collection.py
@@ -82,7 +82,7 @@ class SerializableColTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         result = sc.children_if(otio.schema.Clip)
         self.assertEqual(len(result), 1)
         self.assertTrue(result[0], cl)
-        
+
     def test_children_if_search_range(self):
         range = otio.opentime.TimeRange(
             otio.opentime.RationalTime(0.0, 24.0),
@@ -104,7 +104,7 @@ class SerializableColTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         result = sc.children_if(otio.schema.Clip, range)
         self.assertEqual(len(result), 1)
         self.assertTrue(result[0], cl0)
-    
+
     def test_children_if_shallow_search(self):
         cl = otio.schema.Clip()
         tr = otio.schema.Track()

--- a/tests/test_serializable_collection.py
+++ b/tests/test_serializable_collection.py
@@ -81,7 +81,7 @@ class SerializableColTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         sc.append(tl)
         result = sc.children_if(otio.schema.Clip)
         self.assertEqual(len(result), 1)
-        self.assertTrue(result[0], cl)
+        self.assertEqual(result[0], cl)
 
     def test_children_if_search_range(self):
         range = otio.opentime.TimeRange(
@@ -103,7 +103,7 @@ class SerializableColTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         sc.append(tl)
         result = sc.children_if(otio.schema.Clip, range)
         self.assertEqual(len(result), 1)
-        self.assertTrue(result[0], cl0)
+        self.assertEqual(result[0], cl0)
 
     def test_children_if_shallow_search(self):
         cl = otio.schema.Clip()
@@ -117,7 +117,7 @@ class SerializableColTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertEqual(len(result), 0)
         result = sc.children_if(otio.schema.Clip, shallow_search=False)
         self.assertEqual(len(result), 1)
-        self.assertTrue(result[0], cl)
+        self.assertEqual(result[0], cl)
 
 
 if __name__ == '__main__':

--- a/tests/test_timeline.cpp
+++ b/tests/test_timeline.cpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Contributors to the OpenTimelineIO project
+
+#include "utils.h"
+
+#include <opentimelineio/clip.h>
+#include <opentimelineio/timeline.h>
+#include <opentimelineio/track.h>
+
+#include <iostream>
+
+namespace otime = opentime::OPENTIME_VERSION;
+namespace otio  = opentimelineio::OPENTIMELINEIO_VERSION;
+
+int
+main(int argc, char** argv)
+{
+    Tests tests;
+
+    tests.add_test(
+        "test_children_if", [] {
+        using namespace otio;
+
+        // Find a clip in a timeline.
+        otio::SerializableObject::Retainer<otio::Clip>  cl = new otio::Clip();
+        otio::SerializableObject::Retainer<otio::Track> tr = new otio::Track();
+        tr->append_child(cl);
+        otio::SerializableObject::Retainer<otio::Timeline> tl = new otio::Timeline();
+        tl->tracks()->append_child(tr);
+        opentimelineio::v1_0::ErrorStatus err;
+        auto result = tl->children_if<otio::Clip>(&err);
+        assertEqual(result.size(), 1);
+    });
+
+    tests.run(argc, argv);
+    return 0;
+}

--- a/tests/test_timeline.cpp
+++ b/tests/test_timeline.cpp
@@ -20,16 +20,64 @@ main(int argc, char** argv)
     tests.add_test(
         "test_children_if", [] {
         using namespace otio;
-
-        // Find a clip in a timeline.
-        otio::SerializableObject::Retainer<otio::Clip>  cl = new otio::Clip();
-        otio::SerializableObject::Retainer<otio::Track> tr = new otio::Track();
-        tr->append_child(cl);
-        otio::SerializableObject::Retainer<otio::Timeline> tl = new otio::Timeline();
-        tl->tracks()->append_child(tr);
-        opentimelineio::v1_0::ErrorStatus err;
-        auto result = tl->children_if<otio::Clip>(&err);
-        assertEqual(result.size(), 1);
+        {
+            // Find a clip in a timeline.
+            otio::SerializableObject::Retainer<otio::Clip> cl =
+                new otio::Clip();
+            otio::SerializableObject::Retainer<otio::Track> tr =
+                new otio::Track();
+            tr->append_child(cl);
+            otio::SerializableObject::Retainer<otio::Timeline> tl =
+                new otio::Timeline();
+            tl->tracks()->append_child(tr);
+            opentimelineio::v1_0::ErrorStatus err;
+            auto result = tl->children_if<otio::Clip>(&err);
+            assertEqual(result.size(), 1);
+        }
+        {
+            // Test the search range parameter.
+            TimeRange range(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0));
+            otio::SerializableObject::Retainer<otio::Clip> cl0 =
+                new otio::Clip();
+            cl0->set_source_range(range);
+            otio::SerializableObject::Retainer<otio::Clip> cl1 =
+                new otio::Clip();
+            cl1->set_source_range(range);
+            otio::SerializableObject::Retainer<otio::Clip> cl2 =
+                new otio::Clip();
+            cl2->set_source_range(range);
+            otio::SerializableObject::Retainer<otio::Track> tr =
+                new otio::Track();
+            tr->append_child(cl0);
+            tr->append_child(cl1);
+            tr->append_child(cl2);
+            otio::SerializableObject::Retainer<otio::Timeline> tl =
+                new otio::Timeline();
+            tl->tracks()->append_child(tr);
+            opentimelineio::v1_0::ErrorStatus err;
+            auto result = tl->children_if<otio::Clip>(
+                &err,
+                TimeRange(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0)));
+            assertEqual(result.size(), 1);
+            assertTrue(result[0] = cl0);
+        }
+        {
+            // Test the shallow search parameter.
+            otio::SerializableObject::Retainer<otio::Clip> cl =
+                new otio::Clip();
+            otio::SerializableObject::Retainer<otio::Track> tr =
+                new otio::Track();
+            tr->append_child(cl);
+            otio::SerializableObject::Retainer<otio::Timeline> tl =
+                new otio::Timeline();
+            tl->tracks()->append_child(tr);
+            opentimelineio::v1_0::ErrorStatus err;
+            auto result = tl->children_if<otio::Clip>(&err, nullopt, true);
+            assertEqual(result.size(), 0);
+            result = tl->children_if<otio::Clip>(&err, nullopt, false);
+            assertEqual(result.size(), 1);
+            assertTrue(result[0] = cl);
+        }
     });
 
     tests.run(argc, argv);

--- a/tests/test_timeline.cpp
+++ b/tests/test_timeline.cpp
@@ -20,64 +20,60 @@ main(int argc, char** argv)
     tests.add_test(
         "test_children_if", [] {
         using namespace otio;
-        {
-            // Find a clip in a timeline.
-            otio::SerializableObject::Retainer<otio::Clip> cl =
-                new otio::Clip();
-            otio::SerializableObject::Retainer<otio::Track> tr =
-                new otio::Track();
-            tr->append_child(cl);
-            otio::SerializableObject::Retainer<otio::Timeline> tl =
-                new otio::Timeline();
-            tl->tracks()->append_child(tr);
-            opentimelineio::v1_0::ErrorStatus err;
-            auto result = tl->children_if<otio::Clip>(&err);
-            assertEqual(result.size(), 1);
-        }
-        {
-            // Test the search range parameter.
-            TimeRange range(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0));
-            otio::SerializableObject::Retainer<otio::Clip> cl0 =
-                new otio::Clip();
-            cl0->set_source_range(range);
-            otio::SerializableObject::Retainer<otio::Clip> cl1 =
-                new otio::Clip();
-            cl1->set_source_range(range);
-            otio::SerializableObject::Retainer<otio::Clip> cl2 =
-                new otio::Clip();
-            cl2->set_source_range(range);
-            otio::SerializableObject::Retainer<otio::Track> tr =
-                new otio::Track();
-            tr->append_child(cl0);
-            tr->append_child(cl1);
-            tr->append_child(cl2);
-            otio::SerializableObject::Retainer<otio::Timeline> tl =
-                new otio::Timeline();
-            tl->tracks()->append_child(tr);
-            opentimelineio::v1_0::ErrorStatus err;
-            auto result = tl->children_if<otio::Clip>(
-                &err,
-                TimeRange(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0)));
-            assertEqual(result.size(), 1);
-            assertTrue(result[0] = cl0);
-        }
-        {
-            // Test the shallow search parameter.
-            otio::SerializableObject::Retainer<otio::Clip> cl =
-                new otio::Clip();
-            otio::SerializableObject::Retainer<otio::Track> tr =
-                new otio::Track();
-            tr->append_child(cl);
-            otio::SerializableObject::Retainer<otio::Timeline> tl =
-                new otio::Timeline();
-            tl->tracks()->append_child(tr);
-            opentimelineio::v1_0::ErrorStatus err;
-            auto result = tl->children_if<otio::Clip>(&err, nullopt, true);
-            assertEqual(result.size(), 0);
-            result = tl->children_if<otio::Clip>(&err, nullopt, false);
-            assertEqual(result.size(), 1);
-            assertTrue(result[0] = cl);
-        }
+        otio::SerializableObject::Retainer<otio::Clip> cl =
+            new otio::Clip();
+        otio::SerializableObject::Retainer<otio::Track> tr =
+            new otio::Track();
+        tr->append_child(cl);
+        otio::SerializableObject::Retainer<otio::Timeline> tl =
+            new otio::Timeline();
+        tl->tracks()->append_child(tr);
+        opentimelineio::v1_0::ErrorStatus err;
+        auto result = tl->children_if<otio::Clip>(&err);
+        assertEqual(result.size(), 1);
+        assertTrue(result[0] = cl);
+    });
+    tests.add_test(
+        "test_children_if_search_range", [] {
+        const TimeRange range(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0));
+        otio::SerializableObject::Retainer<otio::Clip> cl0 =
+            new otio::Clip();
+        cl0->set_source_range(range);
+        otio::SerializableObject::Retainer<otio::Clip> cl1 =
+            new otio::Clip();
+        cl1->set_source_range(range);
+        otio::SerializableObject::Retainer<otio::Clip> cl2 =
+            new otio::Clip();
+        cl2->set_source_range(range);
+        otio::SerializableObject::Retainer<otio::Track> tr =
+            new otio::Track();
+        tr->append_child(cl0);
+        tr->append_child(cl1);
+        tr->append_child(cl2);
+        otio::SerializableObject::Retainer<otio::Timeline> tl =
+            new otio::Timeline();
+        tl->tracks()->append_child(tr);
+        opentimelineio::v1_0::ErrorStatus err;
+        auto result = tl->children_if<otio::Clip>(&err, range);
+        assertEqual(result.size(), 1);
+        assertTrue(result[0] = cl0);
+    });
+    tests.add_test(
+        "test_children_if_shallow_search", [] {
+        otio::SerializableObject::Retainer<otio::Clip> cl =
+            new otio::Clip();
+        otio::SerializableObject::Retainer<otio::Track> tr =
+            new otio::Track();
+        tr->append_child(cl);
+        otio::SerializableObject::Retainer<otio::Timeline> tl =
+            new otio::Timeline();
+        tl->tracks()->append_child(tr);
+        opentimelineio::v1_0::ErrorStatus err;
+        auto result = tl->children_if<otio::Clip>(&err, nullopt, true);
+        assertEqual(result.size(), 0);
+        result = tl->children_if<otio::Clip>(&err, nullopt, false);
+        assertEqual(result.size(), 1);
+        assertTrue(result[0] = cl);
     });
 
     tests.run(argc, argv);

--- a/tests/test_timeline.cpp
+++ b/tests/test_timeline.cpp
@@ -35,6 +35,7 @@ main(int argc, char** argv)
     });
     tests.add_test(
         "test_children_if_search_range", [] {
+        using namespace otio;
         const TimeRange range(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0));
         otio::SerializableObject::Retainer<otio::Clip> cl0 =
             new otio::Clip();
@@ -60,6 +61,7 @@ main(int argc, char** argv)
     });
     tests.add_test(
         "test_children_if_shallow_search", [] {
+        using namespace otio;
         otio::SerializableObject::Retainer<otio::Clip> cl =
             new otio::Clip();
         otio::SerializableObject::Retainer<otio::Track> tr =

--- a/tests/test_timeline.cpp
+++ b/tests/test_timeline.cpp
@@ -31,7 +31,7 @@ main(int argc, char** argv)
         opentimelineio::v1_0::ErrorStatus err;
         auto result = tl->children_if<otio::Clip>(&err);
         assertEqual(result.size(), 1);
-        assertTrue(result[0] = cl);
+        assertEqual(result[0].value, cl.value);
     });
     tests.add_test(
         "test_children_if_search_range", [] {
@@ -57,7 +57,7 @@ main(int argc, char** argv)
         opentimelineio::v1_0::ErrorStatus err;
         auto result = tl->children_if<otio::Clip>(&err, range);
         assertEqual(result.size(), 1);
-        assertTrue(result[0] = cl0);
+        assertEqual(result[0].value, cl0.value);
     });
     tests.add_test(
         "test_children_if_shallow_search", [] {
@@ -75,7 +75,7 @@ main(int argc, char** argv)
         assertEqual(result.size(), 0);
         result = tl->children_if<otio::Clip>(&err, nullopt, false);
         assertEqual(result.size(), 1);
-        assertTrue(result[0] = cl);
+        assertEqual(result[0].value, cl.value);
     });
 
     tests.run(argc, argv);

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -566,7 +566,7 @@ class TimelineTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         result = tl.children_if(otio.schema.Clip)
         self.assertEqual(len(result), 1)
         self.assertTrue(result[0], cl)
-        
+
     def test_children_if_search_range(self):
         range = otio.opentime.TimeRange(
             otio.opentime.RationalTime(0.0, 24.0),
@@ -586,7 +586,7 @@ class TimelineTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         result = tl.children_if(otio.schema.Clip, range)
         self.assertEqual(len(result), 1)
         self.assertTrue(result[0], cl0)
-    
+
     def test_children_if_shallow_search(self):
         cl = otio.schema.Clip()
         tr = otio.schema.Track()
@@ -598,6 +598,7 @@ class TimelineTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         result = tl.children_if(otio.schema.Clip, shallow_search=False)
         self.assertEqual(len(result), 1)
         self.assertTrue(result[0], cl)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -565,7 +565,7 @@ class TimelineTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         tl.tracks.append(tr)
         result = tl.children_if(otio.schema.Clip)
         self.assertEqual(len(result), 1)
-        self.assertTrue(result[0], cl)
+        self.assertEqual(result[0], cl)
 
     def test_children_if_search_range(self):
         range = otio.opentime.TimeRange(
@@ -585,7 +585,7 @@ class TimelineTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         tl.tracks.append(tr)
         result = tl.children_if(otio.schema.Clip, range)
         self.assertEqual(len(result), 1)
-        self.assertTrue(result[0], cl0)
+        self.assertEqual(result[0], cl0)
 
     def test_children_if_shallow_search(self):
         cl = otio.schema.Clip()
@@ -597,7 +597,7 @@ class TimelineTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertEqual(len(result), 0)
         result = tl.children_if(otio.schema.Clip, shallow_search=False)
         self.assertEqual(len(result), 1)
-        self.assertTrue(result[0], cl)
+        self.assertEqual(result[0], cl)
 
 
 if __name__ == '__main__':

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -557,6 +557,47 @@ class TimelineTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertEqual(len(tl.video_tracks()), 0)
         self.assertTrue(isinstance(tl.tracks, otio.schema.Stack))
 
+    def test_children_if(self):
+        cl = otio.schema.Clip()
+        tr = otio.schema.Track()
+        tr.append(cl)
+        tl = otio.schema.Timeline()
+        tl.tracks.append(tr)
+        result = tl.children_if(otio.schema.Clip)
+        self.assertEqual(len(result), 1)
+        self.assertTrue(result[0], cl)
+        
+    def test_children_if_search_range(self):
+        range = otio.opentime.TimeRange(
+            otio.opentime.RationalTime(0.0, 24.0),
+            otio.opentime.RationalTime(24.0, 24.0))
+        cl0 = otio.schema.Clip()
+        cl0.source_range = range
+        cl1 = otio.schema.Clip()
+        cl1.source_range = range
+        cl2 = otio.schema.Clip()
+        cl2.source_range = range
+        tr = otio.schema.Track()
+        tr.append(cl0)
+        tr.append(cl1)
+        tr.append(cl2)
+        tl = otio.schema.Timeline()
+        tl.tracks.append(tr)
+        result = tl.children_if(otio.schema.Clip, range)
+        self.assertEqual(len(result), 1)
+        self.assertTrue(result[0], cl0)
+    
+    def test_children_if_shallow_search(self):
+        cl = otio.schema.Clip()
+        tr = otio.schema.Track()
+        tr.append(cl)
+        tl = otio.schema.Timeline()
+        tl.tracks.append(tr)
+        result = tl.children_if(otio.schema.Clip, shallow_search=True)
+        self.assertEqual(len(result), 0)
+        result = tl.children_if(otio.schema.Clip, shallow_search=False)
+        self.assertEqual(len(result), 1)
+        self.assertTrue(result[0], cl)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_track.cpp
+++ b/tests/test_track.cpp
@@ -20,92 +20,90 @@ main(int argc, char** argv)
     tests.add_test(
         "test_children_if", [] {
         using namespace otio;
-        {
-            // Find a clip in a track.
-            otio::SerializableObject::Retainer<otio::Clip> cl =
-                new otio::Clip();
-            otio::SerializableObject::Retainer<otio::Track> tr =
-                new otio::Track();
-            tr->append_child(cl);
-            opentimelineio::v1_0::ErrorStatus err;
-            auto result = tr->children_if<otio::Clip>(&err);
-            assertEqual(result.size(), 1);
-        }
-        {
-            // Test the search range parameter.
-            TimeRange range(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0));
-            otio::SerializableObject::Retainer<otio::Clip> cl0 =
-                new otio::Clip();
-            cl0->set_source_range(range);
-            otio::SerializableObject::Retainer<otio::Clip> cl1 =
-                new otio::Clip();
-            cl1->set_source_range(range);
-            otio::SerializableObject::Retainer<otio::Clip> cl2 =
-                new otio::Clip();
-            cl2->set_source_range(range);
-            otio::SerializableObject::Retainer<otio::Track> tr =
-                new otio::Track();
-            tr->append_child(cl0);
-            tr->append_child(cl1);
-            tr->append_child(cl2);
-            opentimelineio::v1_0::ErrorStatus err;
-            auto result = tr->children_if<otio::Clip>(
-                &err,
-                TimeRange(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0)));
-            assertEqual(result.size(), 1);
-            assertTrue(result[0] = cl0);
-            result = tr->children_if<otio::Clip>(
-                &err,
-                TimeRange(RationalTime(24.0, 24.0), RationalTime(24.0, 24.0)));
-            assertEqual(result.size(), 1);
-            assertTrue(result[0] = cl1);
-            result = tr->children_if<otio::Clip>(
-                &err,
-                TimeRange(RationalTime(48.0, 24.0), RationalTime(24.0, 24.0)));
-            assertEqual(result.size(), 1);
-            assertTrue(result[0] = cl1);
-            result = tr->children_if<otio::Clip>(
-                &err,
-                TimeRange(RationalTime(0.0, 24.0), RationalTime(48.0, 24.0)));
-            assertEqual(result.size(), 2);
-            assertTrue(result[0] = cl0);
-            assertTrue(result[1] = cl1);
-            result = tr->children_if<otio::Clip>(
-                &err,
-                TimeRange(RationalTime(24.0, 24.0), RationalTime(48.0, 24.0)));
-            assertEqual(result.size(), 2);
-            assertTrue(result[0] = cl1);
-            assertTrue(result[1] = cl2);
-            result = tr->children_if<otio::Clip>(
-                &err,
-                TimeRange(RationalTime(0.0, 24.0), RationalTime(72.0, 24.0)));
-            assertEqual(result.size(), 3);
-            assertTrue(result[0] = cl0);
-            assertTrue(result[1] = cl1);
-            assertTrue(result[2] = cl2);
-        }
-        {
-            // Test the shallow search parameter.
-            otio::SerializableObject::Retainer<otio::Clip> cl0 =
-                new otio::Clip();
-            otio::SerializableObject::Retainer<otio::Clip> cl1 =
-                new otio::Clip();
-            otio::SerializableObject::Retainer<otio::Stack> st =
-                new otio::Stack();
-            st->append_child(cl1);
-            otio::SerializableObject::Retainer<otio::Track> tr =
-                new otio::Track();
-            tr->append_child(cl0);
-            tr->append_child(st);
-            opentimelineio::v1_0::ErrorStatus err;
-            auto result = tr->children_if<otio::Clip>(&err, nullopt, true);
-            assertEqual(result.size(), 1);
-            assertTrue(result[0] = cl0);
-            result = tr->children_if<otio::Clip>(&err, nullopt, false);
-            assertEqual(result.size(), 2);
-            assertTrue(result[0] = cl0);
-            assertTrue(result[1] = cl1);
-        }
+        otio::SerializableObject::Retainer<otio::Clip> cl =
+            new otio::Clip();
+        otio::SerializableObject::Retainer<otio::Track> tr =
+            new otio::Track();
+        tr->append_child(cl);
+        opentimelineio::v1_0::ErrorStatus err;
+        auto result = tr->children_if<otio::Clip>(&err);
+        assertEqual(result.size(), 1);
+        assertTrue(result[0] = cl);
+    });
+    tests.add_test(
+        "test_children_if_search_range", [] {
+        const TimeRange range(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0));
+        otio::SerializableObject::Retainer<otio::Clip> cl0 =
+            new otio::Clip();
+        cl0->set_source_range(range);
+        otio::SerializableObject::Retainer<otio::Clip> cl1 =
+            new otio::Clip();
+        cl1->set_source_range(range);
+        otio::SerializableObject::Retainer<otio::Clip> cl2 =
+            new otio::Clip();
+        cl2->set_source_range(range);
+        otio::SerializableObject::Retainer<otio::Track> tr =
+            new otio::Track();
+        tr->append_child(cl0);
+        tr->append_child(cl1);
+        tr->append_child(cl2);
+        opentimelineio::v1_0::ErrorStatus err;
+        auto result = tr->children_if<otio::Clip>(
+            &err,
+            TimeRange(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0)));
+        assertEqual(result.size(), 1);
+        assertTrue(result[0] = cl0);
+        result = tr->children_if<otio::Clip>(
+            &err,
+            TimeRange(RationalTime(24.0, 24.0), RationalTime(24.0, 24.0)));
+        assertEqual(result.size(), 1);
+        assertTrue(result[0] = cl1);
+        result = tr->children_if<otio::Clip>(
+            &err,
+            TimeRange(RationalTime(48.0, 24.0), RationalTime(24.0, 24.0)));
+        assertEqual(result.size(), 1);
+        assertTrue(result[0] = cl1);
+        result = tr->children_if<otio::Clip>(
+            &err,
+            TimeRange(RationalTime(0.0, 24.0), RationalTime(48.0, 24.0)));
+        assertEqual(result.size(), 2);
+        assertTrue(result[0] = cl0);
+        assertTrue(result[1] = cl1);
+        result = tr->children_if<otio::Clip>(
+            &err,
+            TimeRange(RationalTime(24.0, 24.0), RationalTime(48.0, 24.0)));
+        assertEqual(result.size(), 2);
+        assertTrue(result[0] = cl1);
+        assertTrue(result[1] = cl2);
+        result = tr->children_if<otio::Clip>(
+            &err,
+            TimeRange(RationalTime(0.0, 24.0), RationalTime(72.0, 24.0)));
+        assertEqual(result.size(), 3);
+        assertTrue(result[0] = cl0);
+        assertTrue(result[1] = cl1);
+        assertTrue(result[2] = cl2);
+    });
+    tests.add_test(
+        "test_children_if_shallow_search", [] {
+        otio::SerializableObject::Retainer<otio::Clip> cl0 =
+            new otio::Clip();
+        otio::SerializableObject::Retainer<otio::Clip> cl1 =
+            new otio::Clip();
+        otio::SerializableObject::Retainer<otio::Stack> st =
+            new otio::Stack();
+        st->append_child(cl1);
+        otio::SerializableObject::Retainer<otio::Track> tr =
+            new otio::Track();
+        tr->append_child(cl0);
+        tr->append_child(st);
+        opentimelineio::v1_0::ErrorStatus err;
+        auto result = tr->children_if<otio::Clip>(&err, nullopt, true);
+        assertEqual(result.size(), 1);
+        assertTrue(result[0] = cl0);
+        result = tr->children_if<otio::Clip>(&err, nullopt, false);
+        assertEqual(result.size(), 2);
+        assertTrue(result[0] = cl0);
+        assertTrue(result[1] = cl1);
     });
 
     tests.run(argc, argv);

--- a/tests/test_track.cpp
+++ b/tests/test_track.cpp
@@ -28,7 +28,7 @@ main(int argc, char** argv)
         opentimelineio::v1_0::ErrorStatus err;
         auto result = tr->children_if<otio::Clip>(&err);
         assertEqual(result.size(), 1);
-        assertTrue(result[0] = cl);
+        assertEqual(result[0].value, cl.value);
     });
     tests.add_test(
         "test_children_if_search_range", [] {
@@ -53,36 +53,36 @@ main(int argc, char** argv)
             &err,
             TimeRange(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0)));
         assertEqual(result.size(), 1);
-        assertTrue(result[0] = cl0);
+        assertEqual(result[0].value, cl0.value);
         result = tr->children_if<otio::Clip>(
             &err,
             TimeRange(RationalTime(24.0, 24.0), RationalTime(24.0, 24.0)));
         assertEqual(result.size(), 1);
-        assertTrue(result[0] = cl1);
+        assertEqual(result[0].value, cl1.value);
         result = tr->children_if<otio::Clip>(
             &err,
             TimeRange(RationalTime(48.0, 24.0), RationalTime(24.0, 24.0)));
         assertEqual(result.size(), 1);
-        assertTrue(result[0] = cl1);
+        assertEqual(result[0].value, cl2.value);
         result = tr->children_if<otio::Clip>(
             &err,
             TimeRange(RationalTime(0.0, 24.0), RationalTime(48.0, 24.0)));
         assertEqual(result.size(), 2);
-        assertTrue(result[0] = cl0);
-        assertTrue(result[1] = cl1);
+        assertEqual(result[0].value, cl0.value);
+        assertEqual(result[1].value, cl1.value);
         result = tr->children_if<otio::Clip>(
             &err,
             TimeRange(RationalTime(24.0, 24.0), RationalTime(48.0, 24.0)));
         assertEqual(result.size(), 2);
-        assertTrue(result[0] = cl1);
-        assertTrue(result[1] = cl2);
+        assertEqual(result[0].value, cl1.value);
+        assertEqual(result[1].value, cl2.value);
         result = tr->children_if<otio::Clip>(
             &err,
             TimeRange(RationalTime(0.0, 24.0), RationalTime(72.0, 24.0)));
         assertEqual(result.size(), 3);
-        assertTrue(result[0] = cl0);
-        assertTrue(result[1] = cl1);
-        assertTrue(result[2] = cl2);
+        assertEqual(result[0].value, cl0.value);
+        assertEqual(result[1].value, cl1.value);
+        assertEqual(result[2].value, cl2.value);
     });
     tests.add_test(
         "test_children_if_shallow_search", [] {
@@ -101,11 +101,11 @@ main(int argc, char** argv)
         opentimelineio::v1_0::ErrorStatus err;
         auto result = tr->children_if<otio::Clip>(&err, nullopt, true);
         assertEqual(result.size(), 1);
-        assertTrue(result[0] = cl0);
+        assertEqual(result[0].value, cl0.value);
         result = tr->children_if<otio::Clip>(&err, nullopt, false);
         assertEqual(result.size(), 2);
-        assertTrue(result[0] = cl0);
-        assertTrue(result[1] = cl1);
+        assertEqual(result[0].value, cl0.value);
+        assertEqual(result[1].value, cl1.value);
     });
 
     tests.run(argc, argv);

--- a/tests/test_track.cpp
+++ b/tests/test_track.cpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Contributors to the OpenTimelineIO project
+
+#include "utils.h"
+
+#include <opentimelineio/clip.h>
+#include <opentimelineio/track.h>
+
+#include <iostream>
+
+namespace otime = opentime::OPENTIME_VERSION;
+namespace otio  = opentimelineio::OPENTIMELINEIO_VERSION;
+
+int
+main(int argc, char** argv)
+{
+    Tests tests;
+
+    tests.add_test(
+        "test_children_if", [] {
+        using namespace otio;
+
+        // Find a clip in a track.
+        otio::SerializableObject::Retainer<otio::Clip> cl = new otio::Clip();
+        otio::SerializableObject::Retainer<otio::Track> tr = new otio::Track();
+        tr->append_child(cl);
+        opentimelineio::v1_0::ErrorStatus err;
+        auto result = tr->children_if<otio::Clip>(&err);
+        assertEqual(result.size(), 1);
+    });
+
+    tests.run(argc, argv);
+    return 0;
+}

--- a/tests/test_track.cpp
+++ b/tests/test_track.cpp
@@ -32,6 +32,7 @@ main(int argc, char** argv)
     });
     tests.add_test(
         "test_children_if_search_range", [] {
+        using namespace otio;
         const TimeRange range(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0));
         otio::SerializableObject::Retainer<otio::Clip> cl0 =
             new otio::Clip();
@@ -85,6 +86,7 @@ main(int argc, char** argv)
     });
     tests.add_test(
         "test_children_if_shallow_search", [] {
+        using namespace otio;
         otio::SerializableObject::Retainer<otio::Clip> cl0 =
             new otio::Clip();
         otio::SerializableObject::Retainer<otio::Clip> cl1 =

--- a/tests/test_track.cpp
+++ b/tests/test_track.cpp
@@ -4,6 +4,7 @@
 #include "utils.h"
 
 #include <opentimelineio/clip.h>
+#include <opentimelineio/stack.h>
 #include <opentimelineio/track.h>
 
 #include <iostream>
@@ -19,14 +20,92 @@ main(int argc, char** argv)
     tests.add_test(
         "test_children_if", [] {
         using namespace otio;
-
-        // Find a clip in a track.
-        otio::SerializableObject::Retainer<otio::Clip> cl = new otio::Clip();
-        otio::SerializableObject::Retainer<otio::Track> tr = new otio::Track();
-        tr->append_child(cl);
-        opentimelineio::v1_0::ErrorStatus err;
-        auto result = tr->children_if<otio::Clip>(&err);
-        assertEqual(result.size(), 1);
+        {
+            // Find a clip in a track.
+            otio::SerializableObject::Retainer<otio::Clip> cl =
+                new otio::Clip();
+            otio::SerializableObject::Retainer<otio::Track> tr =
+                new otio::Track();
+            tr->append_child(cl);
+            opentimelineio::v1_0::ErrorStatus err;
+            auto result = tr->children_if<otio::Clip>(&err);
+            assertEqual(result.size(), 1);
+        }
+        {
+            // Test the search range parameter.
+            TimeRange range(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0));
+            otio::SerializableObject::Retainer<otio::Clip> cl0 =
+                new otio::Clip();
+            cl0->set_source_range(range);
+            otio::SerializableObject::Retainer<otio::Clip> cl1 =
+                new otio::Clip();
+            cl1->set_source_range(range);
+            otio::SerializableObject::Retainer<otio::Clip> cl2 =
+                new otio::Clip();
+            cl2->set_source_range(range);
+            otio::SerializableObject::Retainer<otio::Track> tr =
+                new otio::Track();
+            tr->append_child(cl0);
+            tr->append_child(cl1);
+            tr->append_child(cl2);
+            opentimelineio::v1_0::ErrorStatus err;
+            auto result = tr->children_if<otio::Clip>(
+                &err,
+                TimeRange(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0)));
+            assertEqual(result.size(), 1);
+            assertTrue(result[0] = cl0);
+            result = tr->children_if<otio::Clip>(
+                &err,
+                TimeRange(RationalTime(24.0, 24.0), RationalTime(24.0, 24.0)));
+            assertEqual(result.size(), 1);
+            assertTrue(result[0] = cl1);
+            result = tr->children_if<otio::Clip>(
+                &err,
+                TimeRange(RationalTime(48.0, 24.0), RationalTime(24.0, 24.0)));
+            assertEqual(result.size(), 1);
+            assertTrue(result[0] = cl1);
+            result = tr->children_if<otio::Clip>(
+                &err,
+                TimeRange(RationalTime(0.0, 24.0), RationalTime(48.0, 24.0)));
+            assertEqual(result.size(), 2);
+            assertTrue(result[0] = cl0);
+            assertTrue(result[1] = cl1);
+            result = tr->children_if<otio::Clip>(
+                &err,
+                TimeRange(RationalTime(24.0, 24.0), RationalTime(48.0, 24.0)));
+            assertEqual(result.size(), 2);
+            assertTrue(result[0] = cl1);
+            assertTrue(result[1] = cl2);
+            result = tr->children_if<otio::Clip>(
+                &err,
+                TimeRange(RationalTime(0.0, 24.0), RationalTime(72.0, 24.0)));
+            assertEqual(result.size(), 3);
+            assertTrue(result[0] = cl0);
+            assertTrue(result[1] = cl1);
+            assertTrue(result[2] = cl2);
+        }
+        {
+            // Test the shallow search parameter.
+            otio::SerializableObject::Retainer<otio::Clip> cl0 =
+                new otio::Clip();
+            otio::SerializableObject::Retainer<otio::Clip> cl1 =
+                new otio::Clip();
+            otio::SerializableObject::Retainer<otio::Stack> st =
+                new otio::Stack();
+            st->append_child(cl1);
+            otio::SerializableObject::Retainer<otio::Track> tr =
+                new otio::Track();
+            tr->append_child(cl0);
+            tr->append_child(st);
+            opentimelineio::v1_0::ErrorStatus err;
+            auto result = tr->children_if<otio::Clip>(&err, nullopt, true);
+            assertEqual(result.size(), 1);
+            assertTrue(result[0] = cl0);
+            result = tr->children_if<otio::Clip>(&err, nullopt, false);
+            assertEqual(result.size(), 2);
+            assertTrue(result[0] = cl0);
+            assertTrue(result[1] = cl1);
+        }
     });
 
     tests.run(argc, argv);

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the OpenTimelineIO project
+
+import unittest
+
+import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
+
+class TrackTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
+
+    def test_children_if(self):
+        cl = otio.schema.Clip()
+        tr = otio.schema.Track()
+        tr.append(cl)
+        result = tr.children_if(otio.schema.Clip)
+        self.assertEqual(len(result), 1)
+        self.assertTrue(result[0], cl)
+        
+    def test_children_if_search_range(self):
+        range = otio.opentime.TimeRange(
+            otio.opentime.RationalTime(0.0, 24.0),
+            otio.opentime.RationalTime(24.0, 24.0))
+        cl0 = otio.schema.Clip()
+        cl0.source_range = range
+        cl1 = otio.schema.Clip()
+        cl1.source_range = range
+        cl2 = otio.schema.Clip()
+        cl2.source_range = range
+        tr = otio.schema.Track()
+        tr.append(cl0)
+        tr.append(cl1)
+        tr.append(cl2)
+        result = tr.children_if(otio.schema.Clip, range)
+        self.assertEqual(len(result), 1)
+        self.assertTrue(result[0], cl0)
+    
+    def test_children_if_shallow_search(self):
+        cl0 = otio.schema.Clip()
+        cl1 = otio.schema.Clip()
+        st = otio.schema.Stack()
+        st.append(cl1)
+        tr = otio.schema.Track()
+        tr.append(cl0)
+        tr.append(st)
+        result = tr.children_if(otio.schema.Clip, shallow_search=True)
+        self.assertEqual(len(result), 1)
+        self.assertTrue(result[0], cl0)
+        result = tr.children_if(otio.schema.Clip, shallow_search=False)
+        self.assertEqual(len(result), 2)
+        self.assertTrue(result[0], cl0)
+        self.assertTrue(result[1], cl1)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -8,6 +8,7 @@ import unittest
 import opentimelineio as otio
 import opentimelineio.test_utils as otio_test_utils
 
+
 class TrackTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
     def test_children_if(self):
@@ -17,7 +18,7 @@ class TrackTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         result = tr.children_if(otio.schema.Clip)
         self.assertEqual(len(result), 1)
         self.assertTrue(result[0], cl)
-        
+
     def test_children_if_search_range(self):
         range = otio.opentime.TimeRange(
             otio.opentime.RationalTime(0.0, 24.0),
@@ -35,7 +36,7 @@ class TrackTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         result = tr.children_if(otio.schema.Clip, range)
         self.assertEqual(len(result), 1)
         self.assertTrue(result[0], cl0)
-    
+
     def test_children_if_shallow_search(self):
         cl0 = otio.schema.Clip()
         cl1 = otio.schema.Clip()
@@ -51,6 +52,7 @@ class TrackTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertEqual(len(result), 2)
         self.assertTrue(result[0], cl0)
         self.assertTrue(result[1], cl1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -17,7 +17,7 @@ class TrackTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         tr.append(cl)
         result = tr.children_if(otio.schema.Clip)
         self.assertEqual(len(result), 1)
-        self.assertTrue(result[0], cl)
+        self.assertEqual(result[0], cl)
 
     def test_children_if_search_range(self):
         range = otio.opentime.TimeRange(
@@ -35,7 +35,7 @@ class TrackTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         tr.append(cl2)
         result = tr.children_if(otio.schema.Clip, range)
         self.assertEqual(len(result), 1)
-        self.assertTrue(result[0], cl0)
+        self.assertEqual(result[0], cl0)
 
     def test_children_if_shallow_search(self):
         cl0 = otio.schema.Clip()
@@ -47,11 +47,11 @@ class TrackTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         tr.append(st)
         result = tr.children_if(otio.schema.Clip, shallow_search=True)
         self.assertEqual(len(result), 1)
-        self.assertTrue(result[0], cl0)
+        self.assertEqual(result[0], cl0)
         result = tr.children_if(otio.schema.Clip, shallow_search=False)
         self.assertEqual(len(result), 2)
-        self.assertTrue(result[0], cl0)
-        self.assertTrue(result[1], cl1)
+        self.assertEqual(result[0], cl0)
+        self.assertEqual(result[1], cl1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Signed-off-by: Darby Johnston <darbyjohnston@yahoo.com>

Fixes #1400

Fixes an issue where SerializableCollection::children_if doesn't recurse into timelines. I'm marking this as a draft for now since it doesn't address all of the items in the issue (Python tests and missing arguments).