### PR TITLE
Adds support to `filepath_from_url` to support non-encoded URLs

### DIFF
--- a/src/py-opentimelineio/opentimelineio/url_utils.py
+++ b/src/py-opentimelineio/opentimelineio/url_utils.py
@@ -9,8 +9,10 @@ from urllib import (
     parse as urlparse,
     request
 )
-import pathlib
-from pathlib import Path, PureWindowsPath
+from pathlib import (
+    Path,
+    PureWindowsPath
+)
 
 
 def url_from_filepath(fpath):
@@ -19,7 +21,7 @@ def url_from_filepath(fpath):
     try:
         # appears to handle absolute windows paths better, which are absolute
         # and start with a drive letter.
-        return urlparse.unquote(pathlib.Path(fpath).as_uri())
+        return urlparse.unquote(Path(fpath).as_uri())
     except ValueError:
         # scheme is "file" for absolute paths, else ""
         scheme = "file" if os.path.isabs(fpath) else ""

--- a/src/py-opentimelineio/opentimelineio/url_utils.py
+++ b/src/py-opentimelineio/opentimelineio/url_utils.py
@@ -4,7 +4,6 @@
 """Utilities for conversion between urls and file paths"""
 
 import os
-import re
 
 from urllib import (
     parse as urlparse,

--- a/src/py-opentimelineio/opentimelineio/url_utils.py
+++ b/src/py-opentimelineio/opentimelineio/url_utils.py
@@ -4,6 +4,7 @@
 """Utilities for conversion between urls and file paths"""
 
 import os
+import re
 
 from urllib import (
     parse as urlparse,
@@ -52,7 +53,7 @@ def filepath_from_url(urlstr):
     filepath = filepath.replace("\\", "/")
 
     # If on Windows, remove the first leading slash left by urlparse
-    if os.name == 'nt' and filepath.startswith('/'):
+    if filepath.startswith('/') and re.match(r"/[a-zA-Z]:/.*", filepath):
         filepath = filepath[1:]
 
     return filepath

--- a/src/py-opentimelineio/opentimelineio/url_utils.py
+++ b/src/py-opentimelineio/opentimelineio/url_utils.py
@@ -49,6 +49,8 @@ def filepath_from_url(urlstr):
     else:
         filepath = parsed_result.netloc + parsed_result.path
 
+    filepath = filepath.replace("\\", "/")
+
     # If on Windows, remove the first leading slash left by urlparse
     if os.name == 'nt' and filepath.startswith('/'):
         filepath = filepath[1:]

--- a/src/py-opentimelineio/opentimelineio/url_utils.py
+++ b/src/py-opentimelineio/opentimelineio/url_utils.py
@@ -62,8 +62,9 @@ def filepath_from_url(urlstr):
 
     filepath = filepath.replace("\\", "/")
 
-    # If on Windows, remove the first leading slash left by urlparse
-    if filepath.startswith('/') and re.match(r"/[a-zA-Z]:/.*", filepath):
+    # If on Windows and using a drive letter,
+    # remove the first leading slash left by urlparse
+    if re.match(r"/[a-zA-Z]:/.*", filepath):
         filepath = filepath[1:]
 
     return filepath

--- a/src/py-opentimelineio/opentimelineio/url_utils.py
+++ b/src/py-opentimelineio/opentimelineio/url_utils.py
@@ -38,7 +38,17 @@ def url_from_filepath(fpath):
 
 
 def filepath_from_url(urlstr):
-    """ Take a url and return a filepath """
+    """
+    Take an url and return a filepath.
+
+    URLs can either be encoded according to the `RFC 3986`_ standard or not.
+    Additionally, Windows mapped paths need to be accounted for when processing a
+    URL; however, there are `ongoing discussions`_ about how to best handle this within
+    Python. This function is meant to cover all of these scenarios in the interim.
+
+    .. _RFC 3986: https://tools.ietf.org/html/rfc3986#section-2.1
+    .. _ongoing discussions: https://discuss.python.org/t/file-uris-in-python/15600
+    """
 
     parsed_result = urlparse.urlparse(urlstr)
 

--- a/src/py-opentimelineio/opentimelineio/url_utils.py
+++ b/src/py-opentimelineio/opentimelineio/url_utils.py
@@ -40,4 +40,17 @@ def filepath_from_url(urlstr):
     """ Take a url and return a filepath """
 
     parsed_result = urlparse.urlparse(urlstr)
-    return request.url2pathname(parsed_result.path)
+
+    # Check if original urlstr is URL encoded
+    if urlparse.unquote(urlstr) != urlstr:
+        filepath = request.url2pathname(parsed_result.path)
+
+    # Otherwise, combine the netloc and path
+    else:
+        filepath = parsed_result.netloc + parsed_result.path
+
+    # If on Windows, remove the first leading slash left by urlparse
+    if os.name == 'nt' and filepath.startswith('/'):
+        filepath = filepath[1:]
+
+    return filepath

--- a/tests/test_url_conversions.py
+++ b/tests/test_url_conversions.py
@@ -10,7 +10,6 @@ import opentimelineio as otio
 
 SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
 SCREENING_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "screening_example.edl")
-PREMIERE_XML_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "premiere_example.xml")
 MEDIA_EXAMPLE_PATH_REL = os.path.relpath(
     os.path.join(
         os.path.dirname(__file__),
@@ -33,6 +32,10 @@ MEDIA_EXAMPLE_PATH_URL_ABS = otio.url_utils.url_from_filepath(
     MEDIA_EXAMPLE_PATH_ABS
 )
 
+ENCODED_WINDOWS_URL = "file://localhost/S%3a/path/file.ext"
+WINDOWS_URL = "file://S:/path/file.ext"
+CORRECTED_WINDOWS_PATH = "S:/path/file.ext"
+
 
 class TestConversions(unittest.TestCase):
     def test_roundtrip_abs(self):
@@ -52,16 +55,13 @@ class TestConversions(unittest.TestCase):
         # should have reconstructed it by this point
         self.assertEqual(os.path.normpath(result), MEDIA_EXAMPLE_PATH_REL)
 
-    def test_premiere_xml_urls(self):
-        timeline = otio.adapters.read_from_file(PREMIERE_XML_EXAMPLE_PATH)
-        for clip in timeline.find_clips():
-            media_ref = clip.media_reference
-
-            if hasattr(media_ref, 'target_url') and media_ref.target_url is not None:
-                url = media_ref.target_url
-                self.assertTrue(url.startswith("file://"))
-                processed_url = otio.url_utils.filepath_from_url(url)
-                self.assertNotEquals(url, processed_url)
+    def test_windows_urls(self):
+        for url in (ENCODED_WINDOWS_URL, WINDOWS_URL):
+            print(f"Original URL: {url}")
+            self.assertTrue(url.startswith("file://"))
+            processed_url = otio.url_utils.filepath_from_url(url)
+            print(f"Processed URL Path: {url}")
+            self.assertEqual(processed_url, CORRECTED_WINDOWS_PATH)
 
 
 if __name__ == "__main__":

--- a/tests/test_url_conversions.py
+++ b/tests/test_url_conversions.py
@@ -60,7 +60,7 @@ class TestConversions(unittest.TestCase):
             print(f"Original URL: {url}")
             self.assertTrue(url.startswith("file://"))
             processed_url = otio.url_utils.filepath_from_url(url)
-            print(f"Processed URL Path: {url}")
+            print(f"Processed URL Path: {processed_url}")
             self.assertEqual(processed_url, CORRECTED_WINDOWS_PATH)
 
 

--- a/tests/test_url_conversions.py
+++ b/tests/test_url_conversions.py
@@ -10,6 +10,7 @@ import opentimelineio as otio
 
 SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
 SCREENING_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "screening_example.edl")
+PREMIERE_XML_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "premiere_example.xml")
 MEDIA_EXAMPLE_PATH_REL = os.path.relpath(
     os.path.join(
         os.path.dirname(__file__),
@@ -50,6 +51,17 @@ class TestConversions(unittest.TestCase):
 
         # should have reconstructed it by this point
         self.assertEqual(os.path.normpath(result), MEDIA_EXAMPLE_PATH_REL)
+
+    def test_premiere_xml_urls(self):
+        timeline = otio.adapters.read_from_file(PREMIERE_XML_EXAMPLE_PATH)
+        for clip in timeline.find_clips():
+            media_ref = clip.media_reference
+
+            if hasattr(media_ref, 'target_url') and media_ref.target_url is not None:
+                url = media_ref.target_url
+                self.assertTrue(url.startswith("file://"))
+                processed_url = otio.url_utils.filepath_from_url(url)
+                self.assertNotEquals(url, processed_url)
 
 
 if __name__ == "__main__":

--- a/tests/test_url_conversions.py
+++ b/tests/test_url_conversions.py
@@ -57,10 +57,7 @@ class TestConversions(unittest.TestCase):
 
     def test_windows_urls(self):
         for url in (ENCODED_WINDOWS_URL, WINDOWS_URL):
-            print(f"Original URL: {url}")
-            self.assertTrue(url.startswith("file://"))
             processed_url = otio.url_utils.filepath_from_url(url)
-            print(f"Processed URL Path: {processed_url}")
             self.assertEqual(processed_url, CORRECTED_WINDOWS_PATH)
 
 


### PR DESCRIPTION
`filepath_from_url` works for encoded URLs but not for URLs that are not encoded. I encountered this when working with URLs from both `.xml` and `.aaf` files. 

The `.xml` file came from Premiere and encoded the URL while the `.aaf` came from Avid and the URL was not encoded.

Examples:

- `"file://localhost/S%3a/path/file.ext"` -> `"S:/path/file.ext"`
- `"file://S:/path/file.ext"` -> `"/path/file.ext"`

My PR updates the code to return the same result with both of the example URLs:

- `"file://localhost/S%3a/path/file.ext"` -> `"S:/path/file.ext"`
- `"file://S:/path/file.ext"` -> `"S:/path/file.ext"`

I tested and dev-ed this on Windows with OTIO `0.15.0` and `0.16.0.dev1`.