### PR TITLE
Switch to using `importlib` from `pkg_resources`

### DIFF
--- a/docs/tutorials/otio-env-variables.md
+++ b/docs/tutorials/otio-env-variables.md
@@ -18,10 +18,10 @@ OTIO_DEFAULT_MEDIA_LINKER
    The name of the default media linker to use after reading a file, if `""` then no
    media linker is automatically invoked.
 
-OTIO_DISABLE_PKG_RESOURCE_PLUGINS
-   By default, OTIO will use the `pkg_resource` entry_points mechanism to discover plugins
-   that have been installed into the current python environment. `pkg_resources`, however, can
-   be slow in certain cases, so for users who wish to disable this behavior, this variable can be set to 1.
+OTIO_DISABLE_ENTRYPOINTS_PLUGINS
+   By default, OTIO will use the `importlib.metadata` entry_points mechanism to discover plugins
+   that have been installed into the current python environment. For users who wish to disable this
+   behavior, this variable can be set to 1.
 
 OTIO_DEFAULT_TARGET_VERSION_FAMILY_LABEL
    If no downgrade arguments are passed to `write_to_file`/`write_to_string`, use the downgrade manifest

--- a/examples/sample_plugin/otio_counter/__init__.py
+++ b/examples/sample_plugin/otio_counter/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Contributors to the OpenTimelineIO project
-import pkg_resources
+
+import importlib.resources
 
 from opentimelineio.plugins import manifest
 
@@ -62,6 +63,7 @@ def plugin_manifest():
     # XXX: note, this doesn't get called.  For an example of this working,
     #      see the mockplugin unit test.
 
+    filepath = importlib.resources.files(__package__) / "plugin_manifest.json"
     return manifest.manifest_from_string(
-        pkg_resources.resource_string(__name__, 'plugin_manifest.json')
+        filepath.read_text()
     )

--- a/setup.py
+++ b/setup.py
@@ -361,8 +361,7 @@ setup(
 
     install_requires=[
         'pyaaf2>=1.4,<1.7',
-        # For python 3.7
-        'importlib_metadata==5.0.0',
+        'importlib_metadata==5.0.0; python_version < "3.8"',
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -361,7 +361,7 @@ setup(
 
     install_requires=[
         'pyaaf2>=1.4,<1.7',
-        'importlib_metadata==5.0.0; python_version < "3.8"',
+        'importlib_metadata>=1.4; python_version < "3.8"',
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -361,6 +361,8 @@ setup(
 
     install_requires=[
         'pyaaf2>=1.4,<1.7',
+        # For python 3.7
+        'importlib_metadata==5.0.0',
     ],
     entry_points={
         'console_scripts': [

--- a/src/py-opentimelineio/opentimelineio/plugins/manifest.py
+++ b/src/py-opentimelineio/opentimelineio/plugins/manifest.py
@@ -3,21 +3,17 @@
 
 """OTIO Python Plugin Manifest system: locates plugins to OTIO."""
 
+from importlib import resources
 import inspect
 import logging
 import os
+from pathlib import Path
 
-# In some circumstances pkg_resources has bad performance characteristics.
-# Using the envirionment variable: $OTIO_DISABLE_PKG_RESOURCE_PLUGINS disables
-# OpenTimelineIO's import and of use of the pkg_resources module.
-if os.environ.get("OTIO_DISABLE_PKG_RESOURCE_PLUGINS", False):
-    pkg_resources = None
-else:
-    try:
-        # on some python interpreters, pkg_resources is not available
-        import pkg_resources
-    except ImportError:
-        pkg_resources = None
+try:
+    from importlib import metadata
+except ImportError:
+    # For python 3.7
+    import importlib_metadata as metadata
 
 from .. import (
     core,
@@ -250,11 +246,14 @@ def load_manifest():
 
             result.extend(manifest_from_file(json_path))
 
-    # setuptools.pkg_resources based plugins
-    if pkg_resources:
-        for plugin in pkg_resources.iter_entry_points(
-                "opentimelineio.plugins"
-        ):
+    if not os.environ.get("OTIO_DISABLE_ENTRYPOINTS_PLUGINS"):
+        try:
+            entry_points = metadata.entry_points(group='opentimelineio.plugins')
+        except TypeError:
+            # For python <= 3.9
+            entry_points = metadata.entry_points().get('opentimelineio.plugins', [])
+
+        for plugin in entry_points:
             plugin_name = plugin.name
             try:
                 plugin_entry_point = plugin.load()
@@ -276,33 +275,23 @@ def load_manifest():
                     plugin_manifest._update_plugin_source(manifest_path)
 
                 except AttributeError:
-                    if not pkg_resources.resource_exists(
-                            plugin.module_name,
-                            'plugin_manifest.json'
-                    ):
-                        raise
+                    name = plugin_entry_point.__name__
 
-                    filepath = os.path.abspath(
-                        pkg_resources.resource_filename(
-                            plugin.module_name,
-                            'plugin_manifest.json'
-                        )
-                    )
+                    try:
+                        filepath = resources.files(name) / "plugin_manifest.json"
+                    except AttributeError:
+                        # For python <= 3.7
+                        with resources.path(name, "plugin_manifest.json") as p:
+                            filepath = Path(p)
 
-                    if filepath in result.source_files:
+                    if filepath.as_posix() in result.source_files:
                         continue
 
-                    manifest_stream = pkg_resources.resource_stream(
-                        plugin.module_name,
-                        'plugin_manifest.json'
-                    )
                     plugin_manifest = core.deserialize_json_from_string(
-                        manifest_stream.read().decode('utf-8')
+                        filepath.read_text()
                     )
-                    manifest_stream.close()
-
-                    plugin_manifest._update_plugin_source(filepath)
-                    plugin_manifest.source_files.append(filepath)
+                    plugin_manifest._update_plugin_source(filepath.as_posix())
+                    plugin_manifest.source_files.append(filepath.as_posix())
 
             except Exception:
                 logging.exception(
@@ -312,9 +301,10 @@ def load_manifest():
 
             result.extend(plugin_manifest)
     else:
-        # XXX: Should we print some kind of warning that pkg_resources isn't
-        #        available?
-        pass
+        logging.debug(
+            "OTIO_DISABLE_ENTRYPOINTS_PLUGINS is set. "
+            "Entry points plugings have been disabled."
+        )
 
     # the builtin plugin manifest
     builtin_manifest_path = os.path.join(

--- a/src/py-opentimelineio/opentimelineio/plugins/manifest.py
+++ b/src/py-opentimelineio/opentimelineio/plugins/manifest.py
@@ -293,9 +293,9 @@ def load_manifest():
                     plugin_manifest._update_plugin_source(filepath.as_posix())
                     plugin_manifest.source_files.append(filepath.as_posix())
 
-            except Exception:
+            except Exception as e:
                 logging.exception(
-                    f"could not load plugin: {plugin_name}"
+                    f"could not load plugin: {plugin_name}.  Exception is: {e}"
                 )
                 continue
 

--- a/tests/baselines/plugin_module/otio_mockplugin/__init__.py
+++ b/tests/baselines/plugin_module/otio_mockplugin/__init__.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Contributors to the OpenTimelineIO project
 
-import pkg_resources
+from importlib import resources
+from pathlib import Path
 
 from opentimelineio.plugins import manifest
 
@@ -20,9 +21,13 @@ a non-standard json file path.
 
 
 def plugin_manifest():
+    try:
+        filepath = resources.files(__package__) / "unusually_named_plugin_manifest.json"
+    except AttributeError:
+        # For python <= 3.7
+        with resources.path(__package__, "unusually_named_plugin_manifest.json") as p:
+            filepath = Path(p)
+
     return manifest.manifest_from_string(
-        pkg_resources.resource_string(
-            __name__,
-            'unusually_named_plugin_manifest.json'
-        )
+        filepath.read_text()
     )

--- a/tests/test_plugin_detection.py
+++ b/tests/test_plugin_detection.py
@@ -103,8 +103,8 @@ class TestSetuptoolsPlugin(unittest.TestCase):
             )
         )
 
-    def test_pkg_resources_disabled(self):
-        os.environ["OTIO_DISABLE_PKG_RESOURCE_PLUGINS"] = "1"
+    def test_entrypoints_disabled(self):
+        os.environ["OTIO_DISABLE_ENTRYPOINTS_PLUGINS"] = "1"
         import_reload(otio.plugins.manifest)
 
         # detection of the environment variable happens on import, force a
@@ -118,7 +118,7 @@ class TestSetuptoolsPlugin(unittest.TestCase):
 
         # remove the environment variable and reload again for usage in the
         # other tests
-        del os.environ["OTIO_DISABLE_PKG_RESOURCE_PLUGINS"]
+        del os.environ["OTIO_DISABLE_ENTRYPOINTS_PLUGINS"]
         import_reload(otio.plugins.manifest)
 
     def test_detect_plugin_json_manifest(self):

--- a/tests/test_plugin_detection.py
+++ b/tests/test_plugin_detection.py
@@ -80,7 +80,8 @@ class TestSetuptoolsPlugin(unittest.TestCase):
         for linker in man.media_linkers:
             self.assertIsInstance(linker, otio.media_linker.MediaLinker)
 
-    def test_overrride_adapter(self):
+    def test_override_adapter(self):
+
         # Test that entrypoint plugins load before builtin and contrib
         man = otio.plugins.manifest.load_manifest()
 
@@ -113,7 +114,7 @@ class TestSetuptoolsPlugin(unittest.TestCase):
 
         # override adapter should not be loaded either
         with self.assertRaises(AssertionError):
-            self.test_overrride_adapter()
+            self.test_override_adapter()
 
         # remove the environment variable and reload again for usage in the
         # other tests

--- a/tests/test_plugin_detection.py
+++ b/tests/test_plugin_detection.py
@@ -5,6 +5,7 @@
 
 import unittest
 import os
+from pathlib import Path
 import sys
 
 from unittest import mock
@@ -28,17 +29,17 @@ class TestSetuptoolsPlugin(unittest.TestCase):
             os.path.normpath(baseline_reader.path_to_baseline_directory()),
             'plugin_module',
         )
-        self.mock_module_manifest_path = os.path.join(
+        self.mock_module_manifest_path = Path(
             mock_module_path,
             "otio_jsonplugin",
             "plugin_manifest.json"
-        )
+        ).absolute().as_posix()
 
-        self.override_adapter_manifest_path = os.path.join(
+        self.override_adapter_manifest_path = Path(
             mock_module_path,
             "otio_override_adapter",
             "plugin_manifest.json"
-        )
+        ).absolute().as_posix()
 
         # Create a WorkingSet as if the module were installed
         entries = [mock_module_path] + sys.path
@@ -91,7 +92,7 @@ class TestSetuptoolsPlugin(unittest.TestCase):
 
         # Override adapter should be the first adapter found
         manifest = adapters[0].plugin_info_map().get('from manifest', None)
-        self.assertEqual(manifest, os.path.abspath(self.override_adapter_manifest_path))
+        self.assertEqual(manifest, self.override_adapter_manifest_path)
 
         self.assertTrue(
             any(


### PR DESCRIPTION
Fixes #1426

As requested in the issue, this replaces `pkg_resources` with `importlib` for plugin detection.

Quick and dirty benchmarks show an improvement in average runtime when accessing plugins:  
![image](https://user-images.githubusercontent.com/1740063/198210346-15c93a17-3b32-4422-969b-d95871c52d3a.png)

The `OTIO_DISABLE_PKG_RESOURCE_PLUGINS` env var and its corresponding test have been removed as they're no longer needed.

Less than ideal, `importlib.metadata` has been in flux since `3.7` so there's some code in here to work with old and new and to avoid a deprecation warning.

Existing tests in `test_plugin_detection` continue to provide coverage.