### PR TITLE
Add Python 3.11 to CI matrix

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ env:
 
 on:
   push:
-    branches: [ main, 'python311' ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -168,8 +168,8 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.python-build }}
           CIBW_SKIP: '*musllinux*'
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
-          CIBW_MANYLINUX_I686_IMAGE: manylinux2010
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_MANYLINUX_I686_IMAGE: manylinux2014
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ env:
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 'python311' ]
   pull_request:
     branches: [ main ]
 
@@ -87,7 +87,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         include:
           - { os: ubuntu-latest, shell: bash }
           - { os: macos-latest, shell: bash }
@@ -157,7 +157,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-build: ['cp37*', 'cp38*', 'cp39*', 'cp310*']
+        python-build: ['cp37*', 'cp38*', 'cp39*', 'cp310*', 'cp311*']
     steps:
       - uses: actions/checkout@v3
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ OpenTimelineIO
 ==============
 
 [![Supported VFX Platform Versions](https://img.shields.io/badge/vfx%20platform-2020--2023-lightgrey.svg)](http://www.vfxplatform.com/)
-![Supported Versions](https://img.shields.io/badge/python-3.7%2C%203.8%2C%203.9%2C%203.10-blue)
+![Supported Versions](https://img.shields.io/badge/python-3.7%2C%203.8%2C%203.9%2C%203.10%2C%203.11-blue)
 [![Build Status](https://github.com/AcademySoftwareFoundation/OpenTimelineIO/actions/workflows/python-package.yml/badge.svg)](https://github.com/AcademySoftwareFoundation/OpenTimelineIO/actions/workflows/python-package.yml)
 [![codecov](https://codecov.io/gh/AcademySoftwareFoundation/OpenTimelineIO/branch/main/graph/badge.svg)](https://codecov.io/gh/AcademySoftwareFoundation/OpenTimelineIO)
 [![docs](https://readthedocs.org/projects/opentimelineio/badge/?version=latest)](https://opentimelineio.readthedocs.io/en/latest/index.html)
@@ -155,8 +155,8 @@ You can also install the PySide2 dependency with `python -m pip install .[view]`
 
 You may need to escape the `[` depending on your shell, `\[view\]` .
 
-Currently the code base is written against python 3.7, 3.8, 3.9, and 3.10, in
-keeping with the pep8 style.  We ask that before developers submit pull
+Currently the code base is written against python 3.7, 3.8, 3.9, 3.10 and 3.11,
+in keeping with the pep8 style.  We ask that before developers submit pull
 request, they:
 
 - run `make test` -- to ensure that none of the unit tests were broken

--- a/setup.py
+++ b/setup.py
@@ -315,6 +315,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Operating System :: OS Independent',
         'Natural Language :: English',
     ],


### PR DESCRIPTION
Python 3.11 was release on Oct. 24, 2022. This PR adds 3.11 to the CI matrix so that we can make sure everything is working as expected even if we don't publish wheels yet.

Note that in order to get 3.11 wheels, I had to update the manylinux docker images to use `manylinux2014`. `manylinux2010` was a CentOS 6 based imaged while 2014 is a CentOS 7 based image. Because 2014 uses glibc 2.17, we are fully compatible with the vfx platform years we support. Also, 2014 uses GCC 10 (10.2.1 to be precised).