### PR TITLE
Updated cibuildwheel settings to generate apple silicon wheels

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -168,7 +168,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build wheels (Python 3)
-        uses: pypa/cibuildwheel@v2.11.1
+        uses: pypa/cibuildwheel@v2.16.2
         with:
           output-dir: wheelhouse
         env:
@@ -176,6 +176,7 @@ jobs:
           CIBW_SKIP: '*musllinux*'
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+          CIBW_ARCHS_MACOS: universal2 arm64
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -176,7 +176,7 @@ jobs:
           CIBW_SKIP: '*musllinux*'
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_I686_IMAGE: manylinux2014
-          CIBW_ARCHS_MACOS: universal2 arm64
+          CIBW_ARCHS_MACOS: x86_64 arm64
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Fixes #1672 


This is a WIP PR for enabling Apple Silicon Support.

Currently, this PR simply enables cibuildwheel for x86_64 and arm64.

TODO:

- [ ] Decide which wheels we feel like we need (is there a demand for `universal2` or are the optimized wheels fine?)
- [ ] Figure out how to do testing on Apple Silicon since [arm64 wheels can't be tested on x86_64](https://cibuildwheel.readthedocs.io/en/stable/faq/#how-to-cross-compile)