### PR TITLE
Adjust license for package uploaded to PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -221,7 +221,7 @@ PROJECT_METADATA = {
     "version": "0.16.0.dev1",
     "author": 'Contributors to the OpenTimelineIO project',
     "author_email": 'otio-discussion@lists.aswf.io',
-    "license": 'Modified Apache 2.0 License',
+    "license": 'Apache 2.0 License',
 }
 
 METADATA_TEMPLATE = """
@@ -310,7 +310,7 @@ setup(
         'Topic :: Multimedia :: Video :: Display',
         'Topic :: Multimedia :: Video :: Non-Linear Editor',
         'Topic :: Software Development :: Libraries :: Python Modules',
-        'License :: Other/Proprietary License',
+        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
@@ -415,5 +415,6 @@ setup(
     },
 
     # expand the project metadata dictionary to fill in those values
-    **PROJECT_METADATA
+    **PROJECT_METADATA,
+    license_file='LICENSE.txt'
 )

--- a/setup.py
+++ b/setup.py
@@ -415,6 +415,5 @@ setup(
     },
 
     # expand the project metadata dictionary to fill in those values
-    **PROJECT_METADATA,
-    license_file='LICENSE.txt'
+    **PROJECT_METADATA
 )


### PR DESCRIPTION
I noticed that our package in PyPI was still advertising the old license (Modified Apache 2.0). So this PR fixes that to make sure. Our next release will now correctly show Apache 2.0.