### PR TITLE
Added --relink-by-name feature to otiotool

### DIFF
--- a/src/py-opentimelineio/opentimelineio/console/otiotool.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiotool.py
@@ -204,6 +204,7 @@ otiotool -i playlist.otio --only-audio --list-tracks --inspect "Interview"
         type=str,
         nargs='+',
         required=True,
+        metavar='PATH(s)',
         help="""Input file path(s). All formats supported by adapter plugins
         are supported. Use '-' to read OTIO from standard input."""
     )
@@ -224,26 +225,30 @@ otiotool -i playlist.otio --only-audio --list-tracks --inspect "Interview"
     parser.add_argument(
         "--only-tracks-with-name",
         type=str,
-        nargs='*',
+        nargs='+',
+        metavar='NAME(s)',
         help="Output tracks with these name(s)"
     )
     parser.add_argument(
         "--only-tracks-with-index",
         type=int,
-        nargs='*',
+        nargs='+',
+        metavar='INDEX(es)',
         help="Output tracks with these indexes"
         " (1 based, in same order as --list-tracks)"
     )
     parser.add_argument(
         "--only-clips-with-name",
         type=str,
-        nargs='*',
+        nargs='+',
+        metavar='NAME(s)',
         help="Output only clips with these name(s)"
     )
     parser.add_argument(
         "--only-clips-with-name-regex",
         type=str,
-        nargs='*',
+        nargs='+',
+        metavar='REGEX(es)',
         help="Output only clips with names matching the given regex"
     )
     parser.add_argument(
@@ -256,6 +261,7 @@ otiotool -i playlist.otio --only-audio --list-tracks --inspect "Interview"
         "--trim",
         type=str,
         nargs=2,
+        metavar=('START', 'END'),
         help="Trim from <start> to <end> as HH:MM:SS:FF timecode or seconds"
     )
 
@@ -264,6 +270,7 @@ otiotool -i playlist.otio --only-audio --list-tracks --inspect "Interview"
         "-f",
         "--flatten",
         choices=['video', 'audio', 'all'],
+        metavar='TYPE',
         help="Flatten multiple tracks into one."
     )
     parser.add_argument(
@@ -289,6 +296,7 @@ otiotool -i playlist.otio --only-audio --list-tracks --inspect "Interview"
     parser.add_argument(
         "--copy-media-to-folder",
         type=str,
+        metavar='FOLDER',
         help="""Copy or download all linked media to the specified folder and
         relink all media references to the copies"""
     )
@@ -337,7 +345,8 @@ otiotool -i playlist.otio --only-audio --list-tracks --inspect "Interview"
     parser.add_argument(
         "--inspect",
         type=str,
-        nargs='*',
+        nargs='+',
+        metavar='NAME(s)',
         help="Inspect details of clips with names matching the given regex"
     )
 
@@ -346,6 +355,7 @@ otiotool -i playlist.otio --only-audio --list-tracks --inspect "Interview"
         "-o",
         "--output",
         type=str,
+        metavar='PATH',
         help="""Output file. All formats supported by adapter plugins
         are supported. Use '-' to write OTIO to standard output."""
     )

--- a/src/py-opentimelineio/opentimelineio/console/otiotool.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiotool.py
@@ -655,7 +655,8 @@ def relink_by_name(timeline, path):
             for x in os.listdir(path)
         ])
     elif os.path.isfile(path):
-        print(f"ERROR: Cannot relink to '{path}': Please specify a folder instead of a file.")
+        print((f"ERROR: Cannot relink to '{path}':"
+               " Please specify a folder instead of a file."))
         return
     else:
         print(f"ERROR: Cannot relink to '{path}': No such file or folder.")
@@ -664,9 +665,7 @@ def relink_by_name(timeline, path):
     for clip in timeline.each_clip():
         url = name_to_url.get(clip.name)
         if url is not None:
-            clip.media_reference = otio.schema.ExternalReference(
-                  target_url=url
-            )
+            clip.media_reference = otio.schema.ExternalReference(target_url=url)
             count += 1
 
     print(f"Relinked {count} clips to files in folder {path}")

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -912,10 +912,10 @@ Duration: 00:02:16:18
             out, err = self.run_test()
             self.assertTrue(
                 ("TIMELINE: Figure 1 - Simple Cut List\n"
-                f"    MEDIA: file://{temp_dir}/Clip-001.empty\n"
-                "    MEDIA: file:///folder/wind-up.mov\n"
-                f"    MEDIA: file://{temp_dir}/Clip-003.empty\n"
-                "    MEDIA: file:///folder/credits.mov\n")
+                 f"    MEDIA: file://{temp_dir}/Clip-001.empty\n"
+                 "    MEDIA: file:///folder/wind-up.mov\n"
+                 f"    MEDIA: file://{temp_dir}/Clip-003.empty\n"
+                 "    MEDIA: file:///folder/credits.mov\n")
                 in out)
 
 

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -8,6 +8,7 @@ import sys
 import os
 import subprocess
 import sysconfig
+import pathlib
 import platform
 
 import io
@@ -903,6 +904,8 @@ Duration: 00:02:16:18
             open(temp_file1, "w").write("A")
             open(temp_file2, "w").write("B")
 
+            temp_url = pathlib.Path(temp_dir).as_uri()
+
             sys.argv = [
                 'otiotool',
                 '-i', SIMPLE_CUT_PATH,
@@ -910,13 +913,13 @@ Duration: 00:02:16:18
                 '--list-media'
             ]
             out, err = self.run_test()
-            self.assertTrue(
+            self.assertIn(
                 ("TIMELINE: Figure 1 - Simple Cut List\n"
-                 f"    MEDIA: file://{temp_dir}/Clip-001.empty\n"
+                 f"    MEDIA: {temp_url}/Clip-001.empty\n"
                  "    MEDIA: file:///folder/wind-up.mov\n"
-                 f"    MEDIA: file://{temp_dir}/Clip-003.empty\n"
-                 "    MEDIA: file:///folder/credits.mov\n")
-                in out)
+                 f"    MEDIA: {temp_url}/Clip-003.empty\n"
+                 "    MEDIA: file:///folder/credits.mov\n"),
+                out)
 
 
 OTIOToolTest_ShellOut = CreateShelloutTest(OTIOToolTest)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -20,9 +20,11 @@ import opentimelineio.test_utils as otio_test_utils
 import opentimelineio.console as otio_console
 
 SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
-SCREENING_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "screening_example.edl")
-PREMIERE_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "premiere_example.xml")
+
 MULTITRACK_PATH = os.path.join(SAMPLE_DATA_DIR, "multitrack.otio")
+PREMIERE_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "premiere_example.xml")
+SCREENING_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "screening_example.edl")
+SIMPLE_CUT_PATH = os.path.join(SAMPLE_DATA_DIR, "simple_cut.otio")
 TRANSITION_PATH = os.path.join(SAMPLE_DATA_DIR, "transition.otio")
 
 
@@ -893,6 +895,28 @@ Duration: 00:02:16:18
              "    range in Sequence 3 (<class 'opentimelineio._otio.Track'>): TimeRange(RationalTime(1198, 24), RationalTime(640, 24))\n"  # noqa E501 line too long
              "    range in NestedScope (<class 'opentimelineio._otio.Stack'>): TimeRange(RationalTime(1198, 24), RationalTime(640, 24))\n"),  # noqa E501 line too long
             out)
+
+    def test_relink(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_file1 = os.path.join(temp_dir, "Clip-001.empty")
+            temp_file2 = os.path.join(temp_dir, "Clip-003.empty")
+            open(temp_file1, "w").write("A")
+            open(temp_file2, "w").write("B")
+
+            sys.argv = [
+                'otiotool',
+                '-i', SIMPLE_CUT_PATH,
+                '--relink-by-name', temp_dir,
+                '--list-media'
+            ]
+            out, err = self.run_test()
+            self.assertTrue(
+                ("TIMELINE: Figure 1 - Simple Cut List\n"
+                f"    MEDIA: file://{temp_dir}/Clip-001.empty\n"
+                "    MEDIA: file:///folder/wind-up.mov\n"
+                f"    MEDIA: file://{temp_dir}/Clip-003.empty\n"
+                "    MEDIA: file:///folder/credits.mov\n")
+                in out)
 
 
 OTIOToolTest_ShellOut = CreateShelloutTest(OTIOToolTest)


### PR DESCRIPTION
This PR adds a new `--relink-by-name` option to `otiotool` which allows you to relink clips to media files in a given folder by matching the clip name to the filename (ignoring file extension).

Also included in this PR are some small improvements to the otiotool usage statement.