### PR TITLE
Fixed wrong sample Python code, closes #1694

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Python:
 import opentimelineio as otio
 
 timeline = otio.adapters.read_from_file("foo.aaf")
-for clip in timeline.find_clips():
+for clip in timeline.each_clip():
   print(clip.name, clip.duration())
 ```
 


### PR DESCRIPTION
```Fixes #1694 ```

**Summarize your change.**

The sample Python code threw an error. The changed code now works. The solution is from [StackOverflow](https://stackoverflow.com/questions/77846715/monkey-patching-opentimelineio-adapter-to-import-final-cut-pro-xml).

**Reference associated tests.**

This PR is about documentation and the README, so I did not run tests.