### PR TITLE
Prepare baseline plugin_manifest.json for removal of the cmx_3600 adapter

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,9 +2,9 @@ name: docs
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, extract_adapters ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, extract_adapters ]
 
 jobs:
   check-links:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,9 +11,9 @@ env:
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, extract_adapters ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, extract_adapters ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/tests/baselines/plugin_module/otio_override_adapter/plugin_manifest.json
+++ b/tests/baselines/plugin_module/otio_override_adapter/plugin_manifest.json
@@ -3,9 +3,9 @@
     "adapters": [
         {
             "OTIO_SCHEMA" : "Adapter.1",
-            "name" : "otio_json",
+            "name" : "otiod",
             "filepath" : "adapter.py",
-            "suffixes" : ["otio"]
+            "suffixes" : ["otiod"]
         }
     ]
 }

--- a/tests/baselines/plugin_module/otio_override_adapter/plugin_manifest.json
+++ b/tests/baselines/plugin_module/otio_override_adapter/plugin_manifest.json
@@ -3,9 +3,9 @@
     "adapters": [
         {
             "OTIO_SCHEMA" : "Adapter.1",
-            "name" : "cmx_3600",
+            "name" : "otio_json",
             "filepath" : "adapter.py",
-            "suffixes" : ["edl"]
+            "suffixes" : ["otio"]
         }
     ]
 }

--- a/tests/test_plugin_detection.py
+++ b/tests/test_plugin_detection.py
@@ -83,11 +83,11 @@ class TestSetuptoolsPlugin(unittest.TestCase):
         # Test that entrypoint plugins load before builtin and contrib
         man = otio.plugins.manifest.load_manifest()
 
-        # The override_adapter creates another cmx_3600 adapter
+        # The override_adapter creates another otiod adapter
         adapters = [adapter for adapter in man.adapters
-                    if adapter.name == "cmx_3600"]
+                    if adapter.name == "otiod"]
 
-        # More then one cmx_3600 adapter should exist.
+        # More then one otiod adapter should exist.
         self.assertTrue(len(adapters) > 1)
 
         # Override adapter should be the first adapter found


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**

This is part of the #1386 issue, preparing for extraction of cmx_3600 adapter

Replaced "cmx_3600" with "otio_json" in **tests/baselines/plugin_module/otio_override_adapter/plugin_manifest.json** to prevent failing tests when we extract the adapter


<!--
Important: If this is your first contribution to OpenTimelineIO, you will need to submit a Contributor License Agreement. For a step-by-step instructions on the pull request process, see
https://github.com/AcademySoftwareFoundation/OpenTimelineIO/tree/main/CONTRIBUTING.md
-->

Signed-off-by: apetrynet <flehnerheener@gmail.com>
