### PR TITLE
Add support for editable installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ docs/_build
 .tox
 cpp_cov_html/
 lcov_html_report/
+*.so
+*.pyd

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -23,6 +23,8 @@ exclude */.DS_Store
 exclude .clang-format
 exclude OTIO_VERSION.json
 global-exclude *.pyc
+global-exclude *.so
+global-exclude *.pyd
 
 prune maintainers
 prune tsc

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -62,7 +62,7 @@ with OpenTimelineIO due to spaces in the path.
 
 ## To build OTIO for Python development:
 
-+ `python -m pip install .`
++ `python -m pip install -e .`
 
 ## To build OTIO for both C++ and Python development:
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ import shlex
 import sys
 import platform
 import subprocess
-import unittest
 import tempfile
 import shutil
 


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**

Fixes #1286.

**Summarize your change.**

`seetuptools` added back [editable installs](https://setuptools.pypa.io/en/latest/userguide/development_mode.html) not too long ago and it now supports extensions!

This PR adds support for installing OTIO in editable mode, using `pip install -e .`.

Note that due to the nature of OTIO, the binaries are not editable. There is not much we can do in regard to that since every time the C++ code changed, we need to re-compile the extension. But at least the Python files are editable.
