### PR TITLE
fcp_xml: serialize marker out value instead of -1

### DIFF
--- a/src/py-opentimelineio/opentimelineio/adapters/fcp_xml.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/fcp_xml.py
@@ -1846,7 +1846,12 @@ def _build_marker(marker):
         marker_e, 'in',
         text='{:.0f}'.format(marked_range.start_time.value)
     )
-    _append_new_sub_element(marker_e, 'out', text='-1')
+    _append_new_sub_element(
+        marker_e, 'out',
+        text='{:.0f}'.format(
+            marked_range.start_time.value + marked_range.duration.value
+        )
+    )
 
     return marker_e
 

--- a/tests/test_fcp7_xml_adapter.py
+++ b/tests/test_fcp7_xml_adapter.py
@@ -1256,11 +1256,33 @@ class AdaptersFcp7XmlTest(unittest.TestCase, test_utils.OTIOAssertions):
             )
         )
 
+        timeline.tracks.markers.append(
+            schema.Marker(
+                name='test_timeline_marker_range',
+                marked_range=opentime.TimeRange(
+                    opentime.RationalTime(123, RATE),
+                    opentime.RationalTime(11, RATE),
+                ),
+                metadata={'fcp_xml': {'comment': 'my_comment'}}
+            )
+        )
+
         v1[1].markers.append(
             schema.Marker(
                 name='test_clip_marker',
                 marked_range=opentime.TimeRange(
                     opentime.RationalTime(125, RATE)
+                ),
+                metadata={'fcp_xml': {'comment': 'my_comment'}}
+            )
+        )
+
+        v1[1].markers.append(
+            schema.Marker(
+                name='test_clip_marker_range',
+                marked_range=opentime.TimeRange(
+                    opentime.RationalTime(125, RATE),
+                    opentime.RationalTime(6, RATE)
                 ),
                 metadata={'fcp_xml': {'comment': 'my_comment'}}
             )


### PR DESCRIPTION
Fixes #1410 

This PR removes the hardcoded -1 when serializing markers with duration to FCP XML. Now the out value for markers will be `marked_range.start_time.value + marked_range.duration.value`.

I modified the existing test `test_fcp7_xml_adapter.test_roundtrip_mem2disk2mem`, adding both timeline and clip markers that have durations.
