### PR TITLE
Added --downgrade option to otiotool.

### DIFF
--- a/src/py-opentimelineio/opentimelineio/console/otiotool.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiotool.py
@@ -32,6 +32,15 @@ def main():
 
     args = parse_arguments()
 
+    # Special case option, which skips all the other phases
+
+    if args.list_versions:
+        print("Available versions for --downgrade FAMILY:VERSION")
+        for family, mapping in otio.versioning.full_map().items():
+            for label in mapping.keys():
+                print(f"  {family}:{label}")
+        return
+
     # Phase 1: Input...
 
     # Most of this function will operate on this list of timelines.
@@ -135,12 +144,6 @@ def main():
                 timeline)
 
     # Final Phase: Output
-
-    if args.list_versions:
-        print("Available versions for --downgrade FAMILY:VERSION")
-        for family, mapping in otio.versioning.full_map().items():
-            for label in mapping.keys():
-                print(f"  {family}:{label}")
 
     if args.downgrade:
         if ":" in args.downgrade:
@@ -427,6 +430,9 @@ otiotool -i playlist.otio --only-audio --list-tracks --inspect "Interview"
 
     if args.keep_flattened_tracks and not args.flatten:
         parser.error("Cannot use --keep-flattened-tracks without also using --flatten.")
+
+    if args.input and args.list_versions:
+        parser.error("Cannot combine --input and --list-versions.")
 
     return args
 

--- a/src/py-opentimelineio/opentimelineio/console/otiotool.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiotool.py
@@ -396,8 +396,9 @@ otiotool -i playlist.otio --only-audio --list-tracks --inspect "Interview"
         to output an OTIO file. FAMILY:VERSION specifies which schema family
         and version to use. If FAMILY: is omitted, the default OTIO_CORE: is
         used. For example `--downgrade OTIO_CORE:0.14.0` is equivalent to
-        `--downgrade 0.14.0`. See the OpenTimelineIO documentation for
-        OTIO_DEFAULT_TARGET_VERSION_FAMILY_LABEL for details."""
+        `--downgrade 0.14.0`. See
+        https://opentimelineio.readthedocs.io/en/latest/tutorials/versioning-schemas.html
+        for details."""
     )
     parser.add_argument(
         "--list-versions",

--- a/src/py-opentimelineio/opentimelineio/console/otiotool.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiotool.py
@@ -385,7 +385,7 @@ otiotool -i playlist.otio --only-audio --list-tracks --inspect "Interview"
         to output an OTIO file. FAMILY:VERSION specifies which schema family
         and version to use. If FAMILY: is omitted, the default OTIO_CORE: is
         used. For example `--downgrade OTIO_CORE:0.14.0` is equivalent to
-        `--downgrade 0.14.0`. See the OpenTimelineIO documentation for 
+        `--downgrade 0.14.0`. See the OpenTimelineIO documentation for
         OTIO_DEFAULT_TARGET_VERSION_FAMILY_LABEL for details."""
     )
 

--- a/src/py-opentimelineio/opentimelineio/console/otiotool.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiotool.py
@@ -38,7 +38,10 @@ def main():
     # Often there will be just one, but this tool in general enough
     # to operate on several. This is essential when the --stack or
     # --concatenate arguments are used.
-    timelines = read_inputs(args.input)
+    if args.input:
+        timelines = read_inputs(args.input)
+    else:
+        timelines = []
 
     # Phase 2: Filter (remove stuff)...
 
@@ -133,6 +136,12 @@ def main():
 
     # Final Phase: Output
 
+    if args.list_versions:
+        print("Available versions for --downgrade FAMILY:VERSION")
+        for family, mapping in otio.versioning.full_map().items():
+            for label in mapping.keys():
+                print(f"  {family}:{label}")
+
     if args.downgrade:
         if ":" in args.downgrade:
             label = args.downgrade
@@ -221,7 +230,6 @@ otiotool -i playlist.otio --only-audio --list-tracks --inspect "Interview"
         "--input",
         type=str,
         nargs='+',
-        required=True,
         metavar='PATH(s)',
         help="""Input file path(s). All formats supported by adapter plugins
         are supported. Use '-' to read OTIO from standard input."""
@@ -388,6 +396,11 @@ otiotool -i playlist.otio --only-audio --list-tracks --inspect "Interview"
         `--downgrade 0.14.0`. See the OpenTimelineIO documentation for
         OTIO_DEFAULT_TARGET_VERSION_FAMILY_LABEL for details."""
     )
+    parser.add_argument(
+        "--list-versions",
+        action='store_true',
+        help="""List available versions for the --downgrade option."""
+    )
 
     parser.add_argument(
         "-o",
@@ -399,6 +412,10 @@ otiotool -i playlist.otio --only-audio --list-tracks --inspect "Interview"
     )
 
     args = parser.parse_args()
+
+    # At least one of these must be specified
+    if not any([args.input, args.list_versions]):
+        parser.error("Must specify at least one of --input or --list-versions.")
 
     # Some options cannot be combined.
 

--- a/src/py-opentimelineio/opentimelineio/console/otiotool.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiotool.py
@@ -133,6 +133,13 @@ def main():
 
     # Final Phase: Output
 
+    if args.downgrade:
+        if ":" in args.downgrade:
+            label = args.downgrade
+        else:
+            label = "OTIO_CORE:" + args.downgrade
+        os.environ["OTIO_DEFAULT_TARGET_VERSION_FAMILY_LABEL"] = label
+
     if args.output:
         # Gather all of the timelines under one OTIO object
         # in preparation for final output
@@ -188,7 +195,8 @@ This tool works in phases, as follows:
     Finally, if the "--output <filename>" option is specified, the resulting
     OTIO will be written to the specified file. The extension of the output
     filename is used to determine the format of the output (e.g. OTIO or any
-    format supported by the adapter plugins.)
+    format supported by the adapter plugins.) If you need to output an older
+    schema version, see the --downgrade option.
 """.strip(),
         epilog="""Examples:
 
@@ -369,6 +377,18 @@ otiotool -i playlist.otio --only-audio --list-tracks --inspect "Interview"
     )
 
     # Output...
+    parser.add_argument(
+        "--downgrade",
+        type=str,
+        metavar='FAMILY:VERSION',
+        help="""Downgrade OTIO schema. Only relevant when --output is used
+        to output an OTIO file. FAMILY:VERSION specifies which schema family
+        and version to use. If FAMILY: is omitted, the default OTIO_CORE: is
+        used. For example `--downgrade OTIO_CORE:0.14.0` is equivalent to
+        `--downgrade 0.14.0`. See the OpenTimelineIO documentation for 
+        OTIO_DEFAULT_TARGET_VERSION_FAMILY_LABEL for details."""
+    )
+
     parser.add_argument(
         "-o",
         "--output",


### PR DESCRIPTION
This PR adds a `--downgrade` option to `otiotool` to make it easy to write out an older OTIO schema.

From the usage statement:
```
  --downgrade FAMILY:VERSION
                        Downgrade OTIO schema. Only relevant when --output is used to output an OTIO file. FAMILY:VERSION specifies which
                        schema family and version to use. If FAMILY: is omitted, the default OTIO_CORE: is used. For example `--downgrade
                        OTIO_CORE:0.14.0` is equivalent to `--downgrade 0.14.0`. See the OpenTimelineIO documentation for
                        OTIO_DEFAULT_TARGET_VERSION_FAMILY_LABEL for details.
```

Example:
```
otiotool -i new_file.otio --downgrade 0.14.0 -o old_file.otio
```

It uses the downgrade mechanism [documented here](https://opentimelineio.readthedocs.io/en/latest/tutorials/versioning-schemas.html#downgrading-at-runtime).