### PR TITLE
Improve test coverage

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ env:
 
 on:
   push:
-    branches: [ main, 'improve_test_coverage' ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -126,6 +126,7 @@ jobs:
     - name: Install coverage dependency
       if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != env.GH_DEPENDABOT
       run: |
+        echo 'OTIO_CXX_DEBUG_BUILD=1' >> $GITHUB_ENV
         sudo apt-get install lcov
     - name: Install python build dependencies
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ env:
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 'improve_test_coverage' ]
   pull_request:
     branches: [ main ]
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ xcuserdata/
 docs/api
 docs/_build
 .tox
+cpp_cov_html/
+lcov_html_report/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: coverage test test_first_fail clean autopep8 lint doc-html \
-	python-version wheel manifest lcov
+	python-version wheel manifest lcov lcov-html lcov-reset
 
 # Special definition to handle Make from stripping newlines
 define newline
@@ -99,16 +99,25 @@ ifndef OTIO_CXX_BUILD_TMP_DIR
 		C++ coverage will not work, because intermediate build products will \
 		not be found.)
 endif
-	lcov --capture -b . --directory ${OTIO_CXX_BUILD_TMP_DIR} \
+	lcov --rc lcov_branch_coverage=1 --capture -b . --directory ${OTIO_CXX_BUILD_TMP_DIR} \
 		--output-file=${OTIO_CXX_BUILD_TMP_DIR}/coverage.info -q
 	cat ${OTIO_CXX_BUILD_TMP_DIR}/coverage.info | sed "s/SF:.*src/SF:src/g"\
 		> ${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info
-	lcov --remove ${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info '/usr/*' \
+	lcov --rc lcov_branch_coverage=1 --remove ${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info '/usr/*' \
 		--output-file=${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info -q
-	lcov --remove ${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info '*/deps/*' \
+	lcov --rc lcov_branch_coverage=1 --remove ${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info '*/deps/*' \
 		--output-file=${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info -q
 	rm ${OTIO_CXX_BUILD_TMP_DIR}/coverage.info
-	lcov --list ${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info
+	# lcov --list ${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info
+
+
+lcov-html: lcov
+	@echo -e "$(ccgreen)Generating C++ HTML coverage report...$(ccend)"
+	genhtml --quiet --branch-coverage --output-directory lcov_html_report ${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info
+
+lcov-reset:
+	@echo "$(tput setaf -Txterm 2)Resetting C++ coverage...$(tput sgr0)"
+	lcov -b . --directory ${OTIO_CXX_BUILD_TMP_DIR} --zerocounters
 
 # run all the unit tests, stopping at the first failure
 test_first_fail: python-version

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ endif
 	lcov --rc lcov_branch_coverage=1 --remove ${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info '*/deps/*' \
 		--output-file=${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info -q
 	rm ${OTIO_CXX_BUILD_TMP_DIR}/coverage.info
-	# lcov --list ${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info
+	lcov --list ${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info
 
 
 lcov-html: lcov

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ class OTIO_build_ext(setuptools.command.build_ext.build_ext):
             '-DOTIO_PYTHON_INSTALL:BOOL=ON',
             '-DOTIO_CXX_INSTALL:BOOL=OFF',
             '-DOTIO_SHARED_LIBS:BOOL=OFF',
-            '-DCMAKE_BUILD_TYPE=' + self.build_config,
+            '-DCMAKE_BUILD_TYPE=' + 'Debug',
             '-DOTIO_PYTHON_INSTALL_DIR=' + install_dir,
             # turn off the C++ tests during a Python build
             '-DBUILD_TESTING:BOOL=OFF',

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def _debugInstance(x):
         print("{}:     {}".format(a, getattr(x, a)))
 
 
-def joinArgs(args):
+def join_args(args):
     return ' '.join(map(shlex.quote, args))
 
 
@@ -165,7 +165,7 @@ class OTIO_build_ext(setuptools.command.build_ext.build_ext):
         self.announce('running cmake generation', level=2)
 
         cmake_args = ['cmake', SOURCE_DIR] + self.generate_cmake_arguments()
-        self.announce(joinArgs(cmake_args), level=2)
+        self.announce(join_args(cmake_args), level=2)
 
         subprocess.check_call(
             cmake_args,
@@ -188,7 +188,7 @@ class OTIO_build_ext(setuptools.command.build_ext.build_ext):
             '--', multi_proc,
         ]
 
-        self.announce(joinArgs(cmake_args), level=2)
+        self.announce(join_args(cmake_args), level=2)
         subprocess.check_call(
             cmake_args,
             cwd=self.build_temp_dir,

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_anyDictionary.h
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_anyDictionary.h
@@ -17,7 +17,7 @@ struct AnyDictionaryProxy : public AnyDictionary::MutationStamp {
     using MutationStamp = AnyDictionary::MutationStamp;
 
     static void throw_dictionary_was_deleted() {
-        throw py::value_error("underlying C++ AnyDictionary has been destroyed");
+        throw py::value_error("Underlying C++ AnyDictionary has been destroyed");
     }
 
     struct Iterator {

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_anyVector.h
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_anyVector.h
@@ -46,7 +46,7 @@ struct AnyVectorProxy : public AnyVector::MutationStamp {
         AnyVector& v = fetch_any_vector();
         index = adjusted_vector_index(index, v);
         if (index < 0 || index >= int(v.size())) {
-            throw py::index_error();
+            throw py::index_error("list index out of range");
         }
         return any_to_py(v[index]);
     }
@@ -55,7 +55,7 @@ struct AnyVectorProxy : public AnyVector::MutationStamp {
         AnyVector& v = fetch_any_vector();
         index = adjusted_vector_index(index, v);
         if (index < 0 || index >= int(v.size())) {
-            throw py::index_error();
+            throw py::index_error("list assignment index out of range");
         }
         std::swap(v[index], pyAny->a);
     }
@@ -75,7 +75,7 @@ struct AnyVectorProxy : public AnyVector::MutationStamp {
     void del_item(int index) {
         AnyVector& v = fetch_any_vector();
         if (v.empty()) {
-            throw py::index_error();
+            throw py::index_error("list index out of range");
         }
 
         index = adjusted_vector_index(index, v);

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -245,7 +245,6 @@ The marked range may have a zero duration. The marked range is in the owning ite
     py::class_<SerializableCollectionIterator>(m, "SerializableCollectionIterator", py::dynamic_attr())
         .def("__iter__", &SerializableCollectionIterator::iter)
         .def("next", &SerializableCollectionIterator::next)
-        .def("__next__", &SerializableCollectionIterator::next);
 
     py::class_<SerializableCollection, SOWithMetadata,
                managing_ptr<SerializableCollection>>(m, "SerializableCollection", py::dynamic_attr(), R"docstring(
@@ -445,7 +444,6 @@ Contains a :class:`.MediaReference` and a trim on that media reference.
     py::class_<CompositionIterator>(m, "CompositionIterator")
         .def("__iter__", &CompositionIterator::iter)
         .def("next", &CompositionIterator::next)
-        .def("__next__", &CompositionIterator::next);
 
     py::class_<Composition, Item, managing_ptr<Composition>>(m, "Composition", py::dynamic_attr(), R"docstring(
 Base class for an :class:`~Item` that contains other :class:`~Item`\s.

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -244,7 +244,7 @@ The marked range may have a zero duration. The marked range is in the owning ite
     using SerializableCollectionIterator = ContainerIterator<SerializableCollection, SerializableObject*>;
     py::class_<SerializableCollectionIterator>(m, "SerializableCollectionIterator", py::dynamic_attr())
         .def("__iter__", &SerializableCollectionIterator::iter)
-        .def("next", &SerializableCollectionIterator::next)
+        .def("next", &SerializableCollectionIterator::next);
 
     py::class_<SerializableCollection, SOWithMetadata,
                managing_ptr<SerializableCollection>>(m, "SerializableCollection", py::dynamic_attr(), R"docstring(
@@ -443,7 +443,7 @@ Contains a :class:`.MediaReference` and a trim on that media reference.
     using CompositionIterator = ContainerIterator<Composition, Composable*>;
     py::class_<CompositionIterator>(m, "CompositionIterator")
         .def("__iter__", &CompositionIterator::iter)
-        .def("next", &CompositionIterator::next)
+        .def("next", &CompositionIterator::next);
 
     py::class_<Composition, Item, managing_ptr<Composition>>(m, "Composition", py::dynamic_attr(), R"docstring(
 Base class for an :class:`~Item` that contains other :class:`~Item`\s.

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -244,7 +244,8 @@ The marked range may have a zero duration. The marked range is in the owning ite
     using SerializableCollectionIterator = ContainerIterator<SerializableCollection, SerializableObject*>;
     py::class_<SerializableCollectionIterator>(m, "SerializableCollectionIterator", py::dynamic_attr())
         .def("__iter__", &SerializableCollectionIterator::iter)
-        .def("next", &SerializableCollectionIterator::next);
+        .def("next", &SerializableCollectionIterator::next)
+        .def("__next__", &SerializableCollectionIterator::next);
 
     py::class_<SerializableCollection, SOWithMetadata,
                managing_ptr<SerializableCollection>>(m, "SerializableCollection", py::dynamic_attr(), R"docstring(
@@ -443,7 +444,8 @@ Contains a :class:`.MediaReference` and a trim on that media reference.
     using CompositionIterator = ContainerIterator<Composition, Composable*>;
     py::class_<CompositionIterator>(m, "CompositionIterator")
         .def("__iter__", &CompositionIterator::iter)
-        .def("next", &CompositionIterator::next);
+        .def("next", &CompositionIterator::next)
+        .def("__next__", &CompositionIterator::next);
 
     py::class_<Composition, Item, managing_ptr<Composition>>(m, "Composition", py::dynamic_attr(), R"docstring(
 Base class for an :class:`~Item` that contains other :class:`~Item`\s.

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_tests.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_tests.cpp
@@ -9,6 +9,8 @@
 #include "opentimelineio/serializableCollection.h"
 #include "opentimelineio/timeline.h"
 #include "otio_utils.h"
+#include "otio_anyDictionary.h"
+#include "otio_anyVector.h"
 
 namespace py = pybind11;
 using namespace pybind11::literals;
@@ -154,6 +156,15 @@ bool test_big_uint() {
     return true;
 }
 
+
+void test_AnyDictionary_destroy(AnyDictionaryProxy* d) {
+    delete d->any_dictionary;
+}
+
+void test_AnyVector_destroy(AnyVectorProxy* v) {
+    delete v->any_vector;
+}
+
 void otio_tests_bindings(py::module m) {
     TypeRegistry& r = TypeRegistry::instance();
     r.register_type<TestObject>();
@@ -171,4 +182,6 @@ void otio_tests_bindings(py::module m) {
     test.def("gil_scoping", &test_gil_scoping);
     test.def("xyzzy", &otio_xyzzy);
     test.def("test_big_uint", &test_big_uint);
+    test.def("test_AnyDictionary_destroy", &test_AnyDictionary_destroy);
+    test.def("test_AnyVector_destroy", &test_AnyVector_destroy);
 }

--- a/src/py-opentimelineio/opentimelineio/core/_core_utils.py
+++ b/src/py-opentimelineio/opentimelineio/core/_core_utils.py
@@ -337,7 +337,7 @@ def _add_mutable_sequence_methods(
                 func = getattr(klass, name)
                 if (
                         isinstance(func, types.FunctionType)
-                        and name not in klass.__abstractmethods__ #and name != "__iter__"
+                        and name not in klass.__abstractmethods__ # noqa and name != "__iter__"
                 ):
                     setattr(sequenceClass, name, func)
                     if name.startswith('__') or name.endswith('__'):

--- a/src/py-opentimelineio/opentimelineio/core/_core_utils.py
+++ b/src/py-opentimelineio/opentimelineio/core/_core_utils.py
@@ -337,7 +337,7 @@ def _add_mutable_sequence_methods(
                 func = getattr(klass, name)
                 if (
                         isinstance(func, types.FunctionType)
-                        and name not in klass.__abstractmethods__
+                        and name not in klass.__abstractmethods__ #and name != "__iter__"
                 ):
                     setattr(sequenceClass, name, func)
                     if name.startswith('__') or name.endswith('__'):

--- a/tests/test_core_utils.py
+++ b/tests/test_core_utils.py
@@ -24,6 +24,12 @@ class AnyDictionaryTests(unittest.TestCase):
         d['a'] = 'newvalue'
         self.assertEqual(d['a'], 'newvalue')
 
+        self.assertTrue('a' in d)  # Test __contains__
+        self.assertFalse('b' in d)
+
+        with self.assertRaises(TypeError):
+            d[1]  # AnyDictionary.__getitem__ only supports strings
+
         del d['a']
         self.assertEqual(dict(d), {})
         with self.assertRaisesRegex(KeyError, "'non-existent'"):
@@ -143,6 +149,7 @@ class AnyVectorTests(unittest.TestCase):
         self.assertTrue(1 in v)  # Test __contains__
         self.assertTrue('234' in v)
         self.assertTrue({} in v)
+        self.assertFalse(5 in v)
 
         self.assertEqual(list(reversed(v)), [{}, '234', 1])
 

--- a/tests/test_core_utils.py
+++ b/tests/test_core_utils.py
@@ -1,3 +1,4 @@
+import sys
 import copy
 import unittest
 
@@ -16,7 +17,7 @@ class AnyDictionaryTests(unittest.TestCase):
         self.assertEqual(len(d), 1)
         self.assertEqual(d['a'], 1)  # New key
 
-        with self.assertRaisesRegex(KeyError, "'non-existent'"):
+        with self.assertRaisesRegexp(KeyError, "'non-existent'"):
             d['non-existent']
 
         # TODO: Test different type of values to exercise the any_to_py function?
@@ -26,7 +27,7 @@ class AnyDictionaryTests(unittest.TestCase):
 
         del d['a']
         self.assertEqual(dict(d), {})
-        with self.assertRaisesRegex(KeyError, "'non-existent'"):
+        with self.assertRaisesRegexp(KeyError, "'non-existent'"):
             del d['non-existent']
 
         for key in iter(d):  # Test AnyDictionaryProxy.Iterator.iter
@@ -51,7 +52,7 @@ class AnyDictionaryTests(unittest.TestCase):
         d['a'] = 'test'
         d['b'] = 'asdasda'
 
-        with self.assertRaisesRegex(ValueError, "container mutated during iteration"):
+        with self.assertRaisesRegexp(ValueError, "container mutated during iteration"):
             for key in d:
                 del d['b']
 
@@ -59,26 +60,26 @@ class AnyDictionaryTests(unittest.TestCase):
         d1 = opentimelineio.core._core_utils.AnyDictionary()
         opentimelineio._otio._testing.test_AnyDictionary_destroy(d1)
 
-        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyDictionary has been destroyed"):  # noqa
+        with self.assertRaisesRegexp(ValueError, r"underlying C\+\+ AnyDictionary has been destroyed"):  # noqa
             d1['asd']
 
         d2 = opentimelineio.core._core_utils.AnyDictionary()
         opentimelineio._otio._testing.test_AnyDictionary_destroy(d2)
 
-        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyDictionary has been destroyed"):  # noqa
+        with self.assertRaisesRegexp(ValueError, r"underlying C\+\+ AnyDictionary has been destroyed"):  # noqa
             d2['asd'] = 'asd'
 
         d3 = opentimelineio.core._core_utils.AnyDictionary()
         opentimelineio._otio._testing.test_AnyDictionary_destroy(d3)
 
-        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyDictionary has been destroyed"):  # noqa
+        with self.assertRaisesRegexp(ValueError, r"underlying C\+\+ AnyDictionary has been destroyed"):  # noqa
             del d3['asd']
 
         d4 = opentimelineio.core._core_utils.AnyDictionary()
         d4['asd'] = 1
         it = iter(d4)
         opentimelineio._otio._testing.test_AnyDictionary_destroy(d4)
-        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyDictionary has been destroyed"):  # noqa
+        with self.assertRaisesRegexp(ValueError, r"underlying C\+\+ AnyDictionary has been destroyed"):  # noqa
             next(it)
 
 
@@ -164,8 +165,12 @@ class AnyVectorTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             v + 'asd'  # __add__ invalid type
 
-        self.assertEqual(str(v), "[1, '234', {}, 1, 2]")
-        self.assertEqual(repr(v), "[1, '234', {}, 1, 2]")
+        if sys.version_info[0] > 2:
+            self.assertEqual(str(v), "[1, '234', {}, 1, 2]")
+            self.assertEqual(repr(v), "[1, '234', {}, 1, 2]")
+        else:
+            self.assertEqual(str(v), "[1L, u'234', {}, 1L, 2L]")
+            self.assertEqual(repr(v), "[1L, u'234', {}, 1L, 2L]")
 
         v3 = opentimelineio.core._core_utils.AnyVector()
         v3.extend(range(10))
@@ -193,26 +198,26 @@ class AnyVectorTests(unittest.TestCase):
         v1 = opentimelineio.core._core_utils.AnyVector()
         opentimelineio._otio._testing.test_AnyVector_destroy(v1)
 
-        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyVector object has been destroyed"):  # noqa
+        with self.assertRaisesRegexp(ValueError, r"underlying C\+\+ AnyVector object has been destroyed"):  # noqa
             v1[0]
 
         v2 = opentimelineio.core._core_utils.AnyVector()
         opentimelineio._otio._testing.test_AnyVector_destroy(v2)
 
-        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyVector object has been destroyed"):  # noqa
+        with self.assertRaisesRegexp(ValueError, r"underlying C\+\+ AnyVector object has been destroyed"):  # noqa
             v2[0] = 1
 
         v3 = opentimelineio.core._core_utils.AnyVector()
         opentimelineio._otio._testing.test_AnyVector_destroy(v3)
 
-        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyVector object has been destroyed"):  # noqa
+        with self.assertRaisesRegexp(ValueError, r"underlying C\+\+ AnyVector object has been destroyed"):  # noqa
             del v3[0]
 
         v4 = opentimelineio.core._core_utils.AnyVector()
         v4.append(1)
         it = iter(v4)
         opentimelineio._otio._testing.test_AnyVector_destroy(v4)
-        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyVector object has been destroyed"):  # noqa
+        with self.assertRaisesRegexp(ValueError, r"underlying C\+\+ AnyVector object has been destroyed"):  # noqa
             next(it)
 
     def test_copy(self):

--- a/tests/test_core_utils.py
+++ b/tests/test_core_utils.py
@@ -223,5 +223,11 @@ class AnyVectorTests(unittest.TestCase):
         v.extend([1, 2, [3, 4], 5])
 
         copied = copy.copy(v)
-        self.assertListEqual(list(v), list(copied))
         self.assertIsNot(v, copied)
+        # AnyVector can only deep copy. So it's __copy__
+        # does a deepcopy.
+        self.assertIsNot(v[2], copied[2])
+
+        deepcopied = copy.deepcopy(v)
+        self.assertIsNot(v, copied)
+        self.assertIsNot(v[2], copied[2])

--- a/tests/test_core_utils.py
+++ b/tests/test_core_utils.py
@@ -33,16 +33,16 @@ class AnyDictionaryTests(unittest.TestCase):
             self.assertTrue(key)
 
         class CustomClass(object):
-            ...
+            pass
 
         with self.assertRaises(TypeError):
             d['custom'] = CustomClass()
 
-        with self.assertRaises(ValueError) as excinfo:
+        with self.assertRaises(ValueError):
             # Integer bigger than C++ int64_t can accept.
             d['super big int'] = 9223372036854775808
 
-        with self.assertRaises(ValueError) as excinfo:
+        with self.assertRaises(ValueError):
             # Integer smaller than C++ int64_t can accept.
             d['super big int'] = -9223372036854775809
 
@@ -59,26 +59,26 @@ class AnyDictionaryTests(unittest.TestCase):
         d1 = opentimelineio.core._core_utils.AnyDictionary()
         opentimelineio._otio._testing.test_AnyDictionary_destroy(d1)
 
-        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyDictionary has been destroyed"):
+        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyDictionary has been destroyed"):  # noqa
             d1['asd']
 
         d2 = opentimelineio.core._core_utils.AnyDictionary()
         opentimelineio._otio._testing.test_AnyDictionary_destroy(d2)
 
-        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyDictionary has been destroyed"):
+        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyDictionary has been destroyed"):  # noqa
             d2['asd'] = 'asd'
 
         d3 = opentimelineio.core._core_utils.AnyDictionary()
         opentimelineio._otio._testing.test_AnyDictionary_destroy(d3)
 
-        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyDictionary has been destroyed"):
+        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyDictionary has been destroyed"):  # noqa
             del d3['asd']
 
         d4 = opentimelineio.core._core_utils.AnyDictionary()
         d4['asd'] = 1
         it = iter(d4)
         opentimelineio._otio._testing.test_AnyDictionary_destroy(d4)
-        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyDictionary has been destroyed"):
+        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyDictionary has been destroyed"):  # noqa
             next(it)
 
 
@@ -86,7 +86,7 @@ class AnyVectorTests(unittest.TestCase):
     def test_main(self):
         v = opentimelineio.core._core_utils.AnyVector()
 
-        with self.assertRaises(IndexError) as excinfo:
+        with self.assertRaises(IndexError):
             del v[0]  # There is a special case in the C++ code for empty vector
 
         v.append(1)
@@ -126,9 +126,10 @@ class AnyVectorTests(unittest.TestCase):
         self.assertEqual(len(v), 1)
         self.assertEqual([value for value in v], [1])
 
-        del v[-1000]  # Will delete the last item even if the index doesn't match.
-                    # It's a surprising behavior.
-                    # This is caused by size_t(index)
+        # Will delete the last item even if the index doesn't match.
+        # It's a surprising behavior.
+        # This is caused by size_t(index)
+        del v[-1000]
 
         v.extend([1, '234', {}])
 
@@ -146,14 +147,14 @@ class AnyVectorTests(unittest.TestCase):
         self.assertEqual(list(reversed(v)), [{}, '234', 1])
 
         self.assertEqual(v.index('234'), 1)
-        
+
         v += [1, 2]
         self.assertEqual(v.count(1), 2)
 
         self.assertEqual(v + ['new'], [1, '234', {}, 1, 2, 'new'])  # __add__
         self.assertEqual(['new'] + v, [1, '234', {}, 1, 2, 'new'])  # __radd__
 
-        self.assertEqual(v + ('new',), [1, '234', {}, 1, 2, 'new'])  # __add__ with non list type
+        self.assertEqual(v + ('new',), [1, '234', {}, 1, 2, 'new'])  # noqa __add__ with non list type
 
         v2 = opentimelineio.core._core_utils.AnyVector()
         v2.append('v2')
@@ -177,7 +178,7 @@ class AnyVectorTests(unittest.TestCase):
 
         v4 = opentimelineio.core._core_utils.AnyVector()
         v4.extend(range(10))
-        
+
         del v4[::2]
         self.assertEqual(list(v4), [1, 3, 5, 7, 9])
 
@@ -192,32 +193,32 @@ class AnyVectorTests(unittest.TestCase):
         v1 = opentimelineio.core._core_utils.AnyVector()
         opentimelineio._otio._testing.test_AnyVector_destroy(v1)
 
-        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyVector object has been destroyed"):
+        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyVector object has been destroyed"):  # noqa
             v1[0]
 
         v2 = opentimelineio.core._core_utils.AnyVector()
         opentimelineio._otio._testing.test_AnyVector_destroy(v2)
 
-        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyVector object has been destroyed"):
+        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyVector object has been destroyed"):  # noqa
             v2[0] = 1
 
         v3 = opentimelineio.core._core_utils.AnyVector()
         opentimelineio._otio._testing.test_AnyVector_destroy(v3)
 
-        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyVector object has been destroyed"):
+        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyVector object has been destroyed"):  # noqa
             del v3[0]
 
         v4 = opentimelineio.core._core_utils.AnyVector()
         v4.append(1)
         it = iter(v4)
         opentimelineio._otio._testing.test_AnyVector_destroy(v4)
-        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyVector object has been destroyed"):
+        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyVector object has been destroyed"):  # noqa
             next(it)
 
     def test_copy(self):
-        l = [1, 2, [3, 4], 5]
-        copied = copy.copy(l)
-        self.assertEqual(list(l), list(copied))
+        list1 = [1, 2, [3, 4], 5]
+        copied = copy.copy(list1)
+        self.assertEqual(list(list1), list(copied))
 
         v = opentimelineio.core._core_utils.AnyVector()
         v.extend([1, 2, [3, 4], 5])
@@ -229,5 +230,5 @@ class AnyVectorTests(unittest.TestCase):
         self.assertIsNot(v[2], copied[2])
 
         deepcopied = copy.deepcopy(v)
-        self.assertIsNot(v, copied)
-        self.assertIsNot(v[2], copied[2])
+        self.assertIsNot(v, deepcopied)
+        self.assertIsNot(v[2], deepcopied[2])

--- a/tests/test_core_utils.py
+++ b/tests/test_core_utils.py
@@ -1,4 +1,3 @@
-import sys
 import copy
 import unittest
 
@@ -17,7 +16,7 @@ class AnyDictionaryTests(unittest.TestCase):
         self.assertEqual(len(d), 1)
         self.assertEqual(d['a'], 1)  # New key
 
-        with self.assertRaisesRegexp(KeyError, "'non-existent'"):
+        with self.assertRaisesRegex(KeyError, "'non-existent'"):
             d['non-existent']
 
         # TODO: Test different type of values to exercise the any_to_py function?
@@ -27,7 +26,7 @@ class AnyDictionaryTests(unittest.TestCase):
 
         del d['a']
         self.assertEqual(dict(d), {})
-        with self.assertRaisesRegexp(KeyError, "'non-existent'"):
+        with self.assertRaisesRegex(KeyError, "'non-existent'"):
             del d['non-existent']
 
         for key in iter(d):  # Test AnyDictionaryProxy.Iterator.iter
@@ -52,7 +51,7 @@ class AnyDictionaryTests(unittest.TestCase):
         d['a'] = 'test'
         d['b'] = 'asdasda'
 
-        with self.assertRaisesRegexp(ValueError, "container mutated during iteration"):
+        with self.assertRaisesRegex(ValueError, "container mutated during iteration"):
             for key in d:
                 del d['b']
 
@@ -60,26 +59,26 @@ class AnyDictionaryTests(unittest.TestCase):
         d1 = opentimelineio.core._core_utils.AnyDictionary()
         opentimelineio._otio._testing.test_AnyDictionary_destroy(d1)
 
-        with self.assertRaisesRegexp(ValueError, r"underlying C\+\+ AnyDictionary has been destroyed"):  # noqa
+        with self.assertRaisesRegex(ValueError, r"Underlying C\+\+ AnyDictionary has been destroyed"):  # noqa
             d1['asd']
 
         d2 = opentimelineio.core._core_utils.AnyDictionary()
         opentimelineio._otio._testing.test_AnyDictionary_destroy(d2)
 
-        with self.assertRaisesRegexp(ValueError, r"underlying C\+\+ AnyDictionary has been destroyed"):  # noqa
+        with self.assertRaisesRegex(ValueError, r"Underlying C\+\+ AnyDictionary has been destroyed"):  # noqa
             d2['asd'] = 'asd'
 
         d3 = opentimelineio.core._core_utils.AnyDictionary()
         opentimelineio._otio._testing.test_AnyDictionary_destroy(d3)
 
-        with self.assertRaisesRegexp(ValueError, r"underlying C\+\+ AnyDictionary has been destroyed"):  # noqa
+        with self.assertRaisesRegex(ValueError, r"Underlying C\+\+ AnyDictionary has been destroyed"):  # noqa
             del d3['asd']
 
         d4 = opentimelineio.core._core_utils.AnyDictionary()
         d4['asd'] = 1
         it = iter(d4)
         opentimelineio._otio._testing.test_AnyDictionary_destroy(d4)
-        with self.assertRaisesRegexp(ValueError, r"underlying C\+\+ AnyDictionary has been destroyed"):  # noqa
+        with self.assertRaisesRegex(ValueError, r"Underlying C\+\+ AnyDictionary has been destroyed"):  # noqa
             next(it)
 
 
@@ -165,12 +164,8 @@ class AnyVectorTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             v + 'asd'  # __add__ invalid type
 
-        if sys.version_info[0] > 2:
-            self.assertEqual(str(v), "[1, '234', {}, 1, 2]")
-            self.assertEqual(repr(v), "[1, '234', {}, 1, 2]")
-        else:
-            self.assertEqual(str(v), "[1L, u'234', {}, 1L, 2L]")
-            self.assertEqual(repr(v), "[1L, u'234', {}, 1L, 2L]")
+        self.assertEqual(str(v), "[1, '234', {}, 1, 2]")
+        self.assertEqual(repr(v), "[1, '234', {}, 1, 2]")
 
         v3 = opentimelineio.core._core_utils.AnyVector()
         v3.extend(range(10))
@@ -198,26 +193,26 @@ class AnyVectorTests(unittest.TestCase):
         v1 = opentimelineio.core._core_utils.AnyVector()
         opentimelineio._otio._testing.test_AnyVector_destroy(v1)
 
-        with self.assertRaisesRegexp(ValueError, r"underlying C\+\+ AnyVector object has been destroyed"):  # noqa
+        with self.assertRaisesRegex(ValueError, r"Underlying C\+\+ AnyVector object has been destroyed"):  # noqa
             v1[0]
 
         v2 = opentimelineio.core._core_utils.AnyVector()
         opentimelineio._otio._testing.test_AnyVector_destroy(v2)
 
-        with self.assertRaisesRegexp(ValueError, r"underlying C\+\+ AnyVector object has been destroyed"):  # noqa
+        with self.assertRaisesRegex(ValueError, r"Underlying C\+\+ AnyVector object has been destroyed"):  # noqa
             v2[0] = 1
 
         v3 = opentimelineio.core._core_utils.AnyVector()
         opentimelineio._otio._testing.test_AnyVector_destroy(v3)
 
-        with self.assertRaisesRegexp(ValueError, r"underlying C\+\+ AnyVector object has been destroyed"):  # noqa
+        with self.assertRaisesRegex(ValueError, r"Underlying C\+\+ AnyVector object has been destroyed"):  # noqa
             del v3[0]
 
         v4 = opentimelineio.core._core_utils.AnyVector()
         v4.append(1)
         it = iter(v4)
         opentimelineio._otio._testing.test_AnyVector_destroy(v4)
-        with self.assertRaisesRegexp(ValueError, r"underlying C\+\+ AnyVector object has been destroyed"):  # noqa
+        with self.assertRaisesRegex(ValueError, r"Underlying C\+\+ AnyVector object has been destroyed"):  # noqa
             next(it)
 
     def test_copy(self):

--- a/tests/test_core_utils.py
+++ b/tests/test_core_utils.py
@@ -1,0 +1,227 @@
+import copy
+import unittest
+
+import opentimelineio._otio
+import opentimelineio.core._core_utils
+
+
+class AnyDictionaryTests(unittest.TestCase):
+    def test_main(self):
+        d = opentimelineio.core._core_utils.AnyDictionary()
+        d['a'] = 1
+
+        self.assertTrue('a' in d)
+        self.assertFalse('asdasdasd' in d)
+
+        self.assertEqual(len(d), 1)
+        self.assertEqual(d['a'], 1)  # New key
+
+        with self.assertRaisesRegex(KeyError, "'non-existent'"):
+            d['non-existent']
+
+        # TODO: Test different type of values to exercise the any_to_py function?
+
+        d['a'] = 'newvalue'
+        self.assertEqual(d['a'], 'newvalue')
+
+        del d['a']
+        self.assertEqual(dict(d), {})
+        with self.assertRaisesRegex(KeyError, "'non-existent'"):
+            del d['non-existent']
+
+        for key in iter(d):  # Test AnyDictionaryProxy.Iterator.iter
+            self.assertTrue(key)
+
+        class CustomClass(object):
+            ...
+
+        with self.assertRaises(TypeError):
+            d['custom'] = CustomClass()
+
+        with self.assertRaises(ValueError) as excinfo:
+            # Integer bigger than C++ int64_t can accept.
+            d['super big int'] = 9223372036854775808
+
+        with self.assertRaises(ValueError) as excinfo:
+            # Integer smaller than C++ int64_t can accept.
+            d['super big int'] = -9223372036854775809
+
+    def test_raise_on_mutation_during_iter(self):
+        d = opentimelineio.core._core_utils.AnyDictionary()
+        d['a'] = 'test'
+        d['b'] = 'asdasda'
+
+        with self.assertRaisesRegex(ValueError, "container mutated during iteration"):
+            for key in d:
+                del d['b']
+
+    def test_raises_if_ref_destroyed(self):
+        d1 = opentimelineio.core._core_utils.AnyDictionary()
+        opentimelineio._otio._testing.test_AnyDictionary_destroy(d1)
+
+        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyDictionary has been destroyed"):
+            d1['asd']
+
+        d2 = opentimelineio.core._core_utils.AnyDictionary()
+        opentimelineio._otio._testing.test_AnyDictionary_destroy(d2)
+
+        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyDictionary has been destroyed"):
+            d2['asd'] = 'asd'
+
+        d3 = opentimelineio.core._core_utils.AnyDictionary()
+        opentimelineio._otio._testing.test_AnyDictionary_destroy(d3)
+
+        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyDictionary has been destroyed"):
+            del d3['asd']
+
+        d4 = opentimelineio.core._core_utils.AnyDictionary()
+        d4['asd'] = 1
+        it = iter(d4)
+        opentimelineio._otio._testing.test_AnyDictionary_destroy(d4)
+        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyDictionary has been destroyed"):
+            next(it)
+
+
+class AnyVectorTests(unittest.TestCase):
+    def test_main(self):
+        v = opentimelineio.core._core_utils.AnyVector()
+
+        with self.assertRaises(IndexError) as excinfo:
+            del v[0]  # There is a special case in the C++ code for empty vector
+
+        v.append(1)
+        self.assertEqual(len(v), 1)
+        v.append(2)
+        self.assertEqual(len(v), 2)
+
+        self.assertEqual([value for value in v], [1, 2])
+
+        v.insert(0, 5)
+        self.assertEqual([value for value in v], [5, 1, 2])
+        self.assertEqual(v[0], 5)
+        self.assertEqual(v[-3], 5)
+
+        with self.assertRaises(IndexError):
+            v[100]
+
+        with self.assertRaises(IndexError):
+            v[-100]
+
+        v[-1] = 100
+        self.assertEqual(v[2], 100)
+
+        with self.assertRaises(IndexError):
+            v[-4] = -1
+
+        with self.assertRaises(IndexError):
+            v[100] = 100
+
+        del v[0]
+        self.assertEqual(len(v), 2)
+        # Doesn't work...
+        # assert v == [1, 100]
+        self.assertEqual([value for value in v], [1, 100])
+
+        del v[1000]  # This will surprisingly delete the last item...
+        self.assertEqual(len(v), 1)
+        self.assertEqual([value for value in v], [1])
+
+        del v[-1000]  # Will delete the last item even if the index doesn't match.
+                    # It's a surprising behavior.
+                    # This is caused by size_t(index)
+
+        v.extend([1, '234', {}])
+
+        items = []
+        for value in iter(v):  # Test AnyVector.Iterator.iter
+            items.append(value)
+
+        self.assertEqual(items, [1, '234', {}])
+        self.assertFalse(v == [1, '234', {}])  # __eq__ is not implemented
+
+        self.assertTrue(1 in v)  # Test __contains__
+        self.assertTrue('234' in v)
+        self.assertTrue({} in v)
+
+        self.assertEqual(list(reversed(v)), [{}, '234', 1])
+
+        self.assertEqual(v.index('234'), 1)
+        
+        v += [1, 2]
+        self.assertEqual(v.count(1), 2)
+
+        self.assertEqual(v + ['new'], [1, '234', {}, 1, 2, 'new'])  # __add__
+        self.assertEqual(['new'] + v, [1, '234', {}, 1, 2, 'new'])  # __radd__
+
+        self.assertEqual(v + ('new',), [1, '234', {}, 1, 2, 'new'])  # __add__ with non list type
+
+        v2 = opentimelineio.core._core_utils.AnyVector()
+        v2.append('v2')
+
+        self.assertEqual(v + v2, [1, '234', {}, 1, 2, 'v2'])  # __add__ with AnyVector
+
+        with self.assertRaises(TypeError):
+            v + 'asd'  # __add__ invalid type
+
+        self.assertEqual(str(v), "[1, '234', {}, 1, 2]")
+        self.assertEqual(repr(v), "[1, '234', {}, 1, 2]")
+
+        v3 = opentimelineio.core._core_utils.AnyVector()
+        v3.extend(range(10))
+        self.assertEqual(v3[2:], [2, 3, 4, 5, 6, 7, 8, 9])
+        self.assertEqual(v3[4:8], [4, 5, 6, 7])
+        self.assertEqual(v3[1:7:2], [1, 3, 5])
+
+        del v3[2:7]
+        self.assertEqual(list(v3), [0, 1, 7, 8, 9])
+
+        v4 = opentimelineio.core._core_utils.AnyVector()
+        v4.extend(range(10))
+        
+        del v4[::2]
+        self.assertEqual(list(v4), [1, 3, 5, 7, 9])
+
+        v5 = opentimelineio.core._core_utils.AnyVector()
+        tmplist = [1, 2]
+        v5.append(tmplist)
+        # If AnyVector was a pure list, this would fail. But it's not a real list.
+        # Appending copies data, completely removing references to it.
+        self.assertIsNot(v5[0], tmplist)
+
+    def test_raises_if_ref_destroyed(self):
+        v1 = opentimelineio.core._core_utils.AnyVector()
+        opentimelineio._otio._testing.test_AnyVector_destroy(v1)
+
+        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyVector object has been destroyed"):
+            v1[0]
+
+        v2 = opentimelineio.core._core_utils.AnyVector()
+        opentimelineio._otio._testing.test_AnyVector_destroy(v2)
+
+        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyVector object has been destroyed"):
+            v2[0] = 1
+
+        v3 = opentimelineio.core._core_utils.AnyVector()
+        opentimelineio._otio._testing.test_AnyVector_destroy(v3)
+
+        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyVector object has been destroyed"):
+            del v3[0]
+
+        v4 = opentimelineio.core._core_utils.AnyVector()
+        v4.append(1)
+        it = iter(v4)
+        opentimelineio._otio._testing.test_AnyVector_destroy(v4)
+        with self.assertRaisesRegex(ValueError, r"underlying C\+\+ AnyVector object has been destroyed"):
+            next(it)
+
+    def test_copy(self):
+        l = [1, 2, [3, 4], 5]
+        copied = copy.copy(l)
+        self.assertEqual(list(l), list(copied))
+
+        v = opentimelineio.core._core_utils.AnyVector()
+        v.extend([1, 2, [3, 4], 5])
+
+        copied = copy.copy(v)
+        self.assertListEqual(list(v), list(copied))
+        self.assertIsNot(v, copied)

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -330,6 +330,20 @@ class TestTime(unittest.TestCase):
                 invalid_df_rate, (24000 / 1001.0), drop_frame=True
             )
 
+    def test_timecode_infer_drop_frame(self):
+        frames = 1084319
+        rates = [
+            (29.97, '10:03:00;05'),
+            (30000.0 / 1001.0, '10:03:00;05'),
+            (59.94, '05:01:30;03'),
+            (60000.0 / 1001.0, '05:01:11;59')
+        ]
+        for rate, timecode in rates:
+            t = otio.opentime.RationalTime(frames, rate)
+
+            self.assertEqual(t.to_timecode(rate, drop_frame=None), timecode)
+            self.assertEqual(t.to_timecode(rate), timecode)
+
     def test_timecode_2997(self):
         ref_values = [
             (10789, '00:05:59:19', '00:05:59;29'),

--- a/tests/test_serializable_collection.py
+++ b/tests/test_serializable_collection.py
@@ -46,6 +46,9 @@ class SerializableColTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.sc[0] = tmp
         self.assertEqual(self.sc[0], tmp)
 
+        with self.assertRaises(IndexError):
+            self.sc[100]
+
     def test_serialize(self):
         encoded = otio.adapters.otio_json.write_to_string(self.sc)
         decoded = otio.adapters.otio_json.read_from_string(encoded)


### PR DESCRIPTION
This PR adds test coverage for the AnyVector and AnyDictionary python bindings and the `opentimelineio.core._core_utils` module.

It supersedes https://github.com/AcademySoftwareFoundation/OpenTimelineIO/pull/1433.

I also change the builds a little bit so that the coverage is measured in debug mode to improve the accuracy of the C++ code coverage when running the python tests and I also added `--rc lcov_branch_coverage=1` to the `lcov` commands.
