### PR TITLE
Don't override __iter__ methods

### DIFF
--- a/src/py-opentimelineio/opentimelineio/core/_core_utils.py
+++ b/src/py-opentimelineio/opentimelineio/core/_core_utils.py
@@ -337,7 +337,7 @@ def _add_mutable_sequence_methods(
                 func = getattr(klass, name)
                 if (
                         isinstance(func, types.FunctionType)
-                        and name not in klass.__abstractmethods__ and not hasattr(sequenceClass, name)
+                        and name not in klass.__abstractmethods__ and not hasattr(sequenceClass, name)  # noqa
                 ):
                     setattr(sequenceClass, name, func)
                     if name.startswith('__') or name.endswith('__'):

--- a/src/py-opentimelineio/opentimelineio/core/_core_utils.py
+++ b/src/py-opentimelineio/opentimelineio/core/_core_utils.py
@@ -337,7 +337,7 @@ def _add_mutable_sequence_methods(
                 func = getattr(klass, name)
                 if (
                         isinstance(func, types.FunctionType)
-                        and name not in klass.__abstractmethods__ # noqa and name != "__iter__"
+                        and name not in klass.__abstractmethods__ and not hasattr(sequenceClass, name)
                 ):
                     setattr(sequenceClass, name, func)
                     if name.startswith('__') or name.endswith('__'):

--- a/src/py-opentimelineio/opentimelineio/core/_core_utils.py
+++ b/src/py-opentimelineio/opentimelineio/core/_core_utils.py
@@ -337,7 +337,8 @@ def _add_mutable_sequence_methods(
                 func = getattr(klass, name)
                 if (
                         isinstance(func, types.FunctionType)
-                        and name not in klass.__abstractmethods__ and not hasattr(sequenceClass, name)  # noqa
+                        and name not in klass.__abstractmethods__
+                        and not hasattr(sequenceClass, name)
                 ):
                     setattr(sequenceClass, name, func)
                     if name.startswith('__') or name.endswith('__'):


### PR DESCRIPTION
**Summarize your change.**


A while ago, I found out that the `__iter__` methods defined in our bindings were being overridden in `_core_utils.py`. This PR fixes that by making sure we don't override methods that already exist.

For example, https://github.com/AcademySoftwareFoundation/OpenTimelineIO/blob/0763bf6e2d34523bf26938c14cfb2730082cff45/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp#L445 was completely overridden before.

Note that I changed this only in the `_add_mutable_sequence_methods` function. `_add_mutable_mapping_methods` is slightly different in that `AnyDictionary` actually has an `__eq__` method built-in and it needs to be overridden with `__eq__` from `collections.abc`.