### PR TITLE
Make opentimelineio headers public

### DIFF
--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -78,7 +78,7 @@ add_library(opentimelineio ${OTIO_SHARED_OR_STATIC_LIB}
 add_library(OTIO::opentimelineio ALIAS opentimelineio)
 
 target_include_directories(opentimelineio
-    PRIVATE       "${IMATH_INCLUDES}"
+    PUBLIC        "${IMATH_INCLUDES}"
                   "${PROJECT_SOURCE_DIR}/src"
                   "${PROJECT_SOURCE_DIR}/src/deps"
                   "${PROJECT_SOURCE_DIR}/src/deps/optional-lite/include"


### PR DESCRIPTION
When linking to opentimelineio statically, cmake can't find imported headers :
```bash
fatal error: 'opentimelineio/clip.h' file not found
#include <opentimelineio/clip.h>
         ^~~~~~~~~~~~~~~~~~~~~~~
```

Making "target_include_directories" PUBLIC allows projects including opentimelineio in their CMakeLists.txt to correctly find the project headers.
