### PR TITLE
Fix rendering of otioz file bundle structure in the docs

### DIFF
--- a/docs/tutorials/otio-filebundles.md
+++ b/docs/tutorials/otio-filebundles.md
@@ -27,13 +27,15 @@ The file bundle adapters expect the `target_url` field of the `media_reference` 
 
 File bundles, regardless of how they're encoded, have a consistent structure:
 
-- something.otioz (or .otiod)
-    - content.otio
-    - version.txt
-    - media
-        - media1
-        - media2
-        - media3
+```
+something.otioz
+├── content.otio
+├── version
+└── media
+    ├── media1
+    ├── media2
+    └── media3
+```
 
 
 ### content.otio file


### PR DESCRIPTION
Fixes #1604.

The rendered version can be seen at https://opentimelineio--1606.org.readthedocs.build/en/1606/tutorials/otio-filebundles.html#structure.