### PR TITLE
Use duration() as a virtual function

### DIFF
--- a/src/opentimelineio/composable.cpp
+++ b/src/opentimelineio/composable.cpp
@@ -66,7 +66,10 @@ Composable::duration(ErrorStatus* error_status) const
 {
     if (error_status)
     {
-        *error_status = ErrorStatus::NOT_IMPLEMENTED;
+        *error_status = ErrorStatus(
+            ErrorStatus::OBJECT_WITHOUT_DURATION,
+            "Cannot determine duration from this kind of object",
+            this);
     }
     return RationalTime();
 }

--- a/src/opentimelineio/item.h
+++ b/src/opentimelineio/item.h
@@ -61,7 +61,7 @@ public:
         return _markers;
     }
 
-    virtual RationalTime duration(ErrorStatus* error_status = nullptr) const;
+    virtual RationalTime duration(ErrorStatus* error_status = nullptr) const override;
 
     virtual TimeRange
     available_range(ErrorStatus* error_status = nullptr) const;

--- a/src/opentimelineio/track.cpp
+++ b/src/opentimelineio/track.cpp
@@ -41,30 +41,6 @@ Track::write_to(Writer& writer) const
     writer.write("kind", _kind);
 }
 
-static RationalTime
-_safe_duration(Composable* c, ErrorStatus* error_status)
-{
-    if (auto item = dynamic_cast<Item*>(c))
-    {
-        return item->duration(error_status);
-    }
-    else if (auto transition = dynamic_cast<Transition*>(c))
-    {
-        return transition->duration(error_status);
-    }
-    else
-    {
-        if (error_status)
-        {
-            *error_status = ErrorStatus(
-                ErrorStatus::OBJECT_WITHOUT_DURATION,
-                "Cannot determine duration from this kind of object",
-                c);
-        }
-        return RationalTime();
-    }
-}
-
 TimeRange
 Track::range_of_child_at_index(int index, ErrorStatus* error_status) const
 {
@@ -79,7 +55,7 @@ Track::range_of_child_at_index(int index, ErrorStatus* error_status) const
     }
 
     Composable*  child          = children()[index];
-    RationalTime child_duration = _safe_duration(child, error_status);
+    RationalTime child_duration = child->duration(error_status);
     if (is_error(error_status))
     {
         return TimeRange();
@@ -92,7 +68,7 @@ Track::range_of_child_at_index(int index, ErrorStatus* error_status) const
         Composable* child2 = children()[i];
         if (!child2->overlapping())
         {
-            start_time += _safe_duration(children()[i], error_status);
+            start_time += children()[i]->duration(error_status);
         }
         if (is_error(error_status))
         {

--- a/src/opentimelineio/transition.h
+++ b/src/opentimelineio/transition.h
@@ -55,8 +55,7 @@ public:
         _out_offset = out_offset;
     }
 
-    // XX is this virtual?
-    virtual RationalTime duration(ErrorStatus* error_status = nullptr) const;
+    virtual RationalTime duration(ErrorStatus* error_status = nullptr) const override;
 
     optional<TimeRange>
     range_in_parent(ErrorStatus* error_status = nullptr) const;


### PR DESCRIPTION
Fixes #1513

I noticed a helper function ```_safe_duration()``` that was  dynamically casting a ```Composable``` just to call the function ```duration()```. This isn't necessary since ```duration()``` is a virtual function of ```Composable```. The function ```_safe_duration()``` could be removed and replaced with calls to ```duration()```.