### PR TITLE
Improve type of function callbacks in register_upgrade_function and register_downgrade_function

### DIFF
--- a/src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp
@@ -2,6 +2,7 @@
 // Copyright Contributors to the OpenTimelineIO project
 
 #include <pybind11/pybind11.h>
+#include <pybind11/functional.h>
 #include "otio_anyDictionary.h"
 #include "otio_anyVector.h"
 #include "otio_bindings.h"
@@ -71,13 +72,12 @@ static void register_python_type(py::object class_object,
 
 static bool register_upgrade_function(std::string const& schema_name,
                                       int version_to_upgrade_to,
-                                      py::object const& upgrade_function_obj) {
+                                      std::function<void(AnyDictionaryProxy*)> const& upgrade_function_obj) {
     std::function<void (AnyDictionary* d)> upgrade_function =  [upgrade_function_obj](AnyDictionary* d) {
         py::gil_scoped_acquire acquire;
         
         auto ptr = d->get_or_create_mutation_stamp();
-        py::object dobj = py::cast((AnyDictionaryProxy*)ptr);
-        upgrade_function_obj(dobj);
+        upgrade_function_obj((AnyDictionaryProxy*)ptr);
     };
     
     // further discussion required about preventing double registering
@@ -112,7 +112,7 @@ static bool
 register_downgrade_function(
         std::string const& schema_name,
         int version_to_downgrade_from,
-        py::object const& downgrade_function_obj) 
+        std::function<void(AnyDictionaryProxy*)> const& downgrade_function_obj)
 {
     std::function<void (AnyDictionary* d)> downgrade_function = ( 
             [downgrade_function_obj](AnyDictionary* d) 
@@ -120,8 +120,7 @@ register_downgrade_function(
                 py::gil_scoped_acquire acquire;
 
                 auto ptr = d->get_or_create_mutation_stamp();
-                py::object dobj = py::cast((AnyDictionaryProxy*)ptr);
-                downgrade_function_obj(dobj);
+                downgrade_function_obj((AnyDictionaryProxy*)ptr);
             }
     );
 


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**

Fixes #1425

**Summarize your change.**

Improve the advertised types of the callback functions in `register_upgrade_function` and `register_downgrade_function` functions.

See https://pybind11.readthedocs.io/en/stable/advanced/cast/functional.html for the Pybind11 documentation of `pybind11/functional.h`.

The help on both functions previously looked like:
```
register_downgrade_function(...) method of builtins.PyCapsule instance
    register_downgrade_function(schema_name: str, version_to_downgrade_from: int, downgrade_function: object) -> bool

register_upgrade_function(...) method of builtins.PyCapsule instance
    register_upgrade_function(schema_name: str, version_to_downgrade_from: int, upgrade_function: object) -> bool
```

while now it looks like:
```
register_downgrade_function(...) method of builtins.PyCapsule instance
    register_downgrade_function(schema_name: str, version_to_downgrade_from: int, downgrade_function: Callable[[opentimelineio._otio.AnyDictionary], None]) -> bool

register_upgrade_function(...) method of builtins.PyCapsule instance
    register_upgrade_function(schema_name: str, version_to_downgrade_from: int, upgrade_function: Callable[[opentimelineio._otio.AnyDictionary], None]) -> bool
```