### PR TITLE
Use IMATH_NAMESPACE in place of Imath

### DIFF
--- a/src/opentimelineio/clip.cpp
+++ b/src/opentimelineio/clip.cpp
@@ -184,7 +184,7 @@ Clip::available_range(ErrorStatus* error_status) const
     return active_media->available_range().value();
 }
 
-optional<Imath::Box2d>
+optional<IMATH_NAMESPACE::Box2d>
 Clip::available_image_bounds(ErrorStatus* error_status) const
 {
     auto active_media = media_reference();
@@ -194,7 +194,7 @@ Clip::available_image_bounds(ErrorStatus* error_status) const
             ErrorStatus::CANNOT_COMPUTE_BOUNDS,
             "No image bounds set on clip",
             this);
-        return optional<Imath::Box2d>();
+        return optional<IMATH_NAMESPACE::Box2d>();
     }
 
     if (!active_media->available_image_bounds())
@@ -203,7 +203,7 @@ Clip::available_image_bounds(ErrorStatus* error_status) const
             ErrorStatus::CANNOT_COMPUTE_BOUNDS,
             "No image bounds set on media reference on clip",
             this);
-        return optional<Imath::Box2d>();
+        return optional<IMATH_NAMESPACE::Box2d>();
     }
 
     return active_media->available_image_bounds();

--- a/src/opentimelineio/clip.h
+++ b/src/opentimelineio/clip.h
@@ -48,7 +48,7 @@ public:
     TimeRange
     available_range(ErrorStatus* error_status = nullptr) const override;
 
-    optional<Imath::Box2d>
+    optional<IMATH_NAMESPACE::Box2d>
     available_image_bounds(ErrorStatus* error_status) const override;
 
 protected:

--- a/src/opentimelineio/composable.cpp
+++ b/src/opentimelineio/composable.cpp
@@ -74,11 +74,11 @@ Composable::duration(ErrorStatus* error_status) const
     return RationalTime();
 }
 
-optional<Imath::Box2d>
+optional<IMATH_NAMESPACE::Box2d>
 Composable::available_image_bounds(ErrorStatus* error_status) const
 {
     *error_status = ErrorStatus::NOT_IMPLEMENTED;
-    return optional<Imath::Box2d>();
+    return optional<IMATH_NAMESPACE::Box2d>();
 }
 
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/composable.h
+++ b/src/opentimelineio/composable.h
@@ -34,7 +34,7 @@ public:
 
     virtual RationalTime duration(ErrorStatus* error_status = nullptr) const;
 
-    virtual optional<Imath::Box2d>
+    virtual optional<IMATH_NAMESPACE::Box2d>
     available_image_bounds(ErrorStatus* error_status) const;
 
 protected:

--- a/src/opentimelineio/deserialization.cpp
+++ b/src/opentimelineio/deserialization.cpp
@@ -609,14 +609,14 @@ SerializableObject::Reader::_decode(_Resolver& resolver)
     else if (schema_name_and_version == "V2d.1")
     {
         double x, y;
-        return _fetch("x", &x) && _fetch("y", &y) ? any(Imath::V2d(x, y))
+        return _fetch("x", &x) && _fetch("y", &y) ? any(IMATH_NAMESPACE::V2d(x, y))
                                                   : any();
     }
     else if (schema_name_and_version == "Box2d.1")
     {
-        Imath::V2d min, max;
+        IMATH_NAMESPACE::V2d min, max;
         return _fetch("min", &min) && _fetch("max", &max)
-                   ? any(Imath::Box2d(std::move(min), std::move(max)))
+                   ? any(IMATH_NAMESPACE::Box2d(std::move(min), std::move(max)))
                    : any();
     }
     else
@@ -743,13 +743,13 @@ SerializableObject::Reader::read(std::string const& key, AnyVector* value)
 }
 
 bool
-SerializableObject::Reader::read(std::string const& key, Imath::V2d* value)
+SerializableObject::Reader::read(std::string const& key, IMATH_NAMESPACE::V2d* value)
 {
     return _fetch(key, value);
 }
 
 bool
-SerializableObject::Reader::read(std::string const& key, Imath::Box2d* value)
+SerializableObject::Reader::read(std::string const& key, IMATH_NAMESPACE::Box2d* value)
 {
     return _fetch(key, value);
 }
@@ -817,7 +817,7 @@ SerializableObject::Reader::read(
 bool
 SerializableObject::Reader::read(
     std::string const&      key,
-    optional<Imath::Box2d>* value)
+    optional<IMATH_NAMESPACE::Box2d>* value)
 {
     return _read_optional(key, value);
 }

--- a/src/opentimelineio/externalReference.cpp
+++ b/src/opentimelineio/externalReference.cpp
@@ -9,7 +9,7 @@ ExternalReference::ExternalReference(
     std::string const&            target_url,
     optional<TimeRange> const&    available_range,
     AnyDictionary const&          metadata,
-    optional<Imath::Box2d> const& available_image_bounds)
+    optional<IMATH_NAMESPACE::Box2d> const& available_image_bounds)
     : Parent(std::string(), available_range, metadata, available_image_bounds)
     , _target_url(target_url)
 {}

--- a/src/opentimelineio/externalReference.h
+++ b/src/opentimelineio/externalReference.h
@@ -23,7 +23,7 @@ public:
         std::string const&            target_url             = std::string(),
         optional<TimeRange> const&    available_range        = nullopt,
         AnyDictionary const&          metadata               = AnyDictionary(),
-        optional<Imath::Box2d> const& available_image_bounds = nullopt);
+        optional<IMATH_NAMESPACE::Box2d> const& available_image_bounds = nullopt);
 
     std::string target_url() const noexcept { return _target_url; }
 

--- a/src/opentimelineio/generatorReference.cpp
+++ b/src/opentimelineio/generatorReference.cpp
@@ -11,7 +11,7 @@ GeneratorReference::GeneratorReference(
     optional<TimeRange> const&    available_range,
     AnyDictionary const&          parameters,
     AnyDictionary const&          metadata,
-    optional<Imath::Box2d> const& available_image_bounds)
+    optional<IMATH_NAMESPACE::Box2d> const& available_image_bounds)
     : Parent(name, available_range, metadata, available_image_bounds)
     , _generator_kind(generator_kind)
     , _parameters(parameters)

--- a/src/opentimelineio/generatorReference.h
+++ b/src/opentimelineio/generatorReference.h
@@ -25,7 +25,7 @@ public:
         optional<TimeRange> const&    available_range        = nullopt,
         AnyDictionary const&          parameters             = AnyDictionary(),
         AnyDictionary const&          metadata               = AnyDictionary(),
-        optional<Imath::Box2d> const& available_image_bounds = nullopt);
+        optional<IMATH_NAMESPACE::Box2d> const& available_image_bounds = nullopt);
 
     std::string generator_kind() const noexcept { return _generator_kind; }
 

--- a/src/opentimelineio/imageSequenceReference.cpp
+++ b/src/opentimelineio/imageSequenceReference.cpp
@@ -16,7 +16,7 @@ ImageSequenceReference::ImageSequenceReference(
     MissingFramePolicy const      missing_frame_policy,
     optional<TimeRange> const&    available_range,
     AnyDictionary const&          metadata,
-    optional<Imath::Box2d> const& available_image_bounds)
+    optional<IMATH_NAMESPACE::Box2d> const& available_image_bounds)
     : Parent(std::string(), available_range, metadata, available_image_bounds)
     , _target_url_base(target_url_base)
     , _name_prefix(name_prefix)

--- a/src/opentimelineio/imageSequenceReference.h
+++ b/src/opentimelineio/imageSequenceReference.h
@@ -38,7 +38,7 @@ public:
             MissingFramePolicy::error,
         optional<TimeRange> const&    available_range        = nullopt,
         AnyDictionary const&          metadata               = AnyDictionary(),
-        optional<Imath::Box2d> const& available_image_bounds = nullopt);
+        optional<IMATH_NAMESPACE::Box2d> const& available_image_bounds = nullopt);
 
     std::string target_url_base() const noexcept { return _target_url_base; }
 

--- a/src/opentimelineio/mediaReference.cpp
+++ b/src/opentimelineio/mediaReference.cpp
@@ -9,7 +9,7 @@ MediaReference::MediaReference(
     std::string const&            name,
     optional<TimeRange> const&    available_range,
     AnyDictionary const&          metadata,
-    optional<Imath::Box2d> const& available_image_bounds)
+    optional<IMATH_NAMESPACE::Box2d> const& available_image_bounds)
     : Parent(name, metadata)
     , _available_range(available_range)
     , _available_image_bounds(available_image_bounds)

--- a/src/opentimelineio/mediaReference.h
+++ b/src/opentimelineio/mediaReference.h
@@ -27,7 +27,7 @@ public:
         std::string const&            name                   = std::string(),
         optional<TimeRange> const&    available_range        = nullopt,
         AnyDictionary const&          metadata               = AnyDictionary(),
-        optional<Imath::Box2d> const& available_image_bounds = nullopt);
+        optional<IMATH_NAMESPACE::Box2d> const& available_image_bounds = nullopt);
 
     optional<TimeRange> available_range() const noexcept
     {
@@ -41,13 +41,13 @@ public:
 
     virtual bool is_missing_reference() const;
 
-    optional<Imath::Box2d> available_image_bounds() const
+    optional<IMATH_NAMESPACE::Box2d> available_image_bounds() const
     {
         return _available_image_bounds;
     }
 
     void set_available_image_bounds(
-        optional<Imath::Box2d> const& available_image_bounds)
+        optional<IMATH_NAMESPACE::Box2d> const& available_image_bounds)
     {
         _available_image_bounds = available_image_bounds;
     }
@@ -60,7 +60,7 @@ protected:
 
 private:
     optional<TimeRange>    _available_range;
-    optional<Imath::Box2d> _available_image_bounds;
+    optional<IMATH_NAMESPACE::Box2d> _available_image_bounds;
 };
 
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/missingReference.cpp
+++ b/src/opentimelineio/missingReference.cpp
@@ -9,7 +9,7 @@ MissingReference::MissingReference(
     std::string const&            name,
     optional<TimeRange> const&    available_range,
     AnyDictionary const&          metadata,
-    optional<Imath::Box2d> const& available_image_bounds)
+    optional<IMATH_NAMESPACE::Box2d> const& available_image_bounds)
     : Parent(name, available_range, metadata, available_image_bounds)
 {}
 

--- a/src/opentimelineio/missingReference.h
+++ b/src/opentimelineio/missingReference.h
@@ -23,7 +23,7 @@ public:
         std::string const&            name                   = std::string(),
         optional<TimeRange> const&    available_range        = nullopt,
         AnyDictionary const&          metadata               = AnyDictionary(),
-        optional<Imath::Box2d> const& available_image_bounds = nullopt);
+        optional<IMATH_NAMESPACE::Box2d> const& available_image_bounds = nullopt);
 
     bool is_missing_reference() const override;
 

--- a/src/opentimelineio/safely_typed_any.cpp
+++ b/src/opentimelineio/safely_typed_any.cpp
@@ -60,13 +60,13 @@ create_safely_typed_any(TimeTransform&& value)
 }
 
 any
-create_safely_typed_any(Imath::V2d&& value)
+create_safely_typed_any(IMATH_NAMESPACE::V2d&& value)
 {
     return any(value);
 }
 
 any
-create_safely_typed_any(Imath::Box2d&& value)
+create_safely_typed_any(IMATH_NAMESPACE::Box2d&& value)
 {
     return any(value);
 }
@@ -143,16 +143,16 @@ safely_cast_time_transform_any(any const& a)
     return any_cast<TimeTransform>(a);
 }
 
-Imath::V2d
+IMATH_NAMESPACE::V2d
 safely_cast_point_any(any const& a)
 {
-    return any_cast<Imath::V2d>(a);
+    return any_cast<IMATH_NAMESPACE::V2d>(a);
 }
 
-Imath::Box2d
+IMATH_NAMESPACE::Box2d
 safely_cast_box_any(any const& a)
 {
-    return any_cast<Imath::Box2d>(a);
+    return any_cast<IMATH_NAMESPACE::Box2d>(a);
 }
 
 AnyDictionary

--- a/src/opentimelineio/safely_typed_any.h
+++ b/src/opentimelineio/safely_typed_any.h
@@ -36,8 +36,8 @@ any create_safely_typed_any(std::string&&);
 any create_safely_typed_any(RationalTime&&);
 any create_safely_typed_any(TimeRange&&);
 any create_safely_typed_any(TimeTransform&&);
-any create_safely_typed_any(Imath::V2d&&);
-any create_safely_typed_any(Imath::Box2d&&);
+any create_safely_typed_any(IMATH_NAMESPACE::V2d&&);
+any create_safely_typed_any(IMATH_NAMESPACE::Box2d&&);
 any create_safely_typed_any(AnyVector&&);
 any create_safely_typed_any(AnyDictionary&&);
 any create_safely_typed_any(SerializableObject*);
@@ -51,8 +51,8 @@ std::string   safely_cast_string_any(any const& a);
 RationalTime  safely_cast_rational_time_any(any const& a);
 TimeRange     safely_cast_time_range_any(any const& a);
 TimeTransform safely_cast_time_transform_any(any const& a);
-Imath::V2d    safely_cast_point_any(any const& a);
-Imath::Box2d  safely_cast_box_any(any const& a);
+IMATH_NAMESPACE::V2d    safely_cast_point_any(any const& a);
+IMATH_NAMESPACE::Box2d  safely_cast_box_any(any const& a);
 
 SerializableObject* safely_cast_retainer_any(any const& a);
 

--- a/src/opentimelineio/serializableObject.h
+++ b/src/opentimelineio/serializableObject.h
@@ -97,8 +97,8 @@ public:
         bool read(std::string const& key, RationalTime* dest);
         bool read(std::string const& key, TimeRange* dest);
         bool read(std::string const& key, class TimeTransform* dest);
-        bool read(std::string const& key, Imath::V2d* value);
-        bool read(std::string const& key, Imath::Box2d* value);
+        bool read(std::string const& key, IMATH_NAMESPACE::V2d* value);
+        bool read(std::string const& key, IMATH_NAMESPACE::Box2d* value);
         bool read(std::string const& key, AnyVector* dest);
         bool read(std::string const& key, AnyDictionary* dest);
         bool read(std::string const& key, any* dest);
@@ -109,7 +109,7 @@ public:
         bool read(std::string const& key, optional<RationalTime>* dest);
         bool read(std::string const& key, optional<TimeRange>* dest);
         bool read(std::string const& key, optional<TimeTransform>* dest);
-        bool read(std::string const& key, optional<Imath::Box2d>* value);
+        bool read(std::string const& key, optional<IMATH_NAMESPACE::Box2d>* value);
 
         // skipping std::string because we translate null into the empty
         // string, so the conversion is somewhat ambiguous
@@ -415,11 +415,11 @@ public:
         void write(std::string const& key, std::string const& value);
         void write(std::string const& key, RationalTime value);
         void write(std::string const& key, TimeRange value);
-        void write(std::string const& key, Imath::V2d value);
-        void write(std::string const& key, Imath::Box2d value);
+        void write(std::string const& key, IMATH_NAMESPACE::V2d value);
+        void write(std::string const& key, IMATH_NAMESPACE::Box2d value);
         void write(std::string const& key, optional<RationalTime> value);
         void write(std::string const& key, optional<TimeRange> value);
-        void write(std::string const& key, optional<Imath::Box2d> value);
+        void write(std::string const& key, optional<IMATH_NAMESPACE::Box2d> value);
         void write(std::string const& key, class TimeTransform value);
         void write(std::string const& key, SerializableObject const* value);
         void write(std::string const& key, SerializableObject* value)

--- a/src/opentimelineio/serialization.cpp
+++ b/src/opentimelineio/serialization.cpp
@@ -77,7 +77,7 @@ public:
     virtual void write_value(class TimeRange const& value)           = 0;
     virtual void write_value(class TimeTransform const& value)       = 0;
     virtual void write_value(struct SerializableObject::ReferenceId) = 0;
-    virtual void write_value(Imath::Box2d const&)                    = 0;
+    virtual void write_value(IMATH_NAMESPACE::Box2d const&)          = 0;
 
 protected:
     void _error(ErrorStatus const& error_status)
@@ -267,7 +267,7 @@ public:
         _store(any(value));
     }
 
-    void write_value(Imath::V2d const& value)
+    void write_value(IMATH_NAMESPACE::V2d const& value)
     {
 
         if (_result_object_policy == ResultObjectPolicy::OnlyAnyDictionary)
@@ -285,7 +285,7 @@ public:
         }
     }
 
-    void write_value(Imath::Box2d const& value) override
+    void write_value(IMATH_NAMESPACE::Box2d const& value) override
     {
         if (_result_object_policy == ResultObjectPolicy::OnlyAnyDictionary)
         {
@@ -589,7 +589,7 @@ public:
         _writer.EndObject();
     }
 
-    void write_value(Imath::V2d const& value)
+    void write_value(IMATH_NAMESPACE::V2d const& value)
     {
         _writer.StartObject();
 
@@ -605,7 +605,7 @@ public:
         _writer.EndObject();
     }
 
-    void write_value(Imath::Box2d const& value)
+    void write_value(IMATH_NAMESPACE::Box2d const& value)
     {
         _writer.StartObject();
 
@@ -690,11 +690,11 @@ SerializableObject::Writer::_build_dispatch_tables()
     wt[&typeid(TimeTransform)] = [this](any const& value) {
         _encoder.write_value(any_cast<TimeTransform const&>(value));
     };
-    wt[&typeid(Imath::V2d)] = [this](any const& value) {
-        _encoder.write_value(any_cast<Imath::V2d const&>(value));
+    wt[&typeid(IMATH_NAMESPACE::V2d)] = [this](any const& value) {
+        _encoder.write_value(any_cast<IMATH_NAMESPACE::V2d const&>(value));
     };
-    wt[&typeid(Imath::Box2d)] = [this](any const& value) {
-        _encoder.write_value(any_cast<Imath::Box2d const&>(value));
+    wt[&typeid(IMATH_NAMESPACE::Box2d)] = [this](any const& value) {
+        _encoder.write_value(any_cast<IMATH_NAMESPACE::Box2d const&>(value));
     };
 
     /*
@@ -733,8 +733,8 @@ SerializableObject::Writer::_build_dispatch_tables()
     et[&typeid(TimeTransform)] = &_simple_any_comparison<TimeTransform>;
     et[&typeid(SerializableObject::ReferenceId)] =
         &_simple_any_comparison<SerializableObject::ReferenceId>;
-    et[&typeid(Imath::V2d)]   = &_simple_any_comparison<Imath::V2d>;
-    et[&typeid(Imath::Box2d)] = &_simple_any_comparison<Imath::Box2d>;
+    et[&typeid(IMATH_NAMESPACE::V2d)]   = &_simple_any_comparison<IMATH_NAMESPACE::V2d>;
+    et[&typeid(IMATH_NAMESPACE::Box2d)] = &_simple_any_comparison<IMATH_NAMESPACE::Box2d>;
 
     /*
      * These next recurse back through the Writer itself:
@@ -898,7 +898,7 @@ SerializableObject::Writer::write(
 void
 SerializableObject::Writer::write(
     std::string const&     key,
-    optional<Imath::Box2d> value)
+    optional<IMATH_NAMESPACE::Box2d> value)
 {
     _encoder_write_key(key);
     value ? _encoder.write_value(*value) : _encoder.write_null_value();
@@ -1058,14 +1058,14 @@ SerializableObject::Writer::write(
 }
 
 void
-SerializableObject::Writer::write(std::string const& key, Imath::V2d value)
+SerializableObject::Writer::write(std::string const& key, IMATH_NAMESPACE::V2d value)
 {
     _encoder_write_key(key);
     _encoder.write_value(value);
 }
 
 void
-SerializableObject::Writer::write(std::string const& key, Imath::Box2d value)
+SerializableObject::Writer::write(std::string const& key, IMATH_NAMESPACE::Box2d value)
 {
     _encoder_write_key(key);
     _encoder.write_value(value);

--- a/src/opentimelineio/stack.cpp
+++ b/src/opentimelineio/stack.cpp
@@ -122,21 +122,21 @@ Stack::find_clips(
     return find_children<Clip>(error_status, search_range, shallow_search);
 }
 
-optional<Imath::Box2d>
+optional<IMATH_NAMESPACE::Box2d>
 Stack::available_image_bounds(ErrorStatus* error_status) const
 {
-    optional<Imath::Box2d> box;
+    optional<IMATH_NAMESPACE::Box2d> box;
     bool                   found_first_child = false;
     for (auto clip: find_children<Clip>(error_status))
     {
-        optional<Imath::Box2d> child_box;
+        optional<IMATH_NAMESPACE::Box2d> child_box;
         if (auto clip_box = clip->available_image_bounds(error_status))
         {
             child_box = clip_box;
         }
         if (is_error(error_status))
         {
-            return optional<Imath::Box2d>();
+            return optional<IMATH_NAMESPACE::Box2d>();
         }
         if (child_box)
         {

--- a/src/opentimelineio/stack.h
+++ b/src/opentimelineio/stack.h
@@ -40,7 +40,7 @@ public:
     std::map<Composable*, TimeRange>
     range_of_all_children(ErrorStatus* error_status = nullptr) const override;
 
-    optional<Imath::Box2d>
+    optional<IMATH_NAMESPACE::Box2d>
     available_image_bounds(ErrorStatus* error_status) const override;
 
     // Find child clips.

--- a/src/opentimelineio/timeline.h
+++ b/src/opentimelineio/timeline.h
@@ -83,7 +83,7 @@ public:
         optional<TimeRange> search_range   = nullopt,
         bool                shallow_search = false) const;
 
-    optional<Imath::Box2d>
+    optional<IMATH_NAMESPACE::Box2d>
     available_image_bounds(ErrorStatus* error_status) const
     {
         return _tracks.value->available_image_bounds(error_status);

--- a/src/opentimelineio/track.cpp
+++ b/src/opentimelineio/track.cpp
@@ -272,10 +272,10 @@ Track::find_clips(
     return find_children<Clip>(error_status, search_range, shallow_search);
 }
 
-optional<Imath::Box2d>
+optional<IMATH_NAMESPACE::Box2d>
 Track::available_image_bounds(ErrorStatus* error_status) const
 {
-    optional<Imath::Box2d> box;
+    optional<IMATH_NAMESPACE::Box2d> box;
     bool                   found_first_clip = false;
     for (const auto& child: children())
     {
@@ -298,7 +298,7 @@ Track::available_image_bounds(ErrorStatus* error_status) const
             }
             if (is_error(error_status))
             {
-                return optional<Imath::Box2d>();
+                return optional<IMATH_NAMESPACE::Box2d>();
             }
         }
     }

--- a/src/opentimelineio/track.h
+++ b/src/opentimelineio/track.h
@@ -65,7 +65,7 @@ public:
     std::map<Composable*, TimeRange>
     range_of_all_children(ErrorStatus* error_status = nullptr) const override;
 
-    optional<Imath::Box2d>
+    optional<IMATH_NAMESPACE::Box2d>
     available_image_bounds(ErrorStatus* error_status) const override;
 
     // Find child clips.

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_imath.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_imath.cpp
@@ -27,102 +27,102 @@ static void define_imath_2d(py::module m) {
     // Note that module_local is used to avoid issues when
     // Imath classes are binded with Pybind11 more than once.
     // Using module_local will avoid conflicts in such cases.
-    py::class_<Imath::V2d>(m, "V2d", py::module_local())
+    py::class_<IMATH_NAMESPACE::V2d>(m, "V2d", py::module_local())
         .def(py::init<>())
         .def(py::init<double>())
         .def(py::init<double, double>())
-        .def_readwrite("x", &Imath::V2d::x)
-        .def_readwrite("y", &Imath::V2d::y)
-        .def("__getitem__", [](Imath::V2d const &v, size_t i) {
+        .def_readwrite("x", &IMATH_NAMESPACE::V2d::x)
+        .def_readwrite("y", &IMATH_NAMESPACE::V2d::y)
+        .def("__getitem__", [](IMATH_NAMESPACE::V2d const &v, size_t i) {
                 return v[i];
             })
-        .def("__eq__", [](Imath::V2d lhs, py::object const& rhs) {
-                return lhs == _type_checked<Imath::V2d>(rhs, "==");
+        .def("__eq__", [](IMATH_NAMESPACE::V2d lhs, py::object const& rhs) {
+                return lhs == _type_checked<IMATH_NAMESPACE::V2d>(rhs, "==");
             })
-        .def("__ne__", [](Imath::V2d lhs, py::object const& rhs) {
-                return lhs != _type_checked<Imath::V2d>(rhs, "!=");
+        .def("__ne__", [](IMATH_NAMESPACE::V2d lhs, py::object const& rhs) {
+                return lhs != _type_checked<IMATH_NAMESPACE::V2d>(rhs, "!=");
             })
-        .def("__xor__", [](Imath::V2d lhs, py::object const& rhs) {
-                return lhs ^ _type_checked<Imath::V2d>(rhs, "^");
+        .def("__xor__", [](IMATH_NAMESPACE::V2d lhs, py::object const& rhs) {
+                return lhs ^ _type_checked<IMATH_NAMESPACE::V2d>(rhs, "^");
             })
-        .def("__mod__", [](Imath::V2d lhs, py::object const& rhs) {
-                return lhs % _type_checked<Imath::V2d>(rhs, "%");
+        .def("__mod__", [](IMATH_NAMESPACE::V2d lhs, py::object const& rhs) {
+                return lhs % _type_checked<IMATH_NAMESPACE::V2d>(rhs, "%");
             })
-        .def("__iadd__", [](Imath::V2d lhs, Imath::V2d rhs) {
+        .def("__iadd__", [](IMATH_NAMESPACE::V2d lhs, IMATH_NAMESPACE::V2d rhs) {
                 return lhs += rhs;
             })
-        .def("__isub__", [](Imath::V2d lhs, Imath::V2d rhs) {
+        .def("__isub__", [](IMATH_NAMESPACE::V2d lhs, IMATH_NAMESPACE::V2d rhs) {
                 return lhs -= rhs;
             })
-        .def("__imul__", [](Imath::V2d lhs, Imath::V2d rhs) {
+        .def("__imul__", [](IMATH_NAMESPACE::V2d lhs, IMATH_NAMESPACE::V2d rhs) {
                 return lhs *= rhs;
             })
-        .def("__idiv__", [](Imath::V2d lhs, Imath::V2d rhs) {
+        .def("__idiv__", [](IMATH_NAMESPACE::V2d lhs, IMATH_NAMESPACE::V2d rhs) {
                 return lhs /= rhs;
             })
         .def(py::self - py::self)
         .def(py::self + py::self)
         .def(py::self * py::self)
         .def(py::self / py::self)
-        .def("equalWithAbsError", [](Imath::V2d* v, Imath::V2d const & v2, double e) {
+        .def("equalWithAbsError", [](IMATH_NAMESPACE::V2d* v, IMATH_NAMESPACE::V2d const & v2, double e) {
                 return v->equalWithAbsError(v2, e);
             })
-        .def("equalWithRelError", [](Imath::V2d* v, Imath::V2d const & v2, double e) {
+        .def("equalWithRelError", [](IMATH_NAMESPACE::V2d* v, IMATH_NAMESPACE::V2d const & v2, double e) {
                 return v->equalWithRelError(v2, e);
             })
-        .def("dot", [](Imath::V2d* v, Imath::V2d const & v2) {
+        .def("dot", [](IMATH_NAMESPACE::V2d* v, IMATH_NAMESPACE::V2d const & v2) {
                 return v->dot(v2);
             })
-        .def("cross", [](Imath::V2d* v, Imath::V2d const & v2) {
+        .def("cross", [](IMATH_NAMESPACE::V2d* v, IMATH_NAMESPACE::V2d const & v2) {
                 return v->cross(v2);
             })
-        .def("length", &Imath::V2d::length)
-        .def("length2", &Imath::V2d::length2)
-        .def("normalize", &Imath::V2d::normalize)
-        .def("normalizeExc", &Imath::V2d::normalizeExc)
-        .def("normalizeNonNull", &Imath::V2d::normalizeNonNull)
-        .def("normalized", &Imath::V2d::normalized)
-        .def("normalizedExc", &Imath::V2d::normalizedExc)
-        .def("normalizedNonNull", &Imath::V2d::normalizedNonNull)
+        .def("length", &IMATH_NAMESPACE::V2d::length)
+        .def("length2", &IMATH_NAMESPACE::V2d::length2)
+        .def("normalize", &IMATH_NAMESPACE::V2d::normalize)
+        .def("normalizeExc", &IMATH_NAMESPACE::V2d::normalizeExc)
+        .def("normalizeNonNull", &IMATH_NAMESPACE::V2d::normalizeNonNull)
+        .def("normalized", &IMATH_NAMESPACE::V2d::normalized)
+        .def("normalizedExc", &IMATH_NAMESPACE::V2d::normalizedExc)
+        .def("normalizedNonNull", &IMATH_NAMESPACE::V2d::normalizedNonNull)
         .def_static("baseTypeLowest", []() {
-                return Imath::V2d::baseTypeLowest();
+                return IMATH_NAMESPACE::V2d::baseTypeLowest();
             })
         .def_static("baseTypeMax", []() {
-                return Imath::V2d::baseTypeMax();
+                return IMATH_NAMESPACE::V2d::baseTypeMax();
             })
         .def_static("baseTypeSmallest", []() {
-                return Imath::V2d::baseTypeSmallest();
+                return IMATH_NAMESPACE::V2d::baseTypeSmallest();
             })
         .def_static("baseTypeEpsilon", []() {
-                return Imath::V2d::baseTypeEpsilon();
+                return IMATH_NAMESPACE::V2d::baseTypeEpsilon();
             })
         .def_static("dimensions", []() {
-                return Imath::V2d::dimensions();
+                return IMATH_NAMESPACE::V2d::dimensions();
             });
 
-    py::class_<Imath::Box2d>(m, "Box2d", py::module_local())
+    py::class_<IMATH_NAMESPACE::Box2d>(m, "Box2d", py::module_local())
         .def(py::init<>())
-        .def(py::init<Imath::V2d>())
-        .def(py::init<Imath::V2d, Imath::V2d>())
-        .def_readwrite("min", &Imath::Box2d::min)
-        .def_readwrite("max", &Imath::Box2d::max)
-        .def("__eq__", [](Imath::Box2d lhs, py::object const& rhs) {
-            return lhs == _type_checked<Imath::Box2d>(rhs, "==");
+        .def(py::init<IMATH_NAMESPACE::V2d>())
+        .def(py::init<IMATH_NAMESPACE::V2d, IMATH_NAMESPACE::V2d>())
+        .def_readwrite("min", &IMATH_NAMESPACE::Box2d::min)
+        .def_readwrite("max", &IMATH_NAMESPACE::Box2d::max)
+        .def("__eq__", [](IMATH_NAMESPACE::Box2d lhs, py::object const& rhs) {
+            return lhs == _type_checked<IMATH_NAMESPACE::Box2d>(rhs, "==");
         })
-        .def("__ne__", [](Imath::Box2d lhs, py::object const& rhs) {
-            return lhs != _type_checked<Imath::Box2d>(rhs, "!=");
+        .def("__ne__", [](IMATH_NAMESPACE::Box2d lhs, py::object const& rhs) {
+            return lhs != _type_checked<IMATH_NAMESPACE::Box2d>(rhs, "!=");
         })
-        .def("center", &Imath::Box2d::center)
-        .def("extendBy", [](Imath::Box2d* box, Imath::V2d const& point ) {
+        .def("center", &IMATH_NAMESPACE::Box2d::center)
+        .def("extendBy", [](IMATH_NAMESPACE::Box2d* box, IMATH_NAMESPACE::V2d const& point ) {
             return box->extendBy(point); 
         })
-        .def("extendBy", [](Imath::Box2d* box, Imath::Box2d const& rhs ) {
+        .def("extendBy", [](IMATH_NAMESPACE::Box2d* box, IMATH_NAMESPACE::Box2d const& rhs ) {
             return box->extendBy(rhs); 
         })
-        .def("intersects", [](Imath::Box2d* box, Imath::V2d const& point ) {
+        .def("intersects", [](IMATH_NAMESPACE::Box2d* box, IMATH_NAMESPACE::V2d const& point ) {
             return box->intersects(point); 
         })
-        .def("intersects", [](Imath::Box2d* box, Imath::Box2d const& rhs ) {
+        .def("intersects", [](IMATH_NAMESPACE::Box2d* box, IMATH_NAMESPACE::Box2d const& rhs ) {
             return box->intersects(rhs); 
         });
 }

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -701,7 +701,7 @@ static void define_media_references(py::module m) {
         .def(py::init([](std::string name,
                          optional<TimeRange> available_range,
                          py::object metadata,
-                         optional<Imath::Box2d> const& available_image_bounds) {
+                         optional<IMATH_NAMESPACE::Box2d> const& available_image_bounds) {
                           return new MediaReference(name, available_range, py_to_any_dictionary(metadata), available_image_bounds); }),
              py::arg_v("name"_a = std::string()),
              "available_range"_a = nullopt,
@@ -717,7 +717,7 @@ static void define_media_references(py::module m) {
         .def(py::init([](std::string name, std::string generator_kind,
                          optional<TimeRange> const& available_range,
                          py::object parameters, py::object metadata,
-                         optional<Imath::Box2d> const& available_image_bounds) {
+                         optional<IMATH_NAMESPACE::Box2d> const& available_image_bounds) {
                           return new GeneratorReference(name, generator_kind,
                                                         available_range,
                                                         py_to_any_dictionary(parameters),
@@ -745,7 +745,7 @@ Note that a :class:`~MissingReference` may have useful metadata, even if the loc
                         std::string name,
                         optional<TimeRange> available_range,
                         py::object metadata,
-                        optional<Imath::Box2d> const& available_image_bounds) {
+                        optional<IMATH_NAMESPACE::Box2d> const& available_image_bounds) {
                     return new MissingReference(
                                   name,
                                   available_range,
@@ -763,7 +763,7 @@ Note that a :class:`~MissingReference` may have useful metadata, even if the loc
         .def(py::init([](std::string target_url,
                          optional<TimeRange> const& available_range,
                          py::object metadata,
-                         optional<Imath::Box2d> const& available_image_bounds) {
+                         optional<IMATH_NAMESPACE::Box2d> const& available_image_bounds) {
                           return new ExternalReference(target_url,
                                                         available_range,
                                                         py_to_any_dictionary(metadata),
@@ -859,7 +859,7 @@ Negative ``start_frame`` is also handled. The above example with a ``start_frame
                          ImageSequenceReference::MissingFramePolicy const missing_frame_policy,
                          optional<TimeRange> const& available_range,
                          py::object metadata,
-                         optional<Imath::Box2d> const& available_image_bounds) {
+                         optional<IMATH_NAMESPACE::Box2d> const& available_image_bounds) {
                           return new ImageSequenceReference(target_url_base,
                                                             name_prefix,
                                                             name_suffix,


### PR DESCRIPTION
Fixes #1499

Use the Imath namespace preprocessor macro `IMATH_NAMESPACE` in place of `Imath`. This allows an external-use Imath with a custom namespace to be used. This PR addresses at least one of the issues from bug report #1499.

Changed all the source code references of `Imath::` with `IMATH_NAMESPACE::`.