### PR TITLE
Replaced usages of deprecated pkg_resources module

### DIFF
--- a/src/py-opentimelineio/opentimelineio/console/otioconvert.py
+++ b/src/py-opentimelineio/opentimelineio/console/otioconvert.py
@@ -157,16 +157,11 @@ def _parsed_args():
     if result.version:
         print(f"OpenTimelineIO version: {otio.__version__}")
 
-        if pkg_resources:
-            pkg_resource_plugins = list(
-                pkg_resources.iter_entry_points("opentimelineio.plugins")
-            )
-            if pkg_resource_plugins:
-                print("Plugins from pkg_resources:")
-                for plugin in pkg_resource_plugins:
-                    print(f"   {plugin.dist}")
-            else:
-                print("No pkg_resource plugins installed.")
+        entry_points = otio.plugins.manifest.plugin_entry_points()
+        if entry_points:
+            print("Plugins from installed packages:")
+            for plugin in entry_points:
+                print(f"   {plugin.dist.name} {plugin.dist.version}")
         parser.exit()
 
     if not result.input:

--- a/src/py-opentimelineio/opentimelineio/console/otiopluginfo.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiopluginfo.py
@@ -8,13 +8,8 @@
 import argparse
 import fnmatch
 import textwrap
-import opentimelineio as otio
 
-# on some python interpreters, pkg_resources is not available
-try:
-    import pkg_resources
-except ImportError:
-    pkg_resources = None
+import opentimelineio as otio
 
 OTIO_PLUGIN_TYPES = ['all'] + otio.plugins.manifest.OTIO_PLUGIN_TYPES
 
@@ -68,7 +63,7 @@ def _parsed_args():
         default=False,
         action="store_true",
         help=(
-            "Print the otio and pkg_resource installed plugin version "
+            "Print the otio and installed plugin package version "
             "information to the commandline."
         ),
     )
@@ -183,16 +178,11 @@ def main():
     if args.version:
         print(f"OpenTimelineIO version: {otio.__version__}")
 
-        if pkg_resources:
-            pkg_resource_plugins = list(
-                pkg_resources.iter_entry_points("opentimelineio.plugins")
-            )
-            if pkg_resource_plugins:
-                print("Plugins from pkg_resources:")
-                for plugin in pkg_resource_plugins:
-                    print(f"   {plugin.dist}")
-            else:
-                print("No pkg_resource plugins installed.")
+        entry_points = otio.plugins.manifest.plugin_entry_points()
+        if entry_points:
+            print("Plugins from installed packages:")
+            for plugin in entry_points:
+                print(f"   {plugin.dist.name} {plugin.dist.version}")
 
     # list the loaded manifests
     print("Manifests loaded:")

--- a/src/py-opentimelineio/opentimelineio/plugins/manifest.py
+++ b/src/py-opentimelineio/opentimelineio/plugins/manifest.py
@@ -8,7 +8,6 @@ import inspect
 import logging
 import os
 from pathlib import Path
-from typing import Union
 
 try:
     from importlib import metadata

--- a/src/py-opentimelineio/opentimelineio/plugins/manifest.py
+++ b/src/py-opentimelineio/opentimelineio/plugins/manifest.py
@@ -33,8 +33,7 @@ OTIO_PLUGIN_TYPES = [
 ]
 
 
-def plugin_entry_points(
-) -> Union[metadata.EntryPoints, metadata.SelectableGroups]:
+def plugin_entry_points():
     """Returns the list of entry points for all available OpenTimelineIO
     plugins.
     """

--- a/src/py-opentimelineio/opentimelineio/plugins/manifest.py
+++ b/src/py-opentimelineio/opentimelineio/plugins/manifest.py
@@ -8,6 +8,7 @@ import inspect
 import logging
 import os
 from pathlib import Path
+from typing import Union
 
 try:
     from importlib import metadata
@@ -30,6 +31,22 @@ OTIO_PLUGIN_TYPES = [
     'hooks',
     'version_manifests',
 ]
+
+
+def plugin_entry_points(
+) -> Union[metadata.EntryPoints, metadata.SelectableGroups]:
+    """Returns the list of entry points for all available OpenTimelineIO
+    plugins.
+    """
+    try:
+        entry_points = metadata.entry_points(group='opentimelineio.plugins')
+    except TypeError:
+        # For python <= 3.9
+        entry_points = metadata.entry_points().get(
+            'opentimelineio.plugins', []
+        )
+
+    return entry_points
 
 
 def manifest_from_file(filepath):
@@ -247,11 +264,7 @@ def load_manifest():
             result.extend(manifest_from_file(json_path))
 
     if not os.environ.get("OTIO_DISABLE_ENTRYPOINTS_PLUGINS"):
-        try:
-            entry_points = metadata.entry_points(group='opentimelineio.plugins')
-        except TypeError:
-            # For python <= 3.9
-            entry_points = metadata.entry_points().get('opentimelineio.plugins', [])
+        entry_points = plugin_entry_points()
 
         for plugin in entry_points:
             plugin_name = plugin.name


### PR DESCRIPTION
**Summarize your change.**

`pkg_resources` is now deprecated. This PR removes references to that module.

Refactored `plugin.manifest` module to factor the pip installed package discovery into a separate function. Made `otiopluginfo` and `otioconvert` use that function rather than doing their own plugin discovery.

**Reference associated tests.**

I did not add new tests, but I validated the output of `otiopluginfo --version` and `otioconvert --version` to validate they're nearly identical. The only difference is that the string `Plugins from pkg_resources:` is now `Plugins from installed packages:`.