### PR TITLE
Remove Plugin schema `execution_scope` parameter

### DIFF
--- a/contrib/opentimelineio_contrib/adapters/contrib_adapters.plugin_manifest.json
+++ b/contrib/opentimelineio_contrib/adapters/contrib_adapters.plugin_manifest.json
@@ -4,63 +4,54 @@
         {
             "OTIO_SCHEMA": "Adapter.1",
             "name": "fcpx_xml",
-            "execution_scope": "in process",
             "filepath": "fcpx_xml.py",
             "suffixes": ["fcpxml"]
         },
         {
             "OTIO_SCHEMA": "Adapter.1",
             "name": "hls_playlist",
-            "execution_scope": "in process",
             "filepath": "hls_playlist.py",
             "suffixes": ["m3u8"]
         },
         {
             "OTIO_SCHEMA" : "Adapter.1",
             "name" : "rv_session",
-            "execution_scope" : "in process",
             "filepath" : "rv.py",
             "suffixes" : ["rv"]
         },
         {
             "OTIO_SCHEMA" : "Adapter.1",
             "name" : "maya_sequencer",
-            "execution_scope" : "in process",
             "filepath" : "maya_sequencer.py",
             "suffixes" : ["ma","mb"]
         },
         {
             "OTIO_SCHEMA" : "Adapter.1",
             "name" : "ale",
-            "execution_scope" : "in process",
             "filepath" : "ale.py",
             "suffixes" : ["ale"]
         },
         {
             "OTIO_SCHEMA" : "Adapter.1",
             "name" : "burnins",
-            "execution_scope" : "in process",
             "filepath" : "burnins.py",
             "suffixes" : []
         },
         {
             "OTIO_SCHEMA" : "Adapter.1",
             "name" : "AAF",
-            "execution_scope" : "in process",
             "filepath" : "advanced_authoring_format.py",
             "suffixes" : ["aaf"]
         },
         {
             "OTIO_SCHEMA": "Adapter.1",
             "name": "xges",
-            "execution_scope": "in process",
             "filepath": "xges.py",
             "suffixes": ["xges"]
         },
         {
             "OTIO_SCHEMA": "Adapter.1",
             "name": "kdenlive",
-            "execution_scope": "in process",
             "filepath": "kdenlive.py",
             "suffixes": ["kdenlive"]
         }
@@ -69,7 +60,6 @@
         {
             "OTIO_SCHEMA" : "SchemaDef.1",
             "name" : "xges",
-            "execution_scope" : "in process",
             "filepath" : "xges.py"
         }
     ]

--- a/docs/tutorials/otio-serialized-schema-only-fields.md
+++ b/docs/tutorials/otio-serialized-schema-only-fields.md
@@ -25,7 +25,6 @@ changes.  If it needs to be updated and this file regenerated, run:
 ### Adapter.1
 
 parameters:
-- *execution_scope*
 - *filepath*
 - *name*
 - *suffixes*
@@ -77,7 +76,6 @@ parameters:
 ### HookScript.1
 
 parameters:
-- *execution_scope*
 - *filepath*
 - *name*
 
@@ -86,7 +84,6 @@ parameters:
 ### MediaLinker.1
 
 parameters:
-- *execution_scope*
 - *filepath*
 - *name*
 
@@ -126,7 +123,6 @@ parameters:
 ### SerializableObject.1
 
 parameters:
-- *execution_scope*
 - *filepath*
 - *name*
 
@@ -282,6 +278,5 @@ parameters:
 ### SchemaDef.1
 
 parameters:
-- *execution_scope*
 - *filepath*
 - *name*

--- a/docs/tutorials/otio-serialized-schema.md
+++ b/docs/tutorials/otio-serialized-schema.md
@@ -49,7 +49,6 @@ Adapters convert between OTIO and other formats.
 ```
 
 parameters:
-- *execution_scope*: Describes whether this adapter is executed in the current python process or in a subshell.  Options are: ['in process', 'out of process'].
 - *filepath*: Absolute path or relative path to adapter module from location of json.
 - *name*: Adapter name.
 - *suffixes*: File suffixes associated with this adapter.
@@ -155,7 +154,6 @@ None
 ```
 
 parameters:
-- *execution_scope*: Describes whether this adapter is executed in the current python process or in a subshell.  Options are: ['in process', 'out of process'].
 - *filepath*: Absolute path or relative path to adapter module from location of json.
 - *name*: Adapter name.
 
@@ -172,7 +170,6 @@ None
 ```
 
 parameters:
-- *execution_scope*: Describes whether this adapter is executed in the current python process or in a subshell.  Options are: ['in process', 'out of process'].
 - *filepath*: Absolute path or relative path to adapter module from location of json.
 - *name*: Adapter name.
 
@@ -270,7 +267,6 @@ A class of plugin that is encoded in a python module, exposed via a
 ```
 
 parameters:
-- *execution_scope*: Describes whether this adapter is executed in the current python process or in a subshell.  Options are: ['in process', 'out of process'].
 - *filepath*: Absolute path or relative path to adapter module from location of json.
 - *name*: Adapter name.
 
@@ -658,6 +654,5 @@ None
 ```
 
 parameters:
-- *execution_scope*: Describes whether this adapter is executed in the current python process or in a subshell.  Options are: ['in process', 'out of process'].
 - *filepath*: Absolute path or relative path to adapter module from location of json.
 - *name*: Adapter name.

--- a/docs/tutorials/write-a-hookscript.md
+++ b/docs/tutorials/write-a-hookscript.md
@@ -31,7 +31,6 @@ To create a new OTIO hook script, you need to create a file myhooks.py. Then add
         {
             "OTIO_SCHEMA" : "HookScript.1",
             "name" : "example hook",
-            "execution_scope" : "in process",
             "filepath" : "myhooks.py"
         }
     ],

--- a/docs/tutorials/write-a-media-linker.md
+++ b/docs/tutorials/write-a-media-linker.md
@@ -4,9 +4,11 @@ OpenTimelineIO Media Linkers are plugins that allow OTIO to replace MissingRefer
 
 The current MediaLinker can be specified as an argument to `otio.adapters.read_from_file` or via an environment variable.  If one is specified, then it will run after the adapter reads the contents of the file before it is returned back.
 
+```python
     #/usr/bin/env python
     import opentimelineio as otio
     mytimeline = otio.adapters.read_from_file("something.edl", media_linker_name="awesome_studios_media_linker")
+```
 
 After the EDL adapter reads something.edl, the media linker "awesome_studios_media_linker" will run and link the media in the file (if it can).
 
@@ -16,25 +18,28 @@ After the EDL adapter reads something.edl, the media linker "awesome_studios_med
 To create a new OTIO Adapter, you need to create a file mymedialinker.py. Then add a manifest that points at that python file:
 
 
+```json
         {
             "OTIO_SCHEMA" : "PluginManifest.1",
             "media_linkers" : [
                 {
                     "OTIO_SCHEMA" : "MediaLinker.1",
                     "name" : "awesome_studios_media_linker",
-                    "execution_scope" : "in process",
                     "filepath" : "mymedialinker.py"
                  }
             ],
             "adapters" : [
             ]
         }
+```
           
 Then you need to add this manifest to your `$OTIO_PLUGIN_MANIFEST_PATH` environment variable (which is separated with `:` for POSIX or `;` for Windows).
 
 Finally, to specify this linker as the default media linker, set `OTIO_DEFAULT_MEDIA_LINKER` to the name of the media linker:
 
-    setenv OTIO_DEFAULT_MEDIA_LINKER "awesome_studios_media_linker"
+```bash
+    export OTIO_DEFAULT_MEDIA_LINKER="awesome_studios_media_linker"
+```
 
 To package and share your media linker, follow [these instructions](write-an-adapter.md#packaging-and-sharing-custom-adapters).
 
@@ -44,6 +49,7 @@ To write a media linker, write a python file with a "link_media_reference" funct
 
 For example:
 
+```python
     def link_media_reference(in_clip, media_linker_argument_map):
         d.update(media_linker_argument_map)
         # you'll probably want to set it to something other than a missing reference
@@ -51,10 +57,12 @@ For example:
             name=in_clip.name + "_tweaked",
             metadata=d
         )
+```
 
 ## For Testing
 
 The otioconvert.py script has a --media-linker argument you can use to test out your media linker (once its on the path).
 
+```bash
     env OTIO_PLUGIN_MANIFEST_PATH=mymanifest.otio.json:$OTIO_PLUGIN_MANIFEST_PATH bin/otioconvert.py -i somefile.edl --media-linker="awesome_studios_media_linker" -o /var/tmp/test.otio
-
+```

--- a/docs/tutorials/write-a-schemadef.md
+++ b/docs/tutorials/write-a-schemadef.md
@@ -76,7 +76,6 @@ Then you must add it to a plugin manifest:
         {
             "OTIO_SCHEMA" : "SchemaDef.1",
             "name" : "mything",
-            "execution_scope" : "in process",
             "filepath" : "mything.py"
          }
     ]

--- a/docs/tutorials/write-an-adapter.md
+++ b/docs/tutorials/write-an-adapter.md
@@ -73,14 +73,12 @@ And a `plugin_manifest.json` like:
         {
             "OTIO_SCHEMA" : "Adapter.1",
             "name" : "adapter_x",
-            "execution_scope" : "in process",
             "filepath" : "adapters/my_adapter_x.py",
             "suffixes" : ["xxx"]
         },
         {
             "OTIO_SCHEMA" : "Adapter.1",
             "name" : "adapter_y",
-            "execution_scope" : "in process",
             "filepath" : "adapters/my_adapter_y.py",
             "suffixes" : ["yyy", "why"]
         }
@@ -89,7 +87,6 @@ And a `plugin_manifest.json` like:
         {
             "OTIO_SCHEMA" : "MediaLinker.1",
             "name" : "my_studios_media_linker",
-            "execution_scope" : "in process",
             "filepath" : "operations/my_linker.py"
         }
     ]
@@ -105,13 +102,10 @@ For example, to register `myadapter.py` that supports files with a `.myext` file
 {
     "OTIO_SCHEMA" : "Adapter.1",
     "name" : "myadapter",
-    "execution_scope" : "in process",
     "filepath" : "myadapter.py",
     "suffixes" : ["myext"]
 }
 ```
-
-Currently (as of OTIO Beta 14) only execution_scope "in process" is supported.
 
 ## Required Functions
 

--- a/examples/sample_plugin/otio_counter/__init__.py
+++ b/examples/sample_plugin/otio_counter/__init__.py
@@ -27,7 +27,6 @@ as a file in this package).
             {
                 "OTIO_SCHEMA": "Adapter.1",
                 "name": "track_counter",
-                "execution_scope": "in process",
                 "filepath": "adapter.py",
                 "suffixes": ["count"]
             }
@@ -43,7 +42,6 @@ as below.
     {
         "OTIO_SCHEMA" : "MediaLinker.1",
         "name" : "linker_example",
-        "execution_scope" : "in process",
         "filepath" : "linker.py"
     }
 

--- a/examples/sample_plugin/otio_counter/plugin_manifest.json
+++ b/examples/sample_plugin/otio_counter/plugin_manifest.json
@@ -4,7 +4,6 @@
         {
             "OTIO_SCHEMA": "Adapter.1",
             "name": "track_counter",
-            "execution_scope": "in process",
             "filepath": "adapter.py",
             "suffixes": ["count"]
         }

--- a/src/py-opentimelineio/opentimelineio/adapters/adapter.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/adapter.py
@@ -45,14 +45,12 @@ class Adapter(plugins.PythonPlugin):
     def __init__(
         self,
         name=None,
-        execution_scope=None,
         filepath=None,
         suffixes=None
     ):
         plugins.PythonPlugin.__init__(
             self,
             name,
-            execution_scope,
             filepath
         )
 
@@ -284,11 +282,9 @@ class Adapter(plugins.PythonPlugin):
             "Adapter("
             "{}, "
             "{}, "
-            "{}, "
             "{}"
             ")".format(
                 repr(self.name),
-                repr(self.execution_scope),
                 repr(self.filepath),
                 repr(self.suffixes),
             )
@@ -298,12 +294,10 @@ class Adapter(plugins.PythonPlugin):
         return (
             "otio.adapter.Adapter("
             "name={}, "
-            "execution_scope={}, "
             "filepath={}, "
             "suffixes={}"
             ")".format(
                 repr(self.name),
-                repr(self.execution_scope),
                 repr(self.filepath),
                 repr(self.suffixes),
             )

--- a/src/py-opentimelineio/opentimelineio/adapters/builtin_adapters.plugin_manifest.json
+++ b/src/py-opentimelineio/opentimelineio/adapters/builtin_adapters.plugin_manifest.json
@@ -4,42 +4,36 @@
         {
             "OTIO_SCHEMA": "Adapter.1",
             "name": "fcp_xml",
-            "execution_scope": "in process",
             "filepath": "fcp_xml.py",
             "suffixes": ["xml"]
         },
         {
             "OTIO_SCHEMA" : "Adapter.1",
             "name" : "otio_json",
-            "execution_scope" : "in process",
             "filepath" : "otio_json.py",
             "suffixes" : ["otio"]
         },
         {
             "OTIO_SCHEMA" : "Adapter.1",
             "name" : "otioz",
-            "execution_scope" : "in process",
             "filepath" : "otioz.py",
             "suffixes" : ["otioz"]
         },
         {
             "OTIO_SCHEMA" : "Adapter.1",
             "name" : "otiod",
-            "execution_scope" : "in process",
             "filepath" : "otiod.py",
             "suffixes" : ["otiod"]
         },
         {
             "OTIO_SCHEMA" : "Adapter.1",
             "name" : "cmx_3600",
-            "execution_scope" : "in process",
             "filepath" : "cmx_3600.py",
             "suffixes" : ["edl"]
         },
         {
             "OTIO_SCHEMA" : "Adapter.1",
             "name" : "svg",
-            "execution_scope" : "in process",
             "filepath" : "svg.py",
             "suffixes" : ["svg"]
         }

--- a/src/py-opentimelineio/opentimelineio/hooks.py
+++ b/src/py-opentimelineio/opentimelineio/hooks.py
@@ -32,7 +32,6 @@ They are defined by the manifests :class:`HookScript`\\s and hooks areas.
            {
                "OTIO_SCHEMA" : "HookScript.1",
                "name" : "example hook",
-               "execution_scope" : "in process",
                "filepath" : "example.py"
            }
        ],
@@ -84,12 +83,11 @@ class HookScript(plugins.PythonPlugin):
     def __init__(
         self,
         name=None,
-        execution_scope=None,
         filepath=None,
     ):
         """HookScript plugin constructor."""
 
-        super().__init__(name, execution_scope, filepath)
+        super().__init__(name, filepath)
 
     def run(self, in_timeline, argument_map={}):
         """Run the hook_function associated with this plugin."""
@@ -103,9 +101,8 @@ class HookScript(plugins.PythonPlugin):
         )
 
     def __str__(self):
-        return "HookScript({}, {}, {})".format(
+        return "HookScript({}, {})".format(
             repr(self.name),
-            repr(self.execution_scope),
             repr(self.filepath)
         )
 
@@ -113,11 +110,9 @@ class HookScript(plugins.PythonPlugin):
         return (
             "otio.hooks.HookScript("
             "name={}, "
-            "execution_scope={}, "
             "filepath={}"
             ")".format(
                 repr(self.name),
-                repr(self.execution_scope),
                 repr(self.filepath)
             )
         )

--- a/src/py-opentimelineio/opentimelineio/media_linker.py
+++ b/src/py-opentimelineio/opentimelineio/media_linker.py
@@ -101,10 +101,9 @@ class MediaLinker(plugins.PythonPlugin):
     def __init__(
         self,
         name=None,
-        execution_scope=None,
         filepath=None,
     ):
-        super().__init__(name, execution_scope, filepath)
+        super().__init__(name, filepath)
 
     def link_media_reference(self, in_clip, media_linker_argument_map=None):
         media_linker_argument_map = media_linker_argument_map or {}
@@ -135,9 +134,8 @@ class MediaLinker(plugins.PythonPlugin):
         return result
 
     def __str__(self):
-        return "MediaLinker({}, {}, {})".format(
+        return "MediaLinker({}, {})".format(
             repr(self.name),
-            repr(self.execution_scope),
             repr(self.filepath)
         )
 
@@ -145,11 +143,9 @@ class MediaLinker(plugins.PythonPlugin):
         return (
             "otio.media_linker.MediaLinker("
             "name={}, "
-            "execution_scope={}, "
             "filepath={}"
             ")".format(
                 repr(self.name),
-                repr(self.execution_scope),
                 repr(self.filepath)
             )
         )

--- a/src/py-opentimelineio/opentimelineio/plugins/python_plugin.py
+++ b/src/py-opentimelineio/opentimelineio/plugins/python_plugin.py
@@ -56,26 +56,15 @@ class PythonPlugin(core.SerializableObject):
     def __init__(
         self,
         name=None,
-        execution_scope=None,
         filepath=None,
     ):
         core.SerializableObject.__init__(self)
         self.name = name
-        self.execution_scope = execution_scope
         self.filepath = filepath
         self._json_path = None
         self._module = None
 
     name = core.serializable_field("name", doc="Adapter name.")
-    execution_scope = core.serializable_field(
-        "execution_scope",
-        str,
-        doc=(
-            "Describes whether this adapter is executed in the current python"
-            " process or in a subshell.  Options are: "
-            "['in process', 'out of process']."
-        )
-    )
     filepath = core.serializable_field(
         "filepath",
         str,

--- a/src/py-opentimelineio/opentimelineio/schema/schemadef.py
+++ b/src/py-opentimelineio/opentimelineio/schema/schemadef.py
@@ -19,10 +19,9 @@ class SchemaDef(plugins.PythonPlugin):
     def __init__(
         self,
         name=None,
-        execution_scope=None,
         filepath=None,
     ):
-        plugins.PythonPlugin.__init__(self, name, execution_scope, filepath)
+        plugins.PythonPlugin.__init__(self, name, filepath)
 
     def module(self):
         """
@@ -66,9 +65,8 @@ class SchemaDef(plugins.PythonPlugin):
         return result
 
     def __str__(self):
-        return "SchemaDef({}, {}, {})".format(
+        return "SchemaDef({}, {})".format(
             repr(self.name),
-            repr(self.execution_scope),
             repr(self.filepath)
         )
 
@@ -76,11 +74,9 @@ class SchemaDef(plugins.PythonPlugin):
         return (
             "otio.schema.SchemaDef("
             "name={}, "
-            "execution_scope={}, "
             "filepath={}"
             ")".format(
                 repr(self.name),
-                repr(self.execution_scope),
                 repr(self.filepath)
             )
         )

--- a/tests/baselines/adapter_example.json
+++ b/tests/baselines/adapter_example.json
@@ -1,7 +1,6 @@
 {
     "OTIO_SCHEMA" : "Adapter.1",
     "name" : "example",
-    "execution_scope" : "in process",
     "filepath" : "example.py",
     "suffixes" : ["example"]
 }

--- a/tests/baselines/hookscript_example.json
+++ b/tests/baselines/hookscript_example.json
@@ -1,6 +1,5 @@
 {
     "OTIO_SCHEMA" : "HookScript.1",
     "name" : "example hook",
-    "execution_scope" : "in process",
     "filepath" : "example.py"
 }

--- a/tests/baselines/media_linker_example.json
+++ b/tests/baselines/media_linker_example.json
@@ -1,6 +1,5 @@
 {
     "OTIO_SCHEMA" : "MediaLinker.1",
     "name" : "example",
-    "execution_scope" : "in process",
     "filepath" : "example.py"
 }

--- a/tests/baselines/plugin_module/otio_jsonplugin/plugin_manifest.json
+++ b/tests/baselines/plugin_module/otio_jsonplugin/plugin_manifest.json
@@ -4,7 +4,6 @@
         {
             "OTIO_SCHEMA": "Adapter.1",
             "name": "mock_adapter_json",
-            "execution_scope": "in process",
             "filepath": "adapter.py",
             "suffixes": ["mockadapter"]
         }
@@ -13,7 +12,6 @@
         {
             "OTIO_SCHEMA" : "MediaLinker.1",
             "name" : "mock_linker_json",
-            "execution_scope" : "in process",
             "filepath" : "linker.py"
         }
     ]

--- a/tests/baselines/plugin_module/otio_mockplugin/unusually_named_plugin_manifest.json
+++ b/tests/baselines/plugin_module/otio_mockplugin/unusually_named_plugin_manifest.json
@@ -4,7 +4,6 @@
         {
             "OTIO_SCHEMA": "Adapter.1",
             "name": "mock_adapter",
-            "execution_scope": "in process",
             "filepath": "adapter.py",
             "suffixes": ["mockadapter"]
         }
@@ -13,7 +12,6 @@
         {
             "OTIO_SCHEMA" : "MediaLinker.1",
             "name" : "mock_linker",
-            "execution_scope" : "in process",
             "filepath" : "linker.py"
         }
     ]

--- a/tests/baselines/plugin_module/otio_override_adapter/plugin_manifest.json
+++ b/tests/baselines/plugin_module/otio_override_adapter/plugin_manifest.json
@@ -4,7 +4,6 @@
         {
             "OTIO_SCHEMA" : "Adapter.1",
             "name" : "cmx_3600",
-            "execution_scope" : "in process",
             "filepath" : "adapter.py",
             "suffixes" : ["edl"]
         }

--- a/tests/baselines/post_write_hookscript_example.json
+++ b/tests/baselines/post_write_hookscript_example.json
@@ -1,6 +1,5 @@
 {
     "OTIO_SCHEMA" : "HookScript.1",
     "name" : "post write example hook",
-    "execution_scope" : "in process",
     "filepath" : "post_write_example.py"
 }

--- a/tests/baselines/schemadef_example.json
+++ b/tests/baselines/schemadef_example.json
@@ -4,7 +4,6 @@
         {
             "OTIO_SCHEMA" : "SchemaDef.1",
             "name" : "example_schemadef",
-            "execution_scope" : "in process",
             "filepath" : "example_schemadef.py"
         }
     ]

--- a/tests/test_adapter_plugin.py
+++ b/tests/test_adapter_plugin.py
@@ -38,7 +38,6 @@ class TestPluginAdapters(unittest.TestCase):
 
     def test_plugin_adapter(self):
         self.assertEqual(self.adp.name, "example")
-        self.assertEqual(self.adp.execution_scope, "in process")
         self.assertEqual(self.adp.filepath, "example.py")
         self.assertEqual(self.adp.suffixes[0], "example")
         self.assertEqual(list(self.adp.suffixes), ['example'])
@@ -48,11 +47,9 @@ class TestPluginAdapters(unittest.TestCase):
             "Adapter("
             "{}, "
             "{}, "
-            "{}, "
             "{}"
             ")".format(
                 repr(self.adp.name),
-                repr(self.adp.execution_scope),
                 repr(self.adp.filepath),
                 repr(self.adp.suffixes),
             )
@@ -61,12 +58,10 @@ class TestPluginAdapters(unittest.TestCase):
             repr(self.adp),
             "otio.adapter.Adapter("
             "name={}, "
-            "execution_scope={}, "
             "filepath={}, "
             "suffixes={}"
             ")".format(
                 repr(self.adp.name),
-                repr(self.adp.execution_scope),
                 repr(self.adp.filepath),
                 repr(self.adp.suffixes),
             )
@@ -294,7 +289,6 @@ class TestPluginManifest(unittest.TestCase):
                     {
                         "OTIO_SCHEMA": "Adapter.1",
                         "name": "local_json",
-                        "execution_scope": "in process",
                         "filepath": "example.py",
                         "suffixes": ["example"]
                     }

--- a/tests/test_hooks_plugins.py
+++ b/tests/test_hooks_plugins.py
@@ -41,7 +41,6 @@ class HookScriptTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
     def test_plugin_hook(self):
         self.assertEqual(self.hook_script.name, "example hook")
-        self.assertEqual(self.hook_script.execution_scope, "in process")
         self.assertEqual(self.hook_script.filepath, "example.py")
 
     def test_plugin_hook_runs(self):
@@ -83,7 +82,6 @@ class TestPluginHookSystem(unittest.TestCase):
 
     def test_plugin_adapter(self):
         self.assertEqual(self.hsf.name, "example hook")
-        self.assertEqual(self.hsf.execution_scope, "in process")
         self.assertEqual(self.hsf.filepath, "example.py")
 
     def test_load_adapter_module(self):
@@ -143,9 +141,8 @@ class TestPluginHookSystem(unittest.TestCase):
 
         self.assertEqual(
             str(self.hsf),
-            "HookScript({}, {}, {})".format(
+            "HookScript({}, {})".format(
                 repr(self.hsf.name),
-                repr(self.hsf.execution_scope),
                 repr(self.hsf.filepath)
             )
         )
@@ -153,11 +150,9 @@ class TestPluginHookSystem(unittest.TestCase):
             repr(self.hsf),
             "otio.hooks.HookScript("
             "name={}, "
-            "execution_scope={}, "
             "filepath={}"
             ")".format(
                 repr(self.hsf.name),
-                repr(self.hsf.execution_scope),
                 repr(self.hsf.filepath)
             )
         )

--- a/tests/test_media_linker.py
+++ b/tests/test_media_linker.py
@@ -31,7 +31,6 @@ class TestPluginMediaLinker(unittest.TestCase):
 
     def test_plugin_adapter(self):
         self.assertEqual(self.mln.name, "example")
-        self.assertEqual(self.mln.execution_scope, "in process")
         self.assertEqual(self.mln.filepath, "example.py")
 
     def test_load_adapter_module(self):
@@ -57,9 +56,8 @@ class TestPluginMediaLinker(unittest.TestCase):
 
         self.assertEqual(
             str(self.mln),
-            "MediaLinker({}, {}, {})".format(
+            "MediaLinker({}, {})".format(
                 repr(self.mln.name),
-                repr(self.mln.execution_scope),
                 repr(self.mln.filepath)
             )
         )
@@ -67,11 +65,9 @@ class TestPluginMediaLinker(unittest.TestCase):
             repr(self.mln),
             "otio.media_linker.MediaLinker("
             "name={}, "
-            "execution_scope={}, "
             "filepath={}"
             ")".format(
                 repr(self.mln.name),
-                repr(self.mln.execution_scope),
                 repr(self.mln.filepath)
             )
         )


### PR DESCRIPTION
When the plugin system was originally designed for the adapter system, the idea was that adapters could be implemented in other languages by sub shelling out.  It was simpler to implement that directly via the `extern_*` pattern seen in the RV and Maya adapters, and now the library is emphasizing native support.  This feature was never implemented, so this PR removes the parameter from the library.

This PR follows #1395 

Closes #728
