### PR TITLE
[Breaking change] Remove support for passing a None value as the name argument

### DIFF
--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -211,12 +211,12 @@ A marker indicates a marked range of time on an item in a timeline, usually with
 The marked range may have a zero duration. The marked range is in the owning item's time coordinate system.
 )docstring")
         .def(py::init([](
-                        optional<std::string> name,
+                        std::string name,
                         TimeRange marked_range,
                         std::string const& color,
                         py::object metadata) {
                           return new Marker(
-                                  name.value_or(""),
+                                  name,
                                   marked_range,
                                   color,
                                   py_to_any_dictionary(metadata));
@@ -552,12 +552,12 @@ Should be subclassed (for example by :class:`.Track` and :class:`.Stack`), not u
         .value("never", Track::NeighborGapPolicy::never);
 
     track_class
-        .def(py::init([](optional<std::string> name, optional<std::vector<Composable*>> children,
+        .def(py::init([](std::string name, optional<std::vector<Composable*>> children,
                          optional<TimeRange> const& source_range,
                          std::string const& kind, py::object metadata) {
                           auto composable_children = vector_or_default<Composable>(children);
                           Track* t = new Track(
-                                  name.value_or(""),
+                                  name,
                                   source_range,
                                   kind,
                                   py_to_any_dictionary(metadata)
@@ -586,7 +586,7 @@ Should be subclassed (for example by :class:`.Track` and :class:`.Stack`), not u
 
 
     py::class_<Stack, Composition, managing_ptr<Stack>>(m, "Stack", py::dynamic_attr())
-        .def(py::init([](optional<std::string> name,
+        .def(py::init([](std::string name,
                          optional<std::vector<Composable*>> children,
                          optional<TimeRange> const& source_range,
                          optional<std::vector<Marker*>> markers,
@@ -594,7 +594,7 @@ Should be subclassed (for example by :class:`.Track` and :class:`.Stack`), not u
                          py::object metadata) {
                           auto composable_children = vector_or_default<Composable>(children);
                           Stack* s = new Stack(
-                                  name.value_or(""),
+                                  name,
                                   source_range,
                                   py_to_any_dictionary(metadata),
                                   vector_or_default<Effect>(effects),
@@ -742,12 +742,12 @@ Represents media for which a concrete reference is missing.
 Note that a :class:`~MissingReference` may have useful metadata, even if the location of the media is not known.
 )docstring")
         .def(py::init([](
-                        optional<std::string> name,
+                        std::string name,
                         optional<TimeRange> available_range,
                         py::object metadata,
                         optional<Imath::Box2d> const& available_image_bounds) {
                     return new MissingReference(
-                                  name.value_or(""),
+                                  name,
                                   available_range,
                                   py_to_any_dictionary(metadata),
                                   available_image_bounds); 

--- a/src/py-opentimelineio/opentimelineio/adapters/fcp_xml.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/fcp_xml.py
@@ -738,7 +738,7 @@ class FCP7XMLParser:
         """
         local_context = context.context_pushing_element(track_element)
         name_element = track_element.find("./name")
-        track_name = (name_element.text if name_element is not None else None)
+        track_name = (name_element.text if name_element is not None else '')
 
         timeline_item_tags = {"clipitem", "generatoritem", "transitionitem"}
 


### PR DESCRIPTION
Remove support for passing a None value as the name argument to Marker, Track, Stack and MissingReference constructors

Follow up to https://github.com/AcademySoftwareFoundation/OpenTimelineIO/pull/1446.

As discussed in the last TSC meeting, it has been agreed that we shuld keep the class constructors consistent, which mean that we should drop the ability to pass None values for the name argument of the `Marker`, `Track`, `Stack` and `MissingReference` class constructors.

Passing None is bad in this case because it's inconsistent with the other constructors, which can be seen as not user friendly.

The `name` parameter is always defined as a kwarg with a default value of `''` (empty string). This means that it's still possible to ignore the name parameter entirely when instantiating a class. The only difference now is that the type will be explicitly exposed (and discoverable) and if something else than a string is passed as an argument, it will cause an exception like this:

```python
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: __init__(): incompatible constructor arguments. The following argument types are supported:
    1. opentimelineio._otio.Marker(name: str = '', marked_range: opentimelineio._opentime.TimeRange = otio.opentime.TimeRange(start_time=otio.opentime.RationalTime(value=0, rate=1), duration=otio.opentime.RationalTime(value=0, rate=1)), color: str = 'RED', metadata: object = None)

Invoked with: kwargs: name=None
```

This is considered a breaking change and should be clearly marked as such in the changelog.