### PR TITLE
Add utility functions for comparison and rounding

### DIFF
--- a/src/opentime/rationalTime.h
+++ b/src/opentime/rationalTime.h
@@ -87,20 +87,20 @@ public:
 
     // Return a RationalTime with the largest integer value not greater than
     // this value.
-    RationalTime floor_value() const
+    RationalTime floor() const
     {
         return RationalTime{ std::floor(_value), _rate };
     }
 
     // Return a RationalTime with the smallest integer value not less than
     // this value.
-    RationalTime ceil_value() const
+    RationalTime ceil() const
     {
         return RationalTime{ std::ceil(_value), _rate };
     }
 
     // Return a RationalTime with the nearest integer value to this value.
-    RationalTime round_value() const
+    RationalTime round() const
     {
         return RationalTime{ std::round(_value), _rate };
     }

--- a/src/opentime/rationalTime.h
+++ b/src/opentime/rationalTime.h
@@ -80,27 +80,27 @@ public:
     // Return whether the value and rate are equal to another RationalTime.
     // This is different from the operator "==" that rescales the time before
     // comparison.
-    constexpr bool exactly_equal(RationalTime other) const noexcept
+    constexpr bool strictly_equal(RationalTime other) const noexcept
     {
         return _value == other._value && _rate == other._rate;
     }
 
     // Return a RationalTime with the largest integer value not greater than
     // this value.
-    RationalTime floor() const
+    RationalTime floor_value() const
     {
         return RationalTime{ std::floor(_value), _rate };
     }
 
     // Return a RationalTime with the smallest integer value not less than
     // this value.
-    RationalTime ceil() const
+    RationalTime ceil_value() const
     {
         return RationalTime{ std::ceil(_value), _rate };
     }
 
     // Return a RationalTime with the nearest integer value to this value.
-    RationalTime round() const
+    RationalTime round_value() const
     {
         return RationalTime{ std::round(_value), _rate };
     }

--- a/src/opentime/rationalTime.h
+++ b/src/opentime/rationalTime.h
@@ -77,6 +77,34 @@ public:
         return fabs(value_rescaled_to(other._rate) - other._value) <= delta;
     }
 
+    // Return whether the value and rate are equal to another RationalTime.
+    // This is different from the operator "==" that rescales the time before
+    // comparison.
+    constexpr bool exactly_equal(RationalTime other) const noexcept
+    {
+        return _value == other._value && _rate == other._rate;
+    }
+
+    // Return a RationalTime with the largest integer value not greater than
+    // this value.
+    RationalTime floor() const
+    {
+        return RationalTime{ std::floor(_value), _rate };
+    }
+
+    // Return a RationalTime with the smallest integer value not less than
+    // this value.
+    RationalTime ceil() const
+    {
+        return RationalTime{ std::ceil(_value), _rate };
+    }
+
+    // Return a RationalTime with the nearest integer value to this value.
+    RationalTime round() const
+    {
+        return RationalTime{ std::round(_value), _rate };
+    }
+
     static RationalTime constexpr duration_from_start_end_time(
         RationalTime start_time,
         RationalTime end_time_exclusive) noexcept
@@ -262,11 +290,6 @@ public:
 private:
     static RationalTime     _invalid_time;
     static constexpr double _invalid_rate = -1;
-
-    RationalTime _floor() const noexcept
-    {
-        return RationalTime{ floor(_value), _rate };
-    }
 
     friend class TimeTransform;
     friend class TimeRange;

--- a/src/opentime/timeRange.h
+++ b/src/opentime/timeRange.h
@@ -62,7 +62,7 @@ public:
         if ((et - _start_time.rescaled_to(_duration))._value > 1)
         {
             return _duration._value != std::floor(_duration._value)
-                       ? et.floor_value()
+                       ? et.floor()
                        : et - RationalTime(1, _duration._rate);
         }
         else

--- a/src/opentime/timeRange.h
+++ b/src/opentime/timeRange.h
@@ -62,7 +62,7 @@ public:
         if ((et - _start_time.rescaled_to(_duration))._value > 1)
         {
             return _duration._value != floor(_duration._value)
-                       ? et._floor()
+                       ? et.floor()
                        : et - RationalTime(1, _duration._rate);
         }
         else

--- a/src/opentime/timeRange.h
+++ b/src/opentime/timeRange.h
@@ -61,8 +61,8 @@ public:
 
         if ((et - _start_time.rescaled_to(_duration))._value > 1)
         {
-            return _duration._value != floor(_duration._value)
-                       ? et.floor()
+            return _duration._value != std::floor(_duration._value)
+                       ? et.floor_value()
                        : et - RationalTime(1, _duration._rate);
         }
         else

--- a/src/py-opentimelineio/opentime-bindings/opentime_rationalTime.cpp
+++ b/src/py-opentimelineio/opentime-bindings/opentime_rationalTime.cpp
@@ -81,6 +81,10 @@ or if the rate is less than or equal to zero.
         .def("value_rescaled_to", (double (RationalTime::*)(RationalTime) const) &RationalTime::value_rescaled_to,
              "other"_a)
         .def("almost_equal", &RationalTime::almost_equal, "other"_a, "delta"_a = 0)
+        .def("strictly_equal", &RationalTime::strictly_equal, "other"_a)
+        .def("floor_value", &RationalTime::floor_value)
+        .def("ceil_value", &RationalTime::ceil_value)
+        .def("round_value", &RationalTime::round_value)
         .def("__copy__", [](RationalTime rt) {
                 return rt;
             })

--- a/src/py-opentimelineio/opentime-bindings/opentime_rationalTime.cpp
+++ b/src/py-opentimelineio/opentime-bindings/opentime_rationalTime.cpp
@@ -82,9 +82,9 @@ or if the rate is less than or equal to zero.
              "other"_a)
         .def("almost_equal", &RationalTime::almost_equal, "other"_a, "delta"_a = 0)
         .def("strictly_equal", &RationalTime::strictly_equal, "other"_a)
-        .def("floor_value", &RationalTime::floor_value)
-        .def("ceil_value", &RationalTime::ceil_value)
-        .def("round_value", &RationalTime::round_value)
+        .def("floor", &RationalTime::floor)
+        .def("ceil", &RationalTime::ceil)
+        .def("round", &RationalTime::round)
         .def("__copy__", [](RationalTime rt) {
                 return rt;
             })

--- a/tests/test_opentime.cpp
+++ b/tests/test_opentime.cpp
@@ -27,6 +27,8 @@ main(int argc, char** argv)
         assertEqual(t1, t1);
         otime::RationalTime t2(30.2);
         assertEqual(t1, t2);
+        otime::RationalTime t3(60.4, 2.0);
+        assertEqual(t1, t3);
     });
 
     tests.add_test("test_inequality", [] {
@@ -36,6 +38,26 @@ main(int argc, char** argv)
         assertNotEqual(t1, t2);
         otime::RationalTime t3(30.2);
         assertFalse(t1 != t3);
+    });
+
+    tests.add_test("test_exact_equality", [] {
+        otime::RationalTime t1(30.2);
+        assertTrue(t1.exactly_equal(t1));
+        otime::RationalTime t2(30.2);
+        assertTrue(t1.exactly_equal(t2));
+        otime::RationalTime t3(60.4, 2.0);
+        assertFalse(t1.exactly_equal(t3));
+    });
+
+    tests.add_test("test_rounding", [] {
+        otime::RationalTime t1(30.2);
+        assertEqual(t1.floor(), otime::RationalTime(30.0));
+        assertEqual(t1.ceil(), otime::RationalTime(31.0));
+        assertEqual(t1.round(), otime::RationalTime(30.0));
+        otime::RationalTime t2(30.8);
+        assertEqual(t2.floor(), otime::RationalTime(30.0));
+        assertEqual(t2.ceil(), otime::RationalTime(31.0));
+        assertEqual(t2.round(), otime::RationalTime(31.0));
     });
 
     tests.add_test("test_from_time_string", [] {

--- a/tests/test_opentime.cpp
+++ b/tests/test_opentime.cpp
@@ -40,24 +40,24 @@ main(int argc, char** argv)
         assertFalse(t1 != t3);
     });
 
-    tests.add_test("test_exact_equality", [] {
+    tests.add_test("test_strict_equality", [] {
         otime::RationalTime t1(30.2);
-        assertTrue(t1.exactly_equal(t1));
+        assertTrue(t1.strictly_equal(t1));
         otime::RationalTime t2(30.2);
-        assertTrue(t1.exactly_equal(t2));
+        assertTrue(t1.strictly_equal(t2));
         otime::RationalTime t3(60.4, 2.0);
-        assertFalse(t1.exactly_equal(t3));
+        assertFalse(t1.strictly_equal(t3));
     });
 
     tests.add_test("test_rounding", [] {
         otime::RationalTime t1(30.2);
-        assertEqual(t1.floor(), otime::RationalTime(30.0));
-        assertEqual(t1.ceil(), otime::RationalTime(31.0));
-        assertEqual(t1.round(), otime::RationalTime(30.0));
+        assertEqual(t1.floor_value(), otime::RationalTime(30.0));
+        assertEqual(t1.ceil_value(), otime::RationalTime(31.0));
+        assertEqual(t1.round_value(), otime::RationalTime(30.0));
         otime::RationalTime t2(30.8);
-        assertEqual(t2.floor(), otime::RationalTime(30.0));
-        assertEqual(t2.ceil(), otime::RationalTime(31.0));
-        assertEqual(t2.round(), otime::RationalTime(31.0));
+        assertEqual(t2.floor_value(), otime::RationalTime(30.0));
+        assertEqual(t2.ceil_value(), otime::RationalTime(31.0));
+        assertEqual(t2.round_value(), otime::RationalTime(31.0));
     });
 
     tests.add_test("test_from_time_string", [] {

--- a/tests/test_opentime.cpp
+++ b/tests/test_opentime.cpp
@@ -51,13 +51,13 @@ main(int argc, char** argv)
 
     tests.add_test("test_rounding", [] {
         otime::RationalTime t1(30.2);
-        assertEqual(t1.floor_value(), otime::RationalTime(30.0));
-        assertEqual(t1.ceil_value(), otime::RationalTime(31.0));
-        assertEqual(t1.round_value(), otime::RationalTime(30.0));
+        assertEqual(t1.floor(), otime::RationalTime(30.0));
+        assertEqual(t1.ceil(), otime::RationalTime(31.0));
+        assertEqual(t1.round(), otime::RationalTime(30.0));
         otime::RationalTime t2(30.8);
-        assertEqual(t2.floor_value(), otime::RationalTime(30.0));
-        assertEqual(t2.ceil_value(), otime::RationalTime(31.0));
-        assertEqual(t2.round_value(), otime::RationalTime(31.0));
+        assertEqual(t2.floor(), otime::RationalTime(30.0));
+        assertEqual(t2.ceil(), otime::RationalTime(31.0));
+        assertEqual(t2.round(), otime::RationalTime(31.0));
     });
 
     tests.add_test("test_from_time_string", [] {

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -55,13 +55,13 @@ class TestTime(unittest.TestCase):
 
     def test_rounding(self):
         t1 = otio.opentime.RationalTime(30.2)
-        self.assertEqual(t1.floor_value(), otio.opentime.RationalTime(30.0))
-        self.assertEqual(t1.ceil_value(), otio.opentime.RationalTime(31.0))
-        self.assertEqual(t1.round_value(), otio.opentime.RationalTime(30.0))
+        self.assertEqual(t1.floor(), otio.opentime.RationalTime(30.0))
+        self.assertEqual(t1.ceil(), otio.opentime.RationalTime(31.0))
+        self.assertEqual(t1.round(), otio.opentime.RationalTime(30.0))
         t2 = otio.opentime.RationalTime(30.8)
-        self.assertEqual(t2.floor_value(), otio.opentime.RationalTime(30.0))
-        self.assertEqual(t2.ceil_value(), otio.opentime.RationalTime(31.0))
-        self.assertEqual(t2.round_value(), otio.opentime.RationalTime(31.0))
+        self.assertEqual(t2.floor(), otio.opentime.RationalTime(30.0))
+        self.assertEqual(t2.ceil(), otio.opentime.RationalTime(31.0))
+        self.assertEqual(t2.round(), otio.opentime.RationalTime(31.0))
 
     def test_comparison(self):
         t1 = otio.opentime.RationalTime(15.2)

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -32,6 +32,8 @@ class TestTime(unittest.TestCase):
         t2 = otio.opentime.RationalTime(30.2)
         self.assertTrue(t1 is not t2)
         self.assertEqual(t1, t2)
+        t3 = otio.opentime.RationalTime(60.4, 2.0)
+        self.assertEqual(t1, t3)
 
     def test_inequality(self):
         t1 = otio.opentime.RationalTime(30.2)
@@ -42,6 +44,24 @@ class TestTime(unittest.TestCase):
         t3 = otio.opentime.RationalTime(30.2)
         self.assertTrue(t1 is not t3)
         self.assertFalse(t1 != t3)
+
+    def test_strict_equality(self):
+        t1 = otio.opentime.RationalTime(30.2)
+        self.assertTrue(t1.strictly_equal(t1))
+        t2 = otio.opentime.RationalTime(30.2)
+        self.assertTrue(t1.strictly_equal(t2))
+        t3 = otio.opentime.RationalTime(60.4, 2.0)
+        self.assertFalse(t1.strictly_equal(t3))
+
+    def test_rounding(self):
+        t1 = otio.opentime.RationalTime(30.2)
+        self.assertEqual(t1.floor_value(), otio.opentime.RationalTime(30.0))
+        self.assertEqual(t1.ceil_value(), otio.opentime.RationalTime(31.0))
+        self.assertEqual(t1.round_value(), otio.opentime.RationalTime(30.0))
+        t2 = otio.opentime.RationalTime(30.8)
+        self.assertEqual(t2.floor_value(), otio.opentime.RationalTime(30.0))
+        self.assertEqual(t2.ceil_value(), otio.opentime.RationalTime(31.0))
+        self.assertEqual(t2.round_value(), otio.opentime.RationalTime(31.0))
 
     def test_comparison(self):
         t1 = otio.opentime.RationalTime(15.2)


### PR DESCRIPTION
Fixes #1622

This PR adds a few utility functions to RationalTime for comparison and rounding:
* A function that compares whether two RationalTimes have the same value and rate. This is different from the "==" operator which scales the time before comparison (e.g., otime::RationalTime(30.2) == otime::RationalTime(60.4, 2.0)).
* Rounding functions that return the floor(), ceil(), and round() of a RationalTime.

If these seem useful I can also add Python bindings for them.