### PR TITLE
Use the C++ override keyword

### DIFF
--- a/src/opentimelineio/clip.h
+++ b/src/opentimelineio/clip.h
@@ -45,17 +45,17 @@ public:
                std::string const& new_active_key,
                ErrorStatus*       error_status = nullptr) noexcept;
 
-    virtual TimeRange
-    available_range(ErrorStatus* error_status = nullptr) const;
+    TimeRange
+    available_range(ErrorStatus* error_status = nullptr) const override;
 
-    virtual optional<Imath::Box2d>
-    available_image_bounds(ErrorStatus* error_status) const;
+    optional<Imath::Box2d>
+    available_image_bounds(ErrorStatus* error_status) const override;
 
 protected:
-    virtual ~Clip();
+    ~Clip() override;
 
-    virtual bool read_from(Reader&);
-    virtual void write_to(Writer&) const;
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
 
 private:
     template <typename MediaRefMap>

--- a/src/opentimelineio/clip.h
+++ b/src/opentimelineio/clip.h
@@ -52,7 +52,7 @@ public:
     available_image_bounds(ErrorStatus* error_status) const override;
 
 protected:
-    ~Clip() override;
+    virtual ~Clip();
 
     bool read_from(Reader&) override;
     void write_to(Writer&) const override;

--- a/src/opentimelineio/composable.h
+++ b/src/opentimelineio/composable.h
@@ -46,7 +46,7 @@ protected:
         return const_cast<Composable*>(this)->_highest_ancestor();
     }
 
-    ~Composable() override;
+    virtual ~Composable();
 
     bool read_from(Reader&) override;
     void write_to(Writer&) const override;

--- a/src/opentimelineio/composable.h
+++ b/src/opentimelineio/composable.h
@@ -46,10 +46,10 @@ protected:
         return const_cast<Composable*>(this)->_highest_ancestor();
     }
 
-    virtual ~Composable();
+    ~Composable() override;
 
-    virtual bool read_from(Reader&);
-    virtual void write_to(Writer&) const;
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
 
 private:
     Composition* _parent;

--- a/src/opentimelineio/composition.h
+++ b/src/opentimelineio/composition.h
@@ -113,7 +113,7 @@ public:
         bool                shallow_search = false) const;
 
 protected:
-    ~Composition() override;
+    virtual ~Composition();
 
     bool read_from(Reader&) override;
     void write_to(Writer&) const override;

--- a/src/opentimelineio/composition.h
+++ b/src/opentimelineio/composition.h
@@ -113,10 +113,10 @@ public:
         bool                shallow_search = false) const;
 
 protected:
-    virtual ~Composition();
+    ~Composition() override;
 
-    virtual bool read_from(Reader&);
-    virtual void write_to(Writer&) const;
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
 
     int _index_of_child(
         Composable const* child,

--- a/src/opentimelineio/effect.h
+++ b/src/opentimelineio/effect.h
@@ -32,7 +32,7 @@ public:
     }
 
 protected:
-    ~Effect() override;
+    virtual ~Effect();
 
     bool read_from(Reader&) override;
     void write_to(Writer&) const override;

--- a/src/opentimelineio/effect.h
+++ b/src/opentimelineio/effect.h
@@ -32,10 +32,10 @@ public:
     }
 
 protected:
-    virtual ~Effect();
+    ~Effect() override;
 
-    virtual bool read_from(Reader&);
-    virtual void write_to(Writer&) const;
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
 
 private:
     std::string _effect_name;

--- a/src/opentimelineio/externalReference.h
+++ b/src/opentimelineio/externalReference.h
@@ -33,7 +33,7 @@ public:
     }
 
 protected:
-    ~ExternalReference() override;
+    virtual ~ExternalReference();
 
     bool read_from(Reader&) override;
     void write_to(Writer&) const override;

--- a/src/opentimelineio/externalReference.h
+++ b/src/opentimelineio/externalReference.h
@@ -33,10 +33,10 @@ public:
     }
 
 protected:
-    virtual ~ExternalReference();
+    ~ExternalReference() override;
 
-    virtual bool read_from(Reader&);
-    virtual void write_to(Writer&) const;
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
 
 private:
     std::string _target_url;

--- a/src/opentimelineio/freezeFrame.h
+++ b/src/opentimelineio/freezeFrame.h
@@ -24,9 +24,7 @@ public:
         AnyDictionary const& metadata = AnyDictionary());
 
 protected:
-    virtual ~FreezeFrame();
-
-private:
+    ~FreezeFrame() override;
 };
 
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/freezeFrame.h
+++ b/src/opentimelineio/freezeFrame.h
@@ -24,7 +24,7 @@ public:
         AnyDictionary const& metadata = AnyDictionary());
 
 protected:
-    ~FreezeFrame() override;
+    virtual ~FreezeFrame();
 };
 
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/gap.h
+++ b/src/opentimelineio/gap.h
@@ -32,13 +32,13 @@ public:
         std::vector<Marker*> const& markers  = std::vector<Marker*>(),
         AnyDictionary const&        metadata = AnyDictionary());
 
-    virtual bool visible() const;
+    bool visible() const override;
 
 protected:
-    virtual ~Gap();
+    ~Gap() override;
 
-    virtual bool read_from(Reader&);
-    virtual void write_to(Writer&) const;
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
 
 private:
 };

--- a/src/opentimelineio/gap.h
+++ b/src/opentimelineio/gap.h
@@ -35,7 +35,7 @@ public:
     bool visible() const override;
 
 protected:
-    ~Gap() override;
+    virtual ~Gap();
 
     bool read_from(Reader&) override;
     void write_to(Writer&) const override;

--- a/src/opentimelineio/gap.h
+++ b/src/opentimelineio/gap.h
@@ -39,8 +39,6 @@ protected:
 
     bool read_from(Reader&) override;
     void write_to(Writer&) const override;
-
-private:
 };
 
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/generatorReference.h
+++ b/src/opentimelineio/generatorReference.h
@@ -39,10 +39,10 @@ public:
     AnyDictionary parameters() const noexcept { return _parameters; }
 
 protected:
-    virtual ~GeneratorReference();
+    ~GeneratorReference() override;
 
-    virtual bool read_from(Reader&);
-    virtual void write_to(Writer&) const;
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
 
 private:
     std::string   _generator_kind;

--- a/src/opentimelineio/generatorReference.h
+++ b/src/opentimelineio/generatorReference.h
@@ -39,7 +39,7 @@ public:
     AnyDictionary parameters() const noexcept { return _parameters; }
 
 protected:
-    ~GeneratorReference() override;
+    virtual ~GeneratorReference();
 
     bool read_from(Reader&) override;
     void write_to(Writer&) const override;

--- a/src/opentimelineio/imageSequenceReference.h
+++ b/src/opentimelineio/imageSequenceReference.h
@@ -109,10 +109,10 @@ public:
         ErrorStatus* error_status = nullptr) const;
 
 protected:
-    virtual ~ImageSequenceReference();
+    ~ImageSequenceReference() override;
 
-    virtual bool read_from(Reader&);
-    virtual void write_to(Writer&) const;
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
 
 private:
     std::string        _target_url_base;

--- a/src/opentimelineio/imageSequenceReference.h
+++ b/src/opentimelineio/imageSequenceReference.h
@@ -109,7 +109,7 @@ public:
         ErrorStatus* error_status = nullptr) const;
 
 protected:
-    ~ImageSequenceReference() override;
+    virtual ~ImageSequenceReference();
 
     bool read_from(Reader&) override;
     void write_to(Writer&) const override;

--- a/src/opentimelineio/item.h
+++ b/src/opentimelineio/item.h
@@ -89,7 +89,7 @@ public:
         ErrorStatus* error_status = nullptr) const;
 
 protected:
-    ~Item() override;
+    virtual ~Item();
 
     bool read_from(Reader&) override;
     void write_to(Writer&) const override;

--- a/src/opentimelineio/item.h
+++ b/src/opentimelineio/item.h
@@ -63,8 +63,8 @@ public:
 
     RationalTime duration(ErrorStatus* error_status = nullptr) const override;
 
-    TimeRange
-    virtual available_range(ErrorStatus* error_status = nullptr) const;
+    virtual TimeRange
+    available_range(ErrorStatus* error_status = nullptr) const;
 
     TimeRange trimmed_range(ErrorStatus* error_status = nullptr) const
     {

--- a/src/opentimelineio/item.h
+++ b/src/opentimelineio/item.h
@@ -33,8 +33,8 @@ public:
         std::vector<Marker*> const& markers      = std::vector<Marker*>(),
         bool                        enabled      = true);
 
-    virtual bool visible() const;
-    virtual bool overlapping() const;
+    bool visible() const override;
+    bool overlapping() const override;
 
     bool enabled() const { return _enabled; };
 
@@ -61,10 +61,10 @@ public:
         return _markers;
     }
 
-    virtual RationalTime duration(ErrorStatus* error_status = nullptr) const override;
+    RationalTime duration(ErrorStatus* error_status = nullptr) const override;
 
-    virtual TimeRange
-    available_range(ErrorStatus* error_status = nullptr) const;
+    TimeRange
+    virtual available_range(ErrorStatus* error_status = nullptr) const;
 
     TimeRange trimmed_range(ErrorStatus* error_status = nullptr) const
     {
@@ -89,10 +89,10 @@ public:
         ErrorStatus* error_status = nullptr) const;
 
 protected:
-    virtual ~Item();
+    ~Item() override;
 
-    virtual bool read_from(Reader&);
-    virtual void write_to(Writer&) const;
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
 
 private:
     optional<TimeRange>           _source_range;

--- a/src/opentimelineio/linearTimeWarp.h
+++ b/src/opentimelineio/linearTimeWarp.h
@@ -33,10 +33,10 @@ public:
     }
 
 protected:
-    virtual ~LinearTimeWarp();
+    ~LinearTimeWarp() override;
 
-    virtual bool read_from(Reader&);
-    virtual void write_to(Writer&) const;
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
 
 private:
     double _time_scalar;

--- a/src/opentimelineio/linearTimeWarp.h
+++ b/src/opentimelineio/linearTimeWarp.h
@@ -33,7 +33,7 @@ public:
     }
 
 protected:
-    ~LinearTimeWarp() override;
+    virtual ~LinearTimeWarp();
 
     bool read_from(Reader&) override;
     void write_to(Writer&) const override;

--- a/src/opentimelineio/marker.h
+++ b/src/opentimelineio/marker.h
@@ -52,7 +52,7 @@ public:
     }
 
 protected:
-    ~Marker() override;
+    virtual ~Marker();
 
     bool read_from(Reader&) override;
     void write_to(Writer&) const override;

--- a/src/opentimelineio/marker.h
+++ b/src/opentimelineio/marker.h
@@ -52,10 +52,10 @@ public:
     }
 
 protected:
-    virtual ~Marker();
+    ~Marker() override;
 
-    virtual bool read_from(Reader&);
-    virtual void write_to(Writer&) const;
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
 
 private:
     std::string _color;

--- a/src/opentimelineio/mediaReference.h
+++ b/src/opentimelineio/mediaReference.h
@@ -53,10 +53,10 @@ public:
     }
 
 protected:
-    virtual ~MediaReference();
+    ~MediaReference() override;
 
-    virtual bool read_from(Reader&);
-    virtual void write_to(Writer&) const;
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
 
 private:
     optional<TimeRange>    _available_range;

--- a/src/opentimelineio/mediaReference.h
+++ b/src/opentimelineio/mediaReference.h
@@ -53,7 +53,7 @@ public:
     }
 
 protected:
-    ~MediaReference() override;
+    virtual ~MediaReference();
 
     bool read_from(Reader&) override;
     void write_to(Writer&) const override;

--- a/src/opentimelineio/missingReference.h
+++ b/src/opentimelineio/missingReference.h
@@ -25,13 +25,13 @@ public:
         AnyDictionary const&          metadata               = AnyDictionary(),
         optional<Imath::Box2d> const& available_image_bounds = nullopt);
 
-    virtual bool is_missing_reference() const;
+    bool is_missing_reference() const override;
 
 protected:
-    virtual ~MissingReference();
+    ~MissingReference() override;
 
-    virtual bool read_from(Reader&);
-    virtual void write_to(Writer&) const;
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
 };
 
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/missingReference.h
+++ b/src/opentimelineio/missingReference.h
@@ -28,7 +28,7 @@ public:
     bool is_missing_reference() const override;
 
 protected:
-    ~MissingReference() override;
+    virtual ~MissingReference();
 
     bool read_from(Reader&) override;
     void write_to(Writer&) const override;

--- a/src/opentimelineio/serializableCollection.h
+++ b/src/opentimelineio/serializableCollection.h
@@ -74,10 +74,10 @@ public:
         bool                shallow_search = false) const;
 
 protected:
-    virtual ~SerializableCollection();
+    ~SerializableCollection() override;
 
-    virtual bool read_from(Reader&);
-    virtual void write_to(Writer&) const;
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
 
 private:
     std::vector<Retainer<SerializableObject>> _children;

--- a/src/opentimelineio/serializableCollection.h
+++ b/src/opentimelineio/serializableCollection.h
@@ -74,7 +74,7 @@ public:
         bool                shallow_search = false) const;
 
 protected:
-    ~SerializableCollection() override;
+    virtual ~SerializableCollection();
 
     bool read_from(Reader&) override;
     void write_to(Writer&) const override;

--- a/src/opentimelineio/serializableObject.h
+++ b/src/opentimelineio/serializableObject.h
@@ -626,6 +626,7 @@ public:
 
 protected:
     virtual ~SerializableObject();
+
     virtual bool _is_deletable();
 
     virtual std::string _schema_name_for_reference() const;

--- a/src/opentimelineio/serializableObject.h
+++ b/src/opentimelineio/serializableObject.h
@@ -628,13 +628,13 @@ protected:
     virtual ~SerializableObject();
     virtual bool _is_deletable();
 
+    virtual std::string _schema_name_for_reference() const;
+
 private:
     SerializableObject(SerializableObject const&)            = delete;
     SerializableObject& operator=(SerializableObject const&) = delete;
     template <typename T>
     friend struct Retainer;
-
-    virtual std::string _schema_name_for_reference() const;
 
     void _managed_retain();
     void _managed_release();

--- a/src/opentimelineio/serializableObjectWithMetadata.h
+++ b/src/opentimelineio/serializableObjectWithMetadata.h
@@ -32,9 +32,10 @@ public:
     AnyDictionary metadata() const noexcept { return _metadata; }
 
 protected:
-    ~SerializableObjectWithMetadata();
-    virtual bool read_from(Reader&);
-    virtual void write_to(Writer&) const;
+    ~SerializableObjectWithMetadata() override;
+    
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
 
 private:
     std::string   _name;

--- a/src/opentimelineio/serializableObjectWithMetadata.h
+++ b/src/opentimelineio/serializableObjectWithMetadata.h
@@ -32,7 +32,7 @@ public:
     AnyDictionary metadata() const noexcept { return _metadata; }
 
 protected:
-    ~SerializableObjectWithMetadata() override;
+    virtual ~SerializableObjectWithMetadata();
     
     bool read_from(Reader&) override;
     void write_to(Writer&) const override;

--- a/src/opentimelineio/stack.h
+++ b/src/opentimelineio/stack.h
@@ -28,20 +28,20 @@ public:
         std::vector<Effect*> const& effects      = std::vector<Effect*>(),
         std::vector<Marker*> const& markers      = std::vector<Marker*>());
 
-    virtual TimeRange range_of_child_at_index(
+    TimeRange range_of_child_at_index(
         int          index,
-        ErrorStatus* error_status = nullptr) const;
-    virtual TimeRange trimmed_range_of_child_at_index(
+        ErrorStatus* error_status = nullptr) const override;
+    TimeRange trimmed_range_of_child_at_index(
         int          index,
-        ErrorStatus* error_status = nullptr) const;
-    virtual TimeRange
-    available_range(ErrorStatus* error_status = nullptr) const;
+        ErrorStatus* error_status = nullptr) const override;
+    TimeRange
+    available_range(ErrorStatus* error_status = nullptr) const override;
 
-    virtual std::map<Composable*, TimeRange>
-    range_of_all_children(ErrorStatus* error_status = nullptr) const;
+    std::map<Composable*, TimeRange>
+    range_of_all_children(ErrorStatus* error_status = nullptr) const override;
 
     optional<Imath::Box2d>
-    available_image_bounds(ErrorStatus* error_status) const;
+    available_image_bounds(ErrorStatus* error_status) const override;
 
     // Find child clips.
     //
@@ -54,14 +54,12 @@ public:
         bool                       shallow_search = false) const;
 
 protected:
-    virtual ~Stack();
+    ~Stack() override;
 
-    virtual std::string composition_kind() const;
+    std::string composition_kind() const override;
 
-    virtual bool read_from(Reader&);
-    virtual void write_to(Writer&) const;
-
-private:
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
 };
 
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/stack.h
+++ b/src/opentimelineio/stack.h
@@ -54,7 +54,7 @@ public:
         bool                       shallow_search = false) const;
 
 protected:
-    ~Stack() override;
+    virtual ~Stack();
 
     std::string composition_kind() const override;
 

--- a/src/opentimelineio/timeEffect.h
+++ b/src/opentimelineio/timeEffect.h
@@ -25,7 +25,7 @@ public:
         AnyDictionary const& metadata    = AnyDictionary());
 
 protected:
-    ~TimeEffect() override;
+    virtual ~TimeEffect();
 };
 
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/timeEffect.h
+++ b/src/opentimelineio/timeEffect.h
@@ -25,7 +25,7 @@ public:
         AnyDictionary const& metadata    = AnyDictionary());
 
 protected:
-    virtual ~TimeEffect();
+    ~TimeEffect() override;
 };
 
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/timeline.h
+++ b/src/opentimelineio/timeline.h
@@ -90,7 +90,7 @@ public:
     }
 
 protected:
-    ~Timeline() override;
+    virtual ~Timeline();
 
     bool read_from(Reader&) override;
     void write_to(Writer&) const override;

--- a/src/opentimelineio/timeline.h
+++ b/src/opentimelineio/timeline.h
@@ -90,10 +90,10 @@ public:
     }
 
 protected:
-    virtual ~Timeline();
+    ~Timeline() override;
 
-    virtual bool read_from(Reader&);
-    virtual void write_to(Writer&) const;
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
 
 private:
     optional<RationalTime> _global_start_time;

--- a/src/opentimelineio/track.h
+++ b/src/opentimelineio/track.h
@@ -79,7 +79,8 @@ public:
         bool                       shallow_search = false) const;
 
 protected:
-    ~Track() override;
+    virtual ~Track();
+
     std::string composition_kind() const override;
 
     bool read_from(Reader&) override;

--- a/src/opentimelineio/track.h
+++ b/src/opentimelineio/track.h
@@ -43,30 +43,30 @@ public:
 
     void set_kind(std::string const& kind) { _kind = kind; }
 
-    virtual TimeRange range_of_child_at_index(
+    TimeRange range_of_child_at_index(
         int          index,
-        ErrorStatus* error_status = nullptr) const;
-    virtual TimeRange trimmed_range_of_child_at_index(
+        ErrorStatus* error_status = nullptr) const override;
+    TimeRange trimmed_range_of_child_at_index(
         int          index,
-        ErrorStatus* error_status = nullptr) const;
-    virtual TimeRange
-    available_range(ErrorStatus* error_status = nullptr) const;
+        ErrorStatus* error_status = nullptr) const override;
+    TimeRange
+    available_range(ErrorStatus* error_status = nullptr) const override;
 
-    virtual std::pair<optional<RationalTime>, optional<RationalTime>>
+    std::pair<optional<RationalTime>, optional<RationalTime>>
     handles_of_child(
         Composable const* child,
-        ErrorStatus*      error_status = nullptr) const;
+        ErrorStatus*      error_status = nullptr) const override;
 
     std::pair<Retainer<Composable>, Retainer<Composable>> neighbors_of(
         Composable const* item,
         ErrorStatus*      error_status = nullptr,
         NeighborGapPolicy insert_gap   = NeighborGapPolicy::never) const;
 
-    virtual std::map<Composable*, TimeRange>
-    range_of_all_children(ErrorStatus* error_status = nullptr) const;
+    std::map<Composable*, TimeRange>
+    range_of_all_children(ErrorStatus* error_status = nullptr) const override;
 
     optional<Imath::Box2d>
-    available_image_bounds(ErrorStatus* error_status) const;
+    available_image_bounds(ErrorStatus* error_status) const override;
 
     // Find child clips.
     //
@@ -79,11 +79,11 @@ public:
         bool                       shallow_search = false) const;
 
 protected:
-    virtual ~Track();
-    virtual std::string composition_kind() const;
+    ~Track() override;
+    std::string composition_kind() const override;
 
-    virtual bool read_from(Reader&);
-    virtual void write_to(Writer&) const;
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
 
 private:
     std::string _kind;

--- a/src/opentimelineio/transition.h
+++ b/src/opentimelineio/transition.h
@@ -32,7 +32,7 @@ public:
         RationalTime         out_offset      = RationalTime(),
         AnyDictionary const& metadata        = AnyDictionary());
 
-    virtual bool overlapping() const;
+    bool overlapping() const override;
 
     std::string transition_type() const noexcept { return _transition_type; }
 
@@ -55,7 +55,7 @@ public:
         _out_offset = out_offset;
     }
 
-    virtual RationalTime duration(ErrorStatus* error_status = nullptr) const override;
+    RationalTime duration(ErrorStatus* error_status = nullptr) const override;
 
     optional<TimeRange>
     range_in_parent(ErrorStatus* error_status = nullptr) const;
@@ -64,10 +64,10 @@ public:
     trimmed_range_in_parent(ErrorStatus* error_status = nullptr) const;
 
 protected:
-    virtual ~Transition();
+    ~Transition() override;
 
-    virtual bool read_from(Reader&);
-    virtual void write_to(Writer&) const;
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
 
 private:
     std::string  _transition_type;

--- a/src/opentimelineio/transition.h
+++ b/src/opentimelineio/transition.h
@@ -64,7 +64,7 @@ public:
     trimmed_range_in_parent(ErrorStatus* error_status = nullptr) const;
 
 protected:
-    ~Transition() override;
+    virtual ~Transition();
 
     bool read_from(Reader&) override;
     void write_to(Writer&) const override;

--- a/src/opentimelineio/unknownSchema.h
+++ b/src/opentimelineio/unknownSchema.h
@@ -37,7 +37,7 @@ public:
     bool is_unknown_schema() const override;
 
 protected:
-    ~UnknownSchema() override;
+    virtual ~UnknownSchema();
 
     std::string _schema_name_for_reference() const override;
 

--- a/src/opentimelineio/unknownSchema.h
+++ b/src/opentimelineio/unknownSchema.h
@@ -31,16 +31,17 @@ public:
         return _original_schema_version;
     }
 
-    virtual bool read_from(Reader&);
-    virtual void write_to(Writer&) const;
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
 
-    virtual bool is_unknown_schema() const;
+    bool is_unknown_schema() const override;
+
+protected:
+    ~UnknownSchema() override;
+
+    std::string _schema_name_for_reference() const override;
 
 private:
-    virtual ~UnknownSchema();
-
-    virtual std::string _schema_name_for_reference() const;
-
     std::string _original_schema_name;
     int         _original_schema_version;
 


### PR DESCRIPTION
Signed-off-by: Darby Johnston <darbyjohnston@yahoo.com>

Fixes #1542

In C++11 the "override" keyword was added which checks at compile time whether a virtual function has been properly overridden. This can catch bugs from typos in derived classes and ensures that base class destructors are marked virtual. Some interesting discussion here, especially on whether destructors should use "override":
https://github.com/isocpp/CppCoreGuidelines/issues/721

Some compilers (e.g., the latest Xcode) now emit warnings for this:
```
/Users/darby/Dev/otio/OpenTimelineIO/src/opentimelineio/item.h:36:18: warning: 'visible' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    virtual bool visible() const;
```


This PR changes:
* Use the "override" keyword on all functions that override a virtual function in a base class
* Make the virtual function SerializableObject::_schema_name_for_reference() protected instead of private
* Make the functions UnknownSchema::~ UnknownSchema() and UnknownSchema::_schema_name_for_reference() protected instead of private