### PR TITLE
Remove some DeprecationWarnings

### DIFF
--- a/contrib/opentimelineio_contrib/adapters/fcpx_xml.py
+++ b/contrib/opentimelineio_contrib/adapters/fcpx_xml.py
@@ -535,7 +535,7 @@ class FcpxOtio:
         format_element = self._find_or_create_format_from(clip)
         asset = self._create_asset_element(clip, format_element)
 
-        if not compound_only and not self._asset_clip_by_name(clip.name):
+        if not compound_only and self._asset_clip_by_name(clip.name) is None:
             self._create_asset_clip_element(
                 clip,
                 format_element,
@@ -919,7 +919,7 @@ class FcpxXml:
             return True
         if element.tag == "asset-clip":
             asset = self._asset_by_id(element.get("ref", None))
-            if asset and asset.get("hasVideo", "0") == "0":
+            if asset is not None and asset.get("hasVideo", "0") == "0":
                 return True
         if element.tag == "ref-clip":
             if element.get("srcEnable", "video") == "audio":
@@ -1018,7 +1018,7 @@ class FcpxXml:
         )
         asset_clip = self._assetclip_by_ref(asset_id)
         metadata = {}
-        if asset_clip:
+        if asset_clip is not None:
             metadata = self._create_metadta(asset_clip)
         return otio.schema.ExternalReference(
             target_url=asset.get("src"),

--- a/src/py-opentimelineio/opentimelineio/adapters/fcp_xml.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/fcp_xml.py
@@ -1498,7 +1498,7 @@ def _build_file(media_reference, br_map):
     # will not get recognized
     # TODO: We should use a better method for this. Perhaps pre-walk the
     #       timeline and find all the track kinds this media is present in?
-    if not file_e.find("media"):
+    if file_e.find("media") is None:
         file_media_e = _get_or_create_subelement(file_e, "media")
 
         audio_exts = {'.wav', '.aac', '.mp3', '.aif', '.aiff', '.m4a'}


### PR DESCRIPTION
**Summarize your change.**

During the tests some DeprecationWarnings pop up. I only fix them. 

**Reference associated tests.**

For example here you see the DeprecationWarnings : https://github.com/AcademySoftwareFoundation/OpenTimelineIO/actions/runs/7483248301/job/20368203066?pr=1669#step:9:18