### PR TITLE
Fix non latin symbols decoding in adapters

### DIFF
--- a/src/py-opentimelineio/opentimelineio/adapters/adapter.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/adapter.py
@@ -105,7 +105,7 @@ class Adapter(plugins.PythonPlugin):
             not self.has_feature("read_from_file") and
             self.has_feature("read_from_string")
         ):
-            with open(filepath) as fo:
+            with open(filepath, encoding="utf-8") as fo:
                 contents = fo.read()
             result = self._execute_function(
                 "read_from_string",
@@ -181,7 +181,7 @@ class Adapter(plugins.PythonPlugin):
             self.has_feature("write_to_string")
         ):
             result = self.write_to_string(input_otio, **adapter_argument_map)
-            with open(filepath, 'w') as fo:
+            with open(filepath, 'w', encoding="utf-8") as fo:
                 fo.write(result)
             result = filepath
 


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
 
Fixes #1321

**Summarize your change.**

As Py2 support is dropped we should be free to commit utf-8 encoding in Python Adapters to handle UTF in input data.

<!--
Important: If this is your first contribution to OpenTimelineIO, you will need to submit a Contributor License Agreement. For a step-by-step instructions on the pull request process, see
https://github.com/AcademySoftwareFoundation/OpenTimelineIO/tree/main/CONTRIBUTING.md
-->
