### PR TITLE
Support compiling with GCC 13

### DIFF
--- a/src/opentime/rationalTime.h
+++ b/src/opentime/rationalTime.h
@@ -7,6 +7,7 @@
 #include "opentime/version.h"
 #include <cmath>
 #include <limits>
+#include <cstdint>
 #include <string>
 
 namespace opentime { namespace OPENTIME_VERSION {


### PR DESCRIPTION
When compiling with GCC 13, we get errors like this:

```
In file included from /home/jcmorin/jcmenv/aswf/OpenTimelineIO/src/opentime/rationalTime.cpp:4:
/home/jcmorin/jcmenv/aswf/OpenTimelineIO/src/opentime/rationalTime.h: In function ‘constexpr double opentime::v1_0::fabs(double)’:
/home/jcmorin/jcmenv/aswf/OpenTimelineIO/src/opentime/rationalTime.h:27:9: error: ‘uint64_t’ does not name a type
   27 |         uint64_t i;
      |         ^~~~~~~~
/home/jcmorin/jcmenv/aswf/OpenTimelineIO/src/opentime/rationalTime.h:10:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
    9 | #include <limits>
  +++ |+#include <cstdint>
   10 | #include <string>
/home/jcmorin/jcmenv/aswf/OpenTimelineIO/src/opentime/rationalTime.h:29:10: error: ‘union opentime::v1_0::fabs(double)::<unnamed>’ has no member named ‘i’
   29 |     bits.i &= std::numeric_limits<uint64_t>::max() / 2;
      |          ^
/home/jcmorin/jcmenv/aswf/OpenTimelineIO/src/opentime/rationalTime.h:29:35: error: ‘uint64_t’ was not declared in this scope
   29 |     bits.i &= std::numeric_limits<uint64_t>::max() / 2;
      |                                   ^~~~~~~~
/home/jcmorin/jcmenv/aswf/OpenTimelineIO/src/opentime/rationalTime.h:29:35: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/jcmorin/jcmenv/aswf/OpenTimelineIO/src/opentime/rationalTime.h:29:43: error: template argument 1 is invalid
   29 |     bits.i &= std::numeric_limits<uint64_t>::max() / 2;
```

Like the note says, we need to include `cstdint`. This is also documented in https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes.