### PR TITLE
Updated TSC chair in GOVERNANCE.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -107,10 +107,10 @@ project at ASWF TAC meetings.
 (alphabetical by last name)
 
 * Jeff Hodges - Adobe
-* Joshua Minor (chair) - Pixar
+* Joshua Minor - Pixar
 * Roger Nelson - Autodesk
 * Nick Porcino - Pixar
-* Eric Reinecke - Netflix
+* Eric Reinecke (chair) - Netflix
 * Stephan Steinbach - Pixar
 
 ### TSC Meetings


### PR DESCRIPTION
In line with the TSC vote on December 7 2023, updated the Chair in `GOVERNANCE.md` from Josh Minor to Eric Reinecke.