### PR TITLE
remove more python2/3 shim code: next -> __next__

### DIFF
--- a/src/py-opentimelineio/opentimelineio-bindings/otio_anyDictionary.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_anyDictionary.cpp
@@ -19,11 +19,7 @@ using namespace pybind11::literals;
 void otio_any_dictionary_bindings(py::module m) {
     py::class_<AnyDictionaryProxy::Iterator>(m, "AnyDictionaryIterator")
         .def("__iter__", &AnyDictionaryProxy::Iterator::iter)
-    #if PY_MAJOR_VERSION >= 3
         .def("__next__", &AnyDictionaryProxy::Iterator::next);
-    #else
-        .def("next", &AnyDictionaryProxy::Iterator::next);
-    #endif
 
     py::class_<AnyDictionaryProxy>(m, "AnyDictionary")
         .def(py::init<>())

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_anyVector.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_anyVector.cpp
@@ -15,11 +15,7 @@ using namespace pybind11::literals;
 void otio_any_vector_bindings(py::module m) {
     py::class_<AnyVectorProxy::Iterator>(m, "AnyVectorIterator")
         .def("__iter__", &AnyVectorProxy::Iterator::iter)
-    #if PY_MAJOR_VERSION >= 3
         .def("__next__", &AnyVectorProxy::Iterator::next);
-    #else
-        .def("next", &AnyVectorProxy::Iterator::next);
-    #endif
     
     py::class_<AnyVectorProxy>(m, "AnyVector")
         .def(py::init<>())

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -244,7 +244,7 @@ The marked range may have a zero duration. The marked range is in the owning ite
     using SerializableCollectionIterator = ContainerIterator<SerializableCollection, SerializableObject*>;
     py::class_<SerializableCollectionIterator>(m, "SerializableCollectionIterator", py::dynamic_attr())
         .def("__iter__", &SerializableCollectionIterator::iter)
-        .def("next", &SerializableCollectionIterator::next);
+        .def("__next__", &SerializableCollectionIterator::next);
 
     py::class_<SerializableCollection, SOWithMetadata,
                managing_ptr<SerializableCollection>>(m, "SerializableCollection", py::dynamic_attr(), R"docstring(
@@ -443,7 +443,7 @@ Contains a :class:`.MediaReference` and a trim on that media reference.
     using CompositionIterator = ContainerIterator<Composition, Composable*>;
     py::class_<CompositionIterator>(m, "CompositionIterator")
         .def("__iter__", &CompositionIterator::iter)
-        .def("next", &CompositionIterator::next);
+        .def("__next__", &CompositionIterator::next);
 
     py::class_<Composition, Item, managing_ptr<Composition>>(m, "Composition", py::dynamic_attr(), R"docstring(
 Base class for an :class:`~Item` that contains other :class:`~Item`\s.

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_utils.h
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_utils.h
@@ -127,7 +127,6 @@ struct MutableSequencePyAPI : public V {
 
         pybind11::class_<This::Iterator>(m, (name + "Iterator").c_str())
             .def("__iter__", &This::Iterator::iter)
-            .def("next", &This::Iterator::next)
             .def("__next__", &This::Iterator::next);
 
         pybind11::class_<This>(m, name.c_str())


### PR DESCRIPTION
@JeanChristopheMorinPerso pointed out that the bindings can expose `__next__` instead of `next` to enable an iterator interface.  In some cases the bindings were exposing both.
