### PR TITLE
Make serialize_json_to_string output compact when indent is less than 1

### DIFF
--- a/src/opentimelineio/serialization.cpp
+++ b/src/opentimelineio/serialization.cpp
@@ -1232,10 +1232,7 @@ serialize_json_to_string_pretty(
         OTIO_rapidjson::kWriteNanAndInfFlag>
         json_writer(output_string_buffer);
 
-    if (indent >= 0)
-    {
-        json_writer.SetIndent(' ', indent);
-    }
+    json_writer.SetIndent(' ', indent);
 
     JSONEncoder<decltype(json_writer)> json_encoder(json_writer);
 
@@ -1256,8 +1253,7 @@ std::string
 serialize_json_to_string_compact(
     const any&                value,
     const schema_version_map* schema_version_targets,
-    ErrorStatus*              error_status,
-    int                       indent)
+    ErrorStatus*              error_status)
 {
     OTIO_rapidjson::StringBuffer output_string_buffer;
 
@@ -1302,8 +1298,7 @@ serialize_json_to_string(
     return serialize_json_to_string_compact(
         value,
         schema_version_targets,
-        error_status,
-        indent);
+        error_status);
 }
 
 bool

--- a/src/opentimelineio/serialization.cpp
+++ b/src/opentimelineio/serialization.cpp
@@ -1216,7 +1216,7 @@ SerializableObject::clone(ErrorStatus* error_status) const
 
 // to json_string
 std::string
-serialize_json_to_string(
+serialize_json_to_string_pretty(
     const any&                value,
     const schema_version_map* schema_version_targets,
     ErrorStatus*              error_status,
@@ -1249,6 +1249,61 @@ serialize_json_to_string(
     }
 
     return std::string(output_string_buffer.GetString());
+}
+
+// to json_string
+std::string
+serialize_json_to_string_compact(
+    const any&                value,
+    const schema_version_map* schema_version_targets,
+    ErrorStatus*              error_status,
+    int                       indent)
+{
+    OTIO_rapidjson::StringBuffer output_string_buffer;
+
+    OTIO_rapidjson::Writer<
+        decltype(output_string_buffer),
+        OTIO_rapidjson::UTF8<>,
+        OTIO_rapidjson::UTF8<>,
+        OTIO_rapidjson::CrtAllocator,
+        OTIO_rapidjson::kWriteNanAndInfFlag>
+        json_writer(output_string_buffer);
+
+    JSONEncoder<decltype(json_writer)> json_encoder(json_writer);
+
+    if (!SerializableObject::Writer::write_root(
+            value,
+            json_encoder,
+            schema_version_targets,
+            error_status))
+    {
+        return std::string();
+    }
+
+    return std::string(output_string_buffer.GetString());
+}
+
+// to json_string
+std::string
+serialize_json_to_string(
+    const any&                value,
+    const schema_version_map* schema_version_targets,
+    ErrorStatus*              error_status,
+    int                       indent)
+{
+    if (indent > 0)
+    {
+        return serialize_json_to_string_pretty(
+            value,
+            schema_version_targets,
+            error_status,
+            indent);
+    }
+    return serialize_json_to_string_compact(
+        value,
+        schema_version_targets,
+        error_status,
+        indent);
 }
 
 bool

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,7 +15,7 @@ foreach(test ${tests_opentime})
            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endforeach()
 
-list(APPEND tests_opentimelineio test_clip test_serializableCollection test_timeline test_track)
+list(APPEND tests_opentimelineio test_clip test_serialization test_serializableCollection test_timeline test_track)
 foreach(test ${tests_opentimelineio})
     add_executable(${test} utils.h utils.cpp ${test}.cpp)
 

--- a/tests/test_serialization.cpp
+++ b/tests/test_serialization.cpp
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Contributors to the OpenTimelineIO project
+
+#include "utils.h"
+
+#include <opentimelineio/clip.h>
+#include <opentimelineio/timeline.h>
+#include <opentimelineio/track.h>
+#include <opentimelineio/serialization.h>
+#include <opentimelineio/serializableObject.h>
+#include <opentimelineio/serializableObjectWithMetadata.h>
+#include <opentimelineio/safely_typed_any.h>
+
+#include <iostream>
+#include <string>
+
+namespace otime = opentime::OPENTIME_VERSION;
+namespace otio  = opentimelineio::OPENTIMELINEIO_VERSION;
+
+int
+main(int argc, char** argv)
+{
+    Tests tests;
+
+    tests.add_test(
+        "success with default indent", [] {
+        otio::SerializableObject::Retainer<otio::Clip> cl =
+            new otio::Clip();
+        otio::SerializableObject::Retainer<otio::Track> tr =
+            new otio::Track();
+        tr->append_child(cl);
+        otio::SerializableObject::Retainer<otio::Timeline> tl =
+            new otio::Timeline();
+        tl->tracks()->append_child(tr);
+
+        otio::ErrorStatus err;
+        auto output = tl.value->to_json_string(&err, {});
+        assertFalse(otio::is_error(err));
+        assertEqual(output.c_str(), R"CONTENT({
+    "OTIO_SCHEMA": "Timeline.1",
+    "metadata": {},
+    "name": "",
+    "global_start_time": null,
+    "tracks": {
+        "OTIO_SCHEMA": "Stack.1",
+        "metadata": {},
+        "name": "tracks",
+        "source_range": null,
+        "effects": [],
+        "markers": [],
+        "enabled": true,
+        "children": [
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {},
+                "name": "",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {},
+                        "name": "",
+                        "source_range": null,
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "MissingReference.1",
+                                "metadata": {},
+                                "name": "",
+                                "available_range": null,
+                                "available_image_bounds": null
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    }
+                ],
+                "kind": "Video"
+            }
+        ]
+    }
+})CONTENT");
+    });
+
+    tests.add_test(
+        "success with indent set to 0", [] {
+        otio::SerializableObject::Retainer<otio::SerializableObjectWithMetadata> so =
+            new otio::SerializableObjectWithMetadata();
+
+        otio::ErrorStatus err;
+        auto output = so.value->to_json_string(&err, {}, 0);
+        assertFalse(otio::is_error(err));
+        assertEqual(output.c_str(), R"CONTENT({"OTIO_SCHEMA":"SerializableObjectWithMetadata.1","metadata":{},"name":""})CONTENT");
+    });
+
+    tests.add_test(
+        "success with indent set to 2", [] {
+        otio::SerializableObject::Retainer<otio::SerializableObjectWithMetadata> so =
+            new otio::SerializableObjectWithMetadata();
+
+        otio::ErrorStatus err;
+        auto output = so.value->to_json_string(&err, {}, 2);
+        assertFalse(otio::is_error(err));
+        assertEqual(output.c_str(), R"CONTENT({
+  "OTIO_SCHEMA": "SerializableObjectWithMetadata.1",
+  "metadata": {},
+  "name": ""
+})CONTENT");
+    });
+
+    tests.run(argc, argv);
+    return 0;
+}


### PR DESCRIPTION
When we use `opentimelineio.serialize_json_to_string` and we set `indent` to 0, it outputs using multiple lines with no indentation instead of outputting a compact, single line string:
```python
>>> opentimelineio.core.serialize_json_to_string(so, indent=0)
{
"OTIO_SCHEMA": "SerializableObjectWithMetadata.1",
"metadata": {
"a": "asd",
"b": "b"
},
"name": "sowithmet"
}
```

With this change, it will output a single line:
```python
>>> opentimelineio.core.serialize_json_to_string(so, indent=0)
{"OTIO_SCHEMA":"SerializableObjectWithMetadata.1","metadata":{"a":"asd","b":"b"},"name":"sowithmet"}
```

A compact string can be useful in unit tests.

Note that I'm still learning C++. The method I used adds some code duplication which I initially tried to avoid but couldn't find a way to avoid it. For example I tried to use a pointer or reference, but like mentioned in https://github.com/Tencent/rapidjson/issues/912#issuecomment-488550187, it doesn't work. Let me know if it could be improved!