### PR TITLE
Improve typing of the drop_frame parameter on the RationalTime.to_timecode method

### DIFF
--- a/src/py-opentimelineio/bindings-common/casters.h
+++ b/src/py-opentimelineio/bindings-common/casters.h
@@ -6,6 +6,10 @@ using nonstd::optional;
 using nonstd::nullopt_t;
 
 namespace pybind11 { namespace detail {
+    // Caster for converting to/from nonstd::optional.
+    // Pybind11 supports optional types when C++17 is used.
+    // So for now we have to create the casters manually.
+    // See https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html#c-17-library-containers
     template<typename T> struct type_caster<optional<T>>
         : public optional_caster<optional<T>> {};
 

--- a/src/py-opentimelineio/bindings-common/casters.h
+++ b/src/py-opentimelineio/bindings-common/casters.h
@@ -1,0 +1,15 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/operators.h>
+#include "nonstd/optional.hpp"
+
+using nonstd::optional;
+using nonstd::nullopt_t;
+
+namespace pybind11 { namespace detail {
+    template<typename T> struct type_caster<optional<T>>
+        : public optional_caster<optional<T>> {};
+
+    template<> struct type_caster<nullopt_t>
+        : public void_caster<nullopt_t> {};
+}}

--- a/src/py-opentimelineio/bindings-common/casters.h
+++ b/src/py-opentimelineio/bindings-common/casters.h
@@ -1,6 +1,5 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <pybind11/operators.h>
 #include "nonstd/optional.hpp"
 
 using nonstd::optional;

--- a/src/py-opentimelineio/opentime-bindings/opentime_rationalTime.cpp
+++ b/src/py-opentimelineio/opentime-bindings/opentime_rationalTime.cpp
@@ -2,15 +2,12 @@
 // Copyright Contributors to the OpenTimelineIO project
 
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 #include <pybind11/operators.h>
-#include "nonstd/optional.hpp"
 
 #include "opentime/rationalTime.h"
 #include "opentimelineio/stringUtils.h"
+#include "opentimelineio/optional.h"
 #include "py-opentimelineio/bindings-common/casters.h"
-
-using nonstd::optional;
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/src/py-opentimelineio/opentime-bindings/opentime_rationalTime.cpp
+++ b/src/py-opentimelineio/opentime-bindings/opentime_rationalTime.cpp
@@ -2,10 +2,15 @@
 // Copyright Contributors to the OpenTimelineIO project
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 #include <pybind11/operators.h>
+#include "nonstd/optional.hpp"
 
 #include "opentime/rationalTime.h"
 #include "opentimelineio/stringUtils.h"
+#include "py-opentimelineio/bindings-common/casters.h"
+
+using nonstd::optional;
 
 namespace py = pybind11;
 using namespace pybind11::literals;
@@ -28,11 +33,10 @@ struct ErrorStatusConverter {
     ErrorStatus error_status;
 };
 
-
-IsDropFrameRate df_enum_converter(py::object& df) {
-    if (df.is(py::none())) {
+IsDropFrameRate df_enum_converter(optional<bool>& df) {
+    if (!df.has_value()) {
         return IsDropFrameRate::InferFromRate;
-    } else if (py::cast<bool>(py::bool_(df))) {
+    } else if (df.value()) {
         return IsDropFrameRate::ForceYes;
     } else {
         return IsDropFrameRate::ForceNo;
@@ -107,7 +111,7 @@ For example, the duration of a clip from frame 10 to frame 15 is 6 frames. Resul
         .def("to_frames", (int (RationalTime::*)() const) &RationalTime::to_frames, "Returns the frame number based on the current rate.")
         .def("to_frames", (int (RationalTime::*)(double) const) &RationalTime::to_frames, "rate"_a, "Returns the frame number based on the given rate.")
         .def("to_seconds", &RationalTime::to_seconds)
-        .def("to_timecode", [](RationalTime rt, double rate, py::object drop_frame) {
+        .def("to_timecode", [](RationalTime rt, double rate, optional<bool> drop_frame) {
                 return rt.to_timecode(
                         rate,
                         df_enum_converter(drop_frame),

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_utils.h
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_utils.h
@@ -6,8 +6,8 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <string>
+#include "py-opentimelineio/bindings-common/casters.h"
 #include "opentimelineio/any.h"
-#include "opentimelineio/optional.h"
 #include "opentimelineio/stringUtils.h"
 #include "opentimelineio/serializableObject.h"
 #include "opentimelineio/vectorIndexing.h"
@@ -17,13 +17,6 @@ using namespace opentimelineio::OPENTIMELINEIO_VERSION;
 
 void install_external_keepalive_monitor(SerializableObject* so, bool apply_now);
 
-namespace pybind11 { namespace detail {
-    template<typename T> struct type_caster<optional<T>>
-        : public optional_caster<optional<T>> {};
-
-    template<> struct type_caster<nullopt_t>
-        : public void_caster<nullopt_t> {};
-}}
 
 template <typename T>
 struct managing_ptr {


### PR DESCRIPTION
**Summarize your change.**

A couple of months ago, I noticed that the `drop_frame` parameter of the `RationalTime.to_timecode` method was using `py::object` as its type. This is confusing for the user.

With the change, running `help(opentimelineio.opentime.RationalTime.to_timecode)` returns:

```
to_timecode(...)
    to_timecode(*args, **kwargs)
    Overloaded function.
    
    1. to_timecode(self: opentimelineio._opentime.RationalTime, rate: float, drop_frame: Optional[bool]) -> str
```

And it still works as before:
```python
>>> opentimelineio.opentime.RationalTime(30 * 59 + 30).to_timecode(29.97, 0)
'00:29:58:06'
>>> opentimelineio.opentime.RationalTime(30 * 59 + 30).to_timecode(29.97, False)
'00:29:58:06'
>>> opentimelineio.opentime.RationalTime(30 * 59 + 30).to_timecode(29.97, 1)
'00:30:00;00'
>>> opentimelineio.opentime.RationalTime(30 * 59 + 30).to_timecode(29.97, True)
'00:30:00;00'
>>> opentimelineio.opentime.RationalTime(30 * 59 + 30).to_timecode(29.97, None)
'00:30:00;00'
```

