### PR TITLE
Improve types of childen, tracks, effects and markers parameters in function signatures

### DIFF
--- a/docs/tutorials/otio-serialized-schema.md
+++ b/docs/tutorials/otio-serialized-schema.md
@@ -79,7 +79,7 @@ parameters:
 
 ```
 
-Base class for an :class:`~Item` that contains other :class:`~Item`\s.
+Base class for an :class:`~Item` that contains :class:`~Composable`\s.
 
 Should be subclassed (for example by :class:`.Track` and :class:`.Stack`), not used directly.
 

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp
@@ -317,8 +317,8 @@ The CORE_VERSION_MAP maps OTIO release versions to maps of schema name to schema
     m.def("flatten_stack", [](Stack* s) {
             return flatten_stack(s, ErrorStatusHandler());
         }, "in_stack"_a);
-    m.def("flatten_stack", [](py::object tracks) {
-            return flatten_stack(py_to_vector<Track*>(tracks), ErrorStatusHandler());
+    m.def("flatten_stack", [](std::vector<Track*> tracks) {
+            return flatten_stack(tracks, ErrorStatusHandler());
         }, "tracks"_a);        
 
     void _build_any_to_py_dispatch_table();

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -447,7 +447,7 @@ Contains a :class:`.MediaReference` and a trim on that media reference.
         .def("__next__", &CompositionIterator::next);
 
     py::class_<Composition, Item, managing_ptr<Composition>>(m, "Composition", py::dynamic_attr(), R"docstring(
-Base class for an :class:`~Item` that contains other :class:`~Item`\s.
+Base class for an :class:`~Item` that contains :class:`~Composable`\s.
 
 Should be subclassed (for example by :class:`.Track` and :class:`.Stack`), not used directly.
 )docstring")

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_utils.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_utils.cpp
@@ -95,7 +95,6 @@ void _build_any_to_py_dispatch_table() {
 }
 
 static py::object _value_to_any = py::none();
-static py::object _value_to_so_vector = py::none();
 
 static void py_to_any(py::object const& o, any* result) {
     if (_value_to_any.is_none()) {
@@ -119,34 +118,6 @@ AnyDictionary py_to_any_dictionary(py::object const& o) {
     }
 
     return safely_cast_any_dictionary_any(a);
-}
-
-std::vector<SerializableObject*> py_to_so_vector(pybind11::object const& o) {
-    if (_value_to_so_vector.is_none()) {
-        py::object core = py::module::import("opentimelineio.core");
-        _value_to_so_vector = core.attr("_value_to_so_vector");
-    }
-
-    std::vector<SerializableObject*> result;
-    if (o.is_none()) {
-        return result;
-    }
-
-    /*
-     * We're depending on _value_to_so_vector(), written in Python, to
-     * not screw up, or we're going to crash.  (1) It has to give us
-     * back an AnyVector.  (2) Every element has to be a
-     * SerializableObject::Retainer<>.
-     */
-
-    py::object obj_vector = _value_to_so_vector(o);     // need to retain this here or we'll lose the any...
-    AnyVector const& v = temp_safely_cast_any_vector_any(obj_vector.cast<PyAny*>()->a);
-
-    result.reserve(v.size());
-    for (auto e: v) {
-        result.push_back(safely_cast_retainer_any(e));
-    }
-    return result;
 }
 
 py::object any_to_py(any const& a, bool top_level) {

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_utils.h
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_utils.h
@@ -160,27 +160,5 @@ pybind11::object any_to_py(any const& a, bool top_level = false);
 pybind11::object plain_string(std::string const& s);
 pybind11::object plain_int(int i);
 AnyDictionary py_to_any_dictionary(pybind11::object const& o);
-std::vector<SerializableObject*> py_to_so_vector(pybind11::object const& o);
 
 bool compare_typeids(std::type_info const& lhs, std::type_info const& rhs);
-
-template <typename T>
-std::vector<T> py_to_vector(pybind11::object const& o) {
-    std::vector<SerializableObject*> vso = py_to_so_vector(o);
-    std::vector<T> result;
-    
-    result.reserve(vso.size());
-    
-    for (auto e: vso) {
-        if (T t = dynamic_cast<T>(e)) {
-            result.push_back(t);
-            continue;
-        }
-
-        throw pybind11::type_error(string_printf("list has element of type %s; expected type %s",
-                                                 type_name_for_error_message(typeid(*e)).c_str(),
-                                                 type_name_for_error_message<T>().c_str()));
-    }
-
-    return result;
-}

--- a/src/py-opentimelineio/opentimelineio/core/__init__.py
+++ b/src/py-opentimelineio/opentimelineio/core/__init__.py
@@ -35,7 +35,6 @@ from .. _otio import ( # noqa
 from . _core_utils import ( # noqa
     add_method,
     _value_to_any,
-    _value_to_so_vector,
     _add_mutable_mapping_methods,
     _add_mutable_sequence_methods,
 )

--- a/src/py-opentimelineio/opentimelineio/core/_core_utils.py
+++ b/src/py-opentimelineio/opentimelineio/core/_core_utils.py
@@ -113,23 +113,6 @@ def _value_to_any(value, ids=None):
             )
 
 
-def _value_to_so_vector(value, ids=None):
-    if not isinstance(value, collections.abc.Sequence) or _is_str(value):
-        raise TypeError(
-            "Expected list/sequence of SerializableObjects;"
-            " found type '{}'".format(type(value))
-        )
-
-    av = AnyVector()
-    for e in value:
-        if not isinstance(e, SerializableObject):
-            raise TypeError(
-                "Expected list/sequence of SerializableObjects;"
-                " found element of type '{}'".format(type(e)))
-        av.append(e)
-    return PyAny(av)
-
-
 _marker_ = object()
 
 


### PR DESCRIPTION
**Summarize your change.**

Continuation of the work I've been doing to improve the parameter types in our bindings.

In this PR, I'm changing the types of the `children`, `tracks`, `effects` and `markers` parameters. A nice side effect is that we no more need the Python > C++ > Python > C++ > Python dance to convert the inputs from a `py::object` and `AnyVector`s.

Previously, there was an hand-coded bridging to `AnyVector` while now it's using facilities in pybind11 to accomplish the same thing. Part of the reason that's possible, is that `py::object` has been replaced in the interfaces with explicit types that pybind11 knows how to deal with.

 Here is an example of why it's important to expose the correct types in constructors (and functions/methods):

The previous behavior was something like this:
```python
>>> opentimelineio._otio.Track(name='asd', children=[1])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jcmorin/jcmenv/aswf/OpenTimelineIO/.venv/lib/python3.10/site-packages/opentimelineio/core/_core_utils.py", line 126, in _value_to_so_vector
    raise TypeError(
TypeError: Expected list/sequence of SerializableObjects; found element of type '<class 'int'>'
```
In this example there is two things to note. First, the error doesn't tell us which argument is of wrong type. Second, it doesn't tell us which specific types should be in the list/sequence. From the code, the list/sequence passed to the children parameter is not all subclasses of `SerializableObject`. It only accepts a list/sequence of type `Composable` and its sublcasses.

Compare this to the new behavior:
```python
>>> opentimelineio._otio.Track(name='asd', children=[1])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: __init__(): incompatible constructor arguments. The following argument types are supported:
    1. opentimelineio._otio.Track(name: object = '', children: Optional[List[opentimelineio._otio.Composable]] = None, source_range: Optional[opentimelineio._opentime.TimeRange] = None, kind: str = 'Video', metadata: object = None)

Invoked with: kwargs: name='asd', children=[1]
```

Now we can at least see all the arguments and the list of all accepted signatures. The signature is clear about that fact that it accepts a list of `Composable` and its subclasses. Pybind11 doesn't tell us which argument is wrong, but that could be contributed to Pybind11 if we feel like it would improve the experience.

---

There is one unanswered question though, at least for me, and it's what about the crashes mentioned in `otio_utils.cpp`? Andl also, what about `Every element has to be a SerializableObject::Retainer<>`? Was all this needed/casued by the fact that we were round tripping to Python?