### PR TITLE
When flattening or trimming tracks, optionally honor linear timewarps.

### DIFF
--- a/src/opentimelineio/stackAlgorithm.cpp
+++ b/src/opentimelineio/stackAlgorithm.cpp
@@ -17,7 +17,8 @@ _flatten_next_item(
     std::vector<Track*> const& tracks,
     int                        track_index,
     optional<TimeRange>        trim_range,
-    ErrorStatus*               error_status)
+    ErrorStatus*               error_status,
+    TrimPolicy                 trim_policy)
 {
     if (track_index < 0)
     {
@@ -34,7 +35,7 @@ _flatten_next_item(
     SerializableObject::Retainer<Track> track_retainer;
     if (trim_range)
     {
-        track = track_trimmed_to_range(track, *trim_range, error_status);
+        track = track_trimmed_to_range(track, *trim_range, error_status, trim_policy);
         if (track == nullptr || is_error(error_status))
         {
             return;
@@ -105,7 +106,8 @@ _flatten_next_item(
                 tracks,
                 track_index - 1,
                 trim,
-                error_status);
+                error_status,
+                trim_policy);
             if (track == nullptr || is_error(error_status))
             {
                 return;
@@ -124,7 +126,9 @@ _flatten_next_item(
 }
 
 Track*
-flatten_stack(Stack* in_stack, ErrorStatus* error_status)
+flatten_stack(Stack* in_stack,
+              ErrorStatus* error_status,
+              TrimPolicy trim_policy)
 {
     std::vector<Track*> tracks;
     tracks.reserve(in_stack->children().size());
@@ -161,12 +165,15 @@ flatten_stack(Stack* in_stack, ErrorStatus* error_status)
         tracks,
         -1,
         nullopt,
-        error_status);
+        error_status,
+        trim_policy);
     return flat_track;
 }
 
 Track*
-flatten_stack(std::vector<Track*> const& tracks, ErrorStatus* error_status)
+flatten_stack(std::vector<Track*> const& tracks,
+              ErrorStatus* error_status,
+              TrimPolicy trim_policy)
 {
     Track* flat_track = new Track;
     flat_track->set_name("Flattened");
@@ -178,7 +185,8 @@ flatten_stack(std::vector<Track*> const& tracks, ErrorStatus* error_status)
         tracks,
         -1,
         nullopt,
-        error_status);
+        error_status,
+        trim_policy);
     return flat_track;
 }
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/stackAlgorithm.h
+++ b/src/opentimelineio/stackAlgorithm.h
@@ -9,9 +9,13 @@
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
-Track* flatten_stack(Stack* in_stack, ErrorStatus* error_status = nullptr);
+Track* flatten_stack(
+    Stack*       in_stack,
+    ErrorStatus* error_status = nullptr,
+    TrimPolicy   trim_policy = IgnoreTimeEffects);
 Track* flatten_stack(
     std::vector<Track*> const& tracks,
-    ErrorStatus*               error_status = nullptr);
+    ErrorStatus*               error_status = nullptr,
+    TrimPolicy                 trim_policy = IgnoreTimeEffects);
 
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/track.h
+++ b/src/opentimelineio/track.h
@@ -8,6 +8,13 @@
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
+enum TrimPolicy
+{
+    IgnoreTimeEffects = 0,
+    HonorTimeEffectsExactly,
+    HonorTimeEffectsWithSnapping
+};
+
 class Clip;
 
 class Track : public Composition

--- a/src/opentimelineio/trackAlgorithm.h
+++ b/src/opentimelineio/trackAlgorithm.h
@@ -11,6 +11,7 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 Track* track_trimmed_to_range(
     Track*       in_track,
     TimeRange    trim_range,
-    ErrorStatus* error_status = nullptr);
+    ErrorStatus* error_status = nullptr,
+    TrimPolicy   trimPolicy = IgnoreTimeEffects);
 
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION


### PR DESCRIPTION
This PR is an attempt to fix https://github.com/AcademySoftwareFoundation/OpenTimelineIO/issues/1464

This change introduces an optional argument to both `flatten_tracks` and `track_trimmed_to_range` to indicate whether timewarps should be honored or not.

I'm not entirely happy with how this PR stands as-is, but I'm posting it to get feedback on it so it can be improved.
