### PR TITLE
README: Fix typo (pypy->pypi)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The OTIO python bindings also support several other kinds of plugins, for more i
 Installing / Quick-Start
 ------------------------
 
-The python-wrapped version of OpenTimelineIO is publicly available via pypy.  You can install OpenTimelineIO via:
+The Python-wrapped version of OpenTimelineIO is publicly available [via PyPI](https://pypi.org/project/OpenTimelineIO/).  You can install OpenTimelineIO via:
 
 `python -m pip install opentimelineio`
 


### PR DESCRIPTION
PyPI ("pie-pee-eye") is the **Py**thon **P**ackage **I**ndex; PyPy ("pie-pie") is an alternative Python implementation. Much digital ink has been spilled over the pronunciation differences alone. (It even has [a dedicated FAQ entry](https://pypi.org/help/#pronunciation) at PyPI.)

I hope it's fine that I did not create an issue for this for the sole purpose of linking it to this PR for auto-closing.

(There are, of course, no tests covering this change, and it will cause no change to the library's behavior.)