### PR TITLE
CMake config file improvements to find dependencies automatically for consumers

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -39,6 +39,7 @@ jobs:
       OTIO_BUILD_CONFIG: Release
       OTIO_BUILD_DIR: ${{ github.workspace }}/build
       OTIO_INSTALL_DIR: ${{ github.workspace }}/install
+      OTIO_CONSUMER_TEST_BUILD_DIR: ${{ github.workspace }}/consumertest
 
     steps:
     - uses: actions/checkout@v3
@@ -81,6 +82,11 @@ jobs:
       run: |
         cd ${{ env.OTIO_BUILD_DIR }}
         cmake --build . --target install --config ${{ env.OTIO_BUILD_CONFIG }}
+    - name: Consumer tests
+      run: |
+        cmake -E make_directory ${{ env.OTIO_CONSUMER_TEST_BUILD_DIR }}
+        cd ${{ env.OTIO_CONSUMER_TEST_BUILD_DIR }}
+        cmake ${{ github.workspace }}/tests/consumer -DCMAKE_PREFIX_PATH=${{ env.OTIO_INSTALL_DIR }}
 
   py_build_test:
     runs-on: ${{ matrix.os }}

--- a/src/opentime/CMakeLists.txt
+++ b/src/opentime/CMakeLists.txt
@@ -42,14 +42,31 @@ if(OTIO_CXX_INSTALL)
             DESTINATION "${OTIO_RESOLVED_CXX_INSTALL_DIR}/include/opentime")
 
     install(TARGETS opentime
-            EXPORT OpenTimeConfig
+            EXPORT OpenTimeTargets
             INCLUDES DESTINATION "${OTIO_RESOLVED_CXX_INSTALL_DIR}/include"
             ARCHIVE DESTINATION "${OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR}"
             LIBRARY DESTINATION "${OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR}"
             RUNTIME DESTINATION "${OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR}")
 
-    install(EXPORT OpenTimeConfig
+    install(EXPORT OpenTimeTargets
             DESTINATION "${OTIO_RESOLVED_CXX_INSTALL_DIR}/share/opentime"
             NAMESPACE OTIO:: )
+
+    include(CMakePackageConfigHelpers)
+    configure_package_config_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/OpenTimeConfig.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/OpenTimeConfig.cmake
+        INSTALL_DESTINATION
+            ${OTIO_RESOLVED_CXX_INSTALL_DIR}/share/opentime
+        NO_SET_AND_CHECK_MACRO
+        NO_CHECK_REQUIRED_COMPONENTS_MACRO
+    )
+
+    install(
+        FILES
+            ${CMAKE_CURRENT_BINARY_DIR}/OpenTimeConfig.cmake
+        DESTINATION
+            ${OTIO_RESOLVED_CXX_INSTALL_DIR}/share/opentime
+    )
 endif()
 

--- a/src/opentime/OpenTimeConfig.cmake.in
+++ b/src/opentime/OpenTimeConfig.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/OpenTimeTargets.cmake")

--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -118,13 +118,30 @@ if(OTIO_CXX_INSTALL)
     endif()
 
     install(TARGETS opentimelineio
-           EXPORT OpenTimelineIOConfig
+           EXPORT OpenTimelineIOTargets
            INCLUDES DESTINATION "${OPENTIMELINEIO_INCLUDES}"
            ARCHIVE DESTINATION "${OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR}"
            LIBRARY DESTINATION "${OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR}"
            RUNTIME DESTINATION "${OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR}")
 
-    install(EXPORT OpenTimelineIOConfig
+    install(EXPORT OpenTimelineIOTargets
            DESTINATION "${OTIO_RESOLVED_CXX_INSTALL_DIR}/share/opentimelineio"
            NAMESPACE OTIO:: )
+
+    include(CMakePackageConfigHelpers)
+    configure_package_config_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/OpenTimelineIOConfig.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/OpenTimelineIOConfig.cmake
+        INSTALL_DESTINATION
+            ${OTIO_RESOLVED_CXX_INSTALL_DIR}/share/opentimelineio
+        NO_SET_AND_CHECK_MACRO
+        NO_CHECK_REQUIRED_COMPONENTS_MACRO
+    )
+
+    install(
+        FILES
+            ${CMAKE_CURRENT_BINARY_DIR}/OpenTimelineIOConfig.cmake
+        DESTINATION
+            ${OTIO_RESOLVED_CXX_INSTALL_DIR}/share/opentimelineio
+    )
 endif()

--- a/src/opentimelineio/OpenTimelineIOConfig.cmake.in
+++ b/src/opentimelineio/OpenTimelineIOConfig.cmake.in
@@ -1,3 +1,6 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+find_dependency(OpenTime)
+
 include("${CMAKE_CURRENT_LIST_DIR}/OpenTimelineIOTargets.cmake")

--- a/src/opentimelineio/OpenTimelineIOConfig.cmake.in
+++ b/src/opentimelineio/OpenTimelineIOConfig.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/OpenTimelineIOTargets.cmake")

--- a/tests/consumer/CMakeLists.txt
+++ b/tests/consumer/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.18.2 FATAL_ERROR)
+
+project(consumer_tests)
+
+add_subdirectory(opentime)
+add_subdirectory(opentimeline)

--- a/tests/consumer/opentime/CMakeLists.txt
+++ b/tests/consumer/opentime/CMakeLists.txt
@@ -1,0 +1,2 @@
+find_package(OpenTime REQUIRED)
+message(STATUS "Found OpenTime successfully at '${OpenTime_DIR}'")

--- a/tests/consumer/opentimeline/CMakeLists.txt
+++ b/tests/consumer/opentimeline/CMakeLists.txt
@@ -1,0 +1,2 @@
+find_package(OpenTimelineIO REQUIRED)
+message(STATUS "Found OpenTimelineIO successfully at '${OpenTimelineIO_DIR}'")


### PR DESCRIPTION
Proposed fixes for https://github.com/AcademySoftwareFoundation/OpenTimelineIO/issues/1192

**Summarize your change.**

In terms of CMake target resolution in link steps, just finding OpenTimelineIO was insufficient, as it depends on OpenTime, so consumers needed to know this detail. It's preferrable that consumers just find packages they are interested in, without knowledge of implementation details of build dependencies.

This change moves to using a canonical form of CMake config files, whereby the `*Config.cmake` is generated from a template allowing dependencies to be found, while the CMake generation of import targets is renamed to a `*Targets.cmake` file. The `*Config.cmake` file includes the `*Target.cmake` file.

See https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#creating-packages for an example.

There are a number of ways to solve the problem, but this was the least invasive.

**Reference associated tests.**

This change adds 'consumer' C++ tests, which runs the CMake configuration step, which is sufficient to determine if all necessary CMake targets are present.