### PR TITLE
Add C++17 guard to casters.h

### DIFF
--- a/src/py-opentimelineio/bindings-common/casters.h
+++ b/src/py-opentimelineio/bindings-common/casters.h
@@ -15,6 +15,8 @@ namespace pybind11 { namespace detail {
     // becomes std::optional starting in C++17, and Pybind11 already defines
     // casters for std::optional, this becomes a duplicate (and therefore build
     // error).
+    // The casters can be removed when C++ versions less than 17 are no longer
+    // supported by OTIO.
     template<typename T> struct type_caster<optional<T>>
         : public optional_caster<optional<T>> {};
 

--- a/src/py-opentimelineio/bindings-common/casters.h
+++ b/src/py-opentimelineio/bindings-common/casters.h
@@ -5,14 +5,20 @@
 using nonstd::optional;
 using nonstd::nullopt_t;
 
+#if __cplusplus < 201703L
 namespace pybind11 { namespace detail {
     // Caster for converting to/from nonstd::optional.
     // Pybind11 supports optional types when C++17 is used.
-    // So for now we have to create the casters manually.
-    // See https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html#c-17-library-containers
+    // So for now we have to create the casters manually. See
+    // https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html#c-17-library-containers
+    // ...however, if this is present AFTER c++17, because nonstd::optional
+    // becomes std::optional starting in C++17, and Pybind11 already defines
+    // casters for std::optional, this becomes a duplicate (and therefore build
+    // error).
     template<typename T> struct type_caster<optional<T>>
         : public optional_caster<optional<T>> {};
 
     template<> struct type_caster<nullopt_t>
         : public void_caster<nullopt_t> {};
 }}
+#endif


### PR DESCRIPTION
When building with C++17 turned ON, our `optional` and `any` libraries, `nonstd::optional` and `nonstd::any`, are replaced with the ones present in `std` in C++17 on.  Because Pybind11 already defines casters for the `std::optional`, this causes a build error, duplicate definition, with the definition found in casters.h.  This PR guards the definition in casters.h and adds to the comment describing why its guarded and when casters.h can be removed.