### PR TITLE
Fix unset __doc__ concatenation error

### DIFF
--- a/src/py-opentimelineio/opentimelineio/core/_core_utils.py
+++ b/src/py-opentimelineio/opentimelineio/core/_core_utils.py
@@ -177,7 +177,9 @@ def _add_mutable_mapping_methods(mapClass):
 
                 # Hide the method frm Sphinx doc.
                 # See https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#info-field-lists  # noqa
-                getattr(mapClass, name).__doc__ += '\n\n:meta private:'
+                getattr(mapClass, name).__doc__ = "{}\n\n:meta private:".format(
+                    getattr(mapClass, name).__doc__ or ""
+                )
 
     mapClass.setdefault = setdefault
     mapClass.pop = pop
@@ -329,7 +331,9 @@ def _add_mutable_sequence_methods(
 
                     # Hide the method frm Sphinx doc.
                     # See https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#info-field-lists  # noqa
-                    getattr(sequenceClass, name).__doc__ += '\n\n:meta private:'
+                    getattr(sequenceClass, name).__doc__ = "{}\n\n:meta private:".format(
+                        getattr(sequenceClass, name).__doc__ or ""
+                    )
 
     if not issubclass(sequenceClass, SerializableObject):
         def __copy__(self):


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**

```Fixes #1548 ```

**Summarize your change.**

Embed-able Python distributions (at least python 3.7 and 3.9) ship with only byte-code compiled versions of their
built-in modules. As a result, the docstrings of classes, methods will not be set (ie. \_\_doc\_\_ will be set to None)

git commit  https://github.com/AcademySoftwareFoundation/OpenTimelineIO/commit/d48163e464cd37ae272d98ef5dca0c804f840475 introduced a change to exclude external functions (namely from `collections_abc`) from the OTIO sphinx documentation by appending a tag to the \_\_doc\_\_ string. However the code assumes that \_\_doc\_\_ is always set to a string.

On embedded python this will result in a crash with the following error:
```
C:\Users\robsz\AppData\Local\Programs\al-editron-beta\resources\python>dist\python.exe -c "import opentimelineio"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Users\robsz\AppData\Local\Programs\al-editron-beta\resources\python\dist\dependencies\opentimelineio\__init__.py", line 14, in <module>
    from . import (
  File "C:\Users\robsz\AppData\Local\Programs\al-editron-beta\resources\python\dist\dependencies\opentimelineio\core\__init__.py", line 35, in <module>
    from . _core_utils import ( # noqa
  File "C:\Users\robsz\AppData\Local\Programs\al-editron-beta\resources\python\dist\dependencies\opentimelineio\core\_core_utils.py", line 407, in <module>
    _add_mutable_mapping_methods(AnyDictionary)
  File "C:\Users\robsz\AppData\Local\Programs\al-editron-beta\resources\python\dist\dependencies\opentimelineio\core\_core_utils.py", line 239, in _add_mutable_mapping_methods
    getattr(mapClass, name).__doc__ += '\n\n:meta private:'
TypeError: unsupported operand type(s) for +=: 'NoneType' and 'str'
```

**Reference associated tests.**

None
