### PR TITLE
Python 3.12 support / imp module deleted

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -93,7 +93,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         include:
           - { os: ubuntu-latest, shell: bash }
           - { os: macos-latest, shell: bash }
@@ -163,7 +163,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-build: ['cp37*', 'cp38*', 'cp39*', 'cp310*', 'cp311*']
+        python-build: ['cp37*', 'cp38*', 'cp39*', 'cp310*', 'cp311*', 'cp312*']
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -168,7 +168,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build wheels (Python 3)
-        uses: pypa/cibuildwheel@v2.11.1
+        uses: pypa/cibuildwheel@v2.16.2
         with:
           output-dir: wheelhouse
         env:

--- a/src/py-opentimelineio/opentimelineio/console/autogen_serialized_datamodel.py
+++ b/src/py-opentimelineio/opentimelineio/console/autogen_serialized_datamodel.py
@@ -200,6 +200,7 @@ def _generate_model_for_module(mod, classes, modules):
             if (
                 inspect.ismodule(thing)
                 and thing not in modules
+                and "opentimelineio" in thing.__name__
                 and all(not thing.__name__.startswith(t) for t in SKIP_MODULES)
             )
         ),

--- a/src/py-opentimelineio/opentimelineio/url_utils.py
+++ b/src/py-opentimelineio/opentimelineio/url_utils.py
@@ -10,8 +10,9 @@ from urllib import (
     request
 )
 from pathlib import (
-    Path,
-    PureWindowsPath
+    PurePath,
+    PureWindowsPath,
+    PurePosixPath
 )
 
 
@@ -21,7 +22,7 @@ def url_from_filepath(fpath):
     try:
         # appears to handle absolute windows paths better, which are absolute
         # and start with a drive letter.
-        return urlparse.unquote(Path(fpath).as_uri())
+        return urlparse.unquote(PurePath(fpath).as_uri())
     except ValueError:
         # scheme is "file" for absolute paths, else ""
         scheme = "file" if os.path.isabs(fpath) else ""
@@ -56,16 +57,16 @@ def filepath_from_url(urlstr):
     parsed_result = urlparse.urlparse(urlstr)
 
     # Convert the parsed URL to a path
-    filepath = Path(request.url2pathname(parsed_result.path))
+    filepath = PurePath(request.url2pathname(parsed_result.path))
 
     # If the network location is a window drive, reassemble the path
     if PureWindowsPath(parsed_result.netloc).drive:
-        filepath = Path(parsed_result.netloc + parsed_result.path)
+        filepath = PurePath(parsed_result.netloc + parsed_result.path)
 
     # Otherwise check if the specified index is a windows drive, then offset the path
     elif PureWindowsPath(filepath.parts[1]).drive:
         # Remove leading "/" if/when `request.url2pathname` yields "/S:/path/file.ext"
-        filepath = filepath.relative_to(filepath.root)
+        filepath = PurePosixPath(*filepath.parts[1:])
 
     # Convert "\" to "/" if needed
     return filepath.as_posix()


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**

https://github.com/AcademySoftwareFoundation/OpenTimelineIO/issues/1668

**Summarize your change.**

The imp module in Python is deprecated since Python 3.4 and is removed in Python 3.12. So the package cannot be imported in Python 3.12 because the imp module doesn't exist anymore. See my issue.

By reading the docs it have to be changed by importlib. So I have made these changes and this works for importing adapters for example :) 

Some documentation :
https://docs.python.org/3.12/whatsnew/3.12.html#imp
https://docs.python.org/3.11/library/imp.html

I have added Python 3.12 in the workflow for Python package. 

I use some linter (black) in my vscode so my changes can be more than the real modifications. If you want I can revert these changes. 

**Reference associated tests.**

Don't have launched the tests, they will run via GitHub Actions, no ?

I'm sorry it's my first PR to OpenTimeLineIO :) 
<!--
Important: If this is your first contribution to OpenTimelineIO, you will need to submit a Contributor License Agreement. For a step-by-step instructions on the pull request process, see
https://github.com/AcademySoftwareFoundation/OpenTimelineIO/tree/main/CONTRIBUTING.md
-->
