### PR TITLE
Add support for ImageSequenceReference to otioz and otiod adapters

### DIFF
--- a/src/py-opentimelineio/opentimelineio/adapters/file_bundle_utils.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/file_bundle_utils.py
@@ -77,10 +77,9 @@ def _prepped_otio_for_bundle_and_manifest(
 ):
     """ Create a new OTIO based on input_otio that has had media references
     replaced according to the media_policy.  Return that new OTIO and a
-    mapping of all the absolute file paths (not URLs) to be used in the bundle,
-    mapped to MediaReferences associated with those files.  Media references in
-    the OTIO will be relinked by the adapters to point to their output
-    locations.
+    list of all the absolute file paths (not URLs) to be used in the bundle.
+    Media references in the OTIO will be relinked by the adapters to point to
+    their output locations.
 
     The otio[dz] adapters use this function to do further relinking and build
     their bundles.
@@ -91,7 +90,7 @@ def _prepped_otio_for_bundle_and_manifest(
     # make sure the incoming OTIO isn't edited
     result_otio = copy.deepcopy(input_otio)
 
-    path_to_reference_map = {}
+    paths = set()
     invalid_files = set()
 
     # result_otio is manipulated in place
@@ -103,68 +102,85 @@ def _prepped_otio_for_bundle_and_manifest(
             )
             continue
 
-        try:
-            target_url = cl.media_reference.target_url
-        except AttributeError:
-            # not an ExternalReference, ignoring it.
-            continue
+        for mr in cl.media_references().values():
+            if isinstance(mr, schema.ImageSequenceReference):
+                url = cl.media_reference.target_url_base
+            else:
+                try:
+                    url = cl.media_reference.target_url
+                except AttributeError:
+                    # not an ImageSequenceReference or object with target_url,
+                    # ignoring it.
+                    continue
 
-        parsed_url = urlparse.urlparse(target_url)
+            parsed_url = urlparse.urlparse(url)
 
-        # ensure that the urlscheme is either file or ""
-        # file means "absolute path"
-        # none is interpreted as a relative path, relative to cwd
-        if parsed_url.scheme not in ("file", ""):
-            if media_policy is MediaReferencePolicy.ErrorIfNotFile:
-                raise NotAFileOnDisk(
-                    "The {} adapter only works with media reference"
-                    " target_url attributes that begin with 'file:'.  Got a "
-                    "target_url of:  '{}'".format(adapter_name, target_url)
-                )
-            if media_policy is MediaReferencePolicy.MissingIfNotFile:
-                cl.media_reference = reference_cloned_and_missing(
-                    cl.media_reference,
-                    "target_url is not a file scheme url (start with url:)"
-                )
-                continue
+            # ensure that the urlscheme is either file or ""
+            # file means "absolute path"
+            # none is interpreted as a relative path, relative to cwd
+            if parsed_url.scheme not in ("file", ""):
+                if media_policy is MediaReferencePolicy.ErrorIfNotFile:
+                    raise NotAFileOnDisk(
+                        "The {} adapter only works with file URLs."
+                        " Got a URL of:  '{}'".format(adapter_name, url)
+                    )
+                if media_policy is MediaReferencePolicy.MissingIfNotFile:
+                    cl.media_reference = reference_cloned_and_missing(
+                        cl.media_reference,
+                        "not a file URL"
+                    )
+                    continue
 
-        # get an absolute path to the target file
-        target_file = os.path.abspath(url_utils.filepath_from_url(target_url))
+            # get absolute paths to the target files
+            target_files = []
+            if isinstance(mr, schema.ImageSequenceReference):
+                for number in range(mr.number_of_images_in_sequence()):
+                    target_files.append(os.path.abspath(
+                        url_utils.filepath_from_url(
+                            mr.target_url_for_image_number(number))))
+            else:
+                target_files.append(os.path.abspath(
+                    url_utils.filepath_from_url(url)))
 
-        # if the file hasn't already been checked
-        if (
-            target_file not in path_to_reference_map
-            and target_file not in invalid_files
-            and (
-                not os.path.exists(target_file)
-                or not os.path.isfile(target_file)
-            )
-        ):
-            invalid_files.add(target_file)
+            # if the file hasn't already been checked
+            for target_file in target_files:
+                if (
+                    target_file not in paths
+                    and target_file not in invalid_files
+                    and (
+                        not os.path.exists(target_file)
+                        or not os.path.isfile(target_file)
+                    )
+                ):
+                    invalid_files.add(target_file)
 
-        if target_file in invalid_files:
-            if media_policy is MediaReferencePolicy.ErrorIfNotFile:
-                raise NotAFileOnDisk(target_file)
-            if media_policy is MediaReferencePolicy.MissingIfNotFile:
-                cl.media_reference = reference_cloned_and_missing(
-                    cl.media_reference,
-                    "target_url target is not a file or does not exist"
-                )
+            invalid = False
+            for target_file in target_files:
+                if target_file in invalid_files:
+                    if media_policy is MediaReferencePolicy.ErrorIfNotFile:
+                        raise NotAFileOnDisk(target_file)
+                    invalid = True
+                    break
+            if invalid:
+                if media_policy is MediaReferencePolicy.MissingIfNotFile:
+                    cl.media_reference = reference_cloned_and_missing(
+                        cl.media_reference,
+                        "not a file URL or does not exist"
+                    )
 
-                # do not need to relink it in the future or add this target to
-                # the manifest, because the path is either not a file or does
-                # not exist.
-                continue
+                    # do not need to relink it in the future or add this target to
+                    # the manifest, because the path is either not a file or does
+                    # not exist.
+                    continue
 
-        # add the media reference to the list of references that point at this
-        # file, they will need to be relinked
-        path_to_reference_map.setdefault(target_file, []).append(
-            cl.media_reference
-        )
+            # add the media reference to the list of references that point at this
+            # file, they will need to be relinked
+            for target_file in target_files:
+                paths.add(target_file)
 
-    _guarantee_unique_basenames(path_to_reference_map.keys(), adapter_name)
+    _guarantee_unique_basenames(paths, adapter_name)
 
-    return result_otio, path_to_reference_map
+    return result_otio, list(paths)
 
 
 def _total_file_size_of(filepaths):

--- a/src/py-opentimelineio/opentimelineio/adapters/otiod.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/otiod.py
@@ -19,6 +19,7 @@ from . import (
 
 from .. import (
     exceptions,
+    schema,
     url_utils,
 )
 
@@ -82,14 +83,13 @@ def write_to_file(
     # -------------------------------------------------------------------------
     # - build file manifest (list of paths to files on disk that will be put
     #   into the archive)
-    # - build a mapping of path to file on disk to url to put into the media
-    #   reference in the result
+    # - build a mapping of input paths to output paths
     # - relink the media references to point at the final location inside the
     #   archive
     # - build the resulting structure (zip file, directory)
     # -------------------------------------------------------------------------
 
-    result_otio, path_to_mr_map = utils._prepped_otio_for_bundle_and_manifest(
+    result_otio, paths = utils._prepped_otio_for_bundle_and_manifest(
         input_otio,
         media_policy,
         "OTIOD"
@@ -97,35 +97,48 @@ def write_to_file(
 
     # dryrun reports the total size of files
     if dryrun:
-        return utils._total_file_size_of(path_to_mr_map.keys())
+        return utils._total_file_size_of(paths)
 
+    # get the output paths
     abspath_to_output_path_map = {}
-
-    # relink all the media references to their target paths
-    for abspath, references in path_to_mr_map.items():
+    for abspath in paths:
         target = os.path.join(
             filepath,
             utils.BUNDLE_DIR_NAME,
             os.path.basename(abspath)
         )
+        abspath_to_output_path_map[abspath] = target
 
-        # conform to posix style paths inside the bundle, so that they are
-        # portable between windows and *nix style environments
-        final_path = str(pathlib.Path(target).as_posix())
+    # relink all the media references to their target paths
+    for cl in result_otio.find_clips():
+        for mr in cl.media_references().values():
+            if isinstance(mr, schema.ImageSequenceReference):
+                url = cl.media_reference.target_url_base
+            else:
+                try:
+                    url = cl.media_reference.target_url
+                except AttributeError:
+                    continue
+            url_utils.filepath_from_url(url)
 
-        # cache the output path
-        abspath_to_output_path_map[abspath] = final_path
+            target = os.path.join(
+                utils.BUNDLE_DIR_NAME,
+                os.path.basename(url_utils.filepath_from_url(url)))
 
-        for mr in references:
-            # author the relative path from the root of the bundle in url
-            # form into the target_url
-            mr.target_url = url_utils.url_from_filepath(
-                os.path.relpath(final_path, filepath)
-            )
+            # conform to posix style paths inside the bundle, so that they are
+            # portable between windows and *nix style environments
+            final_path = str(pathlib.Path(target).as_posix())
+
+            # author the final_path in url form into the media reference
+            url = url_utils.url_from_filepath(final_path)
+            if isinstance(mr, schema.ImageSequenceReference):
+                mr.target_url_base = url if url.endswith('/') else url + '/'
+            else:
+                mr.target_url = url
 
     os.mkdir(filepath)
 
-    # write the otioz file to the temp directory
+    # write the otio file
     otio_json.write_to_file(
         result_otio,
         os.path.join(filepath, utils.BUNDLE_PLAYLIST_PATH)

--- a/src/py-opentimelineio/opentimelineio/adapters/otiod.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/otiod.py
@@ -119,7 +119,6 @@ def write_to_file(
                     url = cl.media_reference.target_url
                 except AttributeError:
                     continue
-            url_utils.filepath_from_url(url)
 
             target = os.path.join(
                 utils.BUNDLE_DIR_NAME,

--- a/src/py-opentimelineio/opentimelineio/adapters/otioz.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/otioz.py
@@ -116,7 +116,6 @@ def write_to_file(
                     url = cl.media_reference.target_url
                 except AttributeError:
                     continue
-            url_utils.filepath_from_url(url)
 
             target = os.path.join(
                 utils.BUNDLE_DIR_NAME,

--- a/tests/test_otiod.py
+++ b/tests/test_otiod.py
@@ -7,6 +7,7 @@
 
 import unittest
 import os
+import pathlib
 import tempfile
 
 import opentimelineio as otio
@@ -118,14 +119,13 @@ class OTIODTester(unittest.TestCase, otio_test_utils.OTIOAssertions):
         # conform media references in input to what they should be in the output
         for cl in self.tl.find_clips():
             # construct an absolute file path to the result
-            cl.media_reference.target_url = (
-                otio.url_utils.url_from_filepath(
-                    os.path.join(
-                        otio.adapters.file_bundle_utils.BUNDLE_DIR_NAME,
-                        os.path.basename(cl.media_reference.target_url)
-                    )
-                )
+            url = cl.media_reference.target_url
+            target = os.path.join(
+                otio.adapters.file_bundle_utils.BUNDLE_DIR_NAME,
+                os.path.basename(url)
             )
+            final_path = str(pathlib.Path(target).as_posix())
+            cl.media_reference.target_url = final_path
 
         self.assertJsonEqual(result, self.tl)
 

--- a/tests/test_otiod.py
+++ b/tests/test_otiod.py
@@ -64,7 +64,7 @@ class OTIODTester(unittest.TestCase, otio_test_utils.OTIOAssertions):
             )
         )
 
-        self.assertEqual(manifest, {})
+        self.assertEqual(manifest, [])
         for cl in result_otio.find_clips():
             self.assertIsInstance(
                 cl.media_reference,
@@ -87,9 +87,9 @@ class OTIODTester(unittest.TestCase, otio_test_utils.OTIOAssertions):
             )
         )
 
-        self.assertEqual(len(manifest.keys()), 2)
+        self.assertEqual(len(manifest), 2)
 
-        files_in_manifest = set(manifest.keys())
+        files_in_manifest = set(manifest)
         known_files = {
             MEDIA_EXAMPLE_PATH_ABS: 5,
             os.path.abspath(MEDIA_EXAMPLE_PATH_REL): 4
@@ -97,9 +97,6 @@ class OTIODTester(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
         # should only contain absolute paths
         self.assertEqual(files_in_manifest, set(known_files.keys()))
-
-        for fname, count in known_files.items():
-            self.assertEqual(len(manifest[fname]), count)
 
     def test_round_trip(self):
         with tempfile.NamedTemporaryFile(suffix=".otiod") as bogusfile:


### PR DESCRIPTION
Fixes #1621

This PR adds support for ImageSequenceReference media references to the otioz and otiod adapters. It should also add support for multiple media references but I haven't tested that yet.

The main changes are to the function ```_prepped_otio_for_bundle_and_manifest``` which is shared by both adapters. Previously the function returned a map of media paths and associated media references. The media paths were used to locate the media files and the media references were used to relink the resulting .otio file. Since image sequence references can produce multiple media paths (render.0001.exr, render.0002.exr, etc.) that mapping didn't seem to make sense any more so I changed the function to just return the list of media files. The relinking is now handled as a separate step that iterates through the media references on its own.

I have tested converting some simple .otio files with both movies and image sequences to .otioz and .otiod and have verified the results look OK. Most of the unit tests look like they are passing OK though I still need to add tests for the new functionality.