### PR TITLE
Add optional comment field to Marker

### DIFF
--- a/docs/tutorials/otio-serialized-schema-only-fields.md
+++ b/docs/tutorials/otio-serialized-schema-only-fields.md
@@ -212,6 +212,7 @@ parameters:
 
 parameters:
 - *color*
+- *comment*
 - *marked_range*
 - *metadata*
 - *name*

--- a/docs/tutorials/otio-serialized-schema.md
+++ b/docs/tutorials/otio-serialized-schema.md
@@ -526,6 +526,7 @@ system.
 
 parameters:
 - *color*: Color string for this marker (for example: 'RED'), based on the :class:`~Color` enum.
+- *comment*: Optional comment for this marker.
 - *marked_range*: Range this marker applies to, relative to the :class:`.Item` this marker is attached to (e.g. the :class:`.Clip` or :class:`.Track` that owns this marker).
 - *metadata*: 
 - *name*: 

--- a/src/opentimelineio/marker.cpp
+++ b/src/opentimelineio/marker.cpp
@@ -10,10 +10,12 @@ Marker::Marker(
     std::string const&   name,
     TimeRange const&     marked_range,
     std::string const&   color,
-    AnyDictionary const& metadata)
+    AnyDictionary const& metadata,
+    std::string const&   comment)
     : Parent(name, metadata)
     , _color(color)
     , _marked_range(marked_range)
+    , _comment(comment)
 {}
 
 Marker::~Marker()
@@ -24,6 +26,7 @@ Marker::read_from(Reader& reader)
 {
     return reader.read_if_present("color", &_color)
            && reader.read("marked_range", &_marked_range)
+           && reader.read_if_present("comment", &_comment)
            && Parent::read_from(reader);
 }
 
@@ -33,6 +36,7 @@ Marker::write_to(Writer& writer) const
     Parent::write_to(writer);
     writer.write("color", _color);
     writer.write("marked_range", _marked_range);
+    writer.write("comment", _comment);
 }
 
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/marker.h
+++ b/src/opentimelineio/marker.h
@@ -38,7 +38,8 @@ public:
         std::string const&   name         = std::string(),
         TimeRange const&     marked_range = TimeRange(),
         std::string const&   color        = Color::green,
-        AnyDictionary const& metadata     = AnyDictionary());
+        AnyDictionary const& metadata     = AnyDictionary(),
+        std::string const&   comment      = std::string());
 
     std::string color() const noexcept { return _color; }
 
@@ -51,6 +52,10 @@ public:
         _marked_range = marked_range;
     }
 
+    std::string comment() const noexcept { return _comment; }
+
+    void set_comment(std::string const& comment) { _comment = comment; }
+
 protected:
     virtual ~Marker();
 
@@ -60,6 +65,7 @@ protected:
 private:
     std::string _color;
     TimeRange   _marked_range;
+    std::string _comment;
 };
 
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -214,19 +214,23 @@ The marked range may have a zero duration. The marked range is in the owning ite
                         std::string name,
                         TimeRange marked_range,
                         std::string const& color,
-                        py::object metadata) {
+                        py::object metadata,
+                        std::string const& comment) {
                           return new Marker(
                                   name,
                                   marked_range,
                                   color,
-                                  py_to_any_dictionary(metadata));
+                                  py_to_any_dictionary(metadata),
+                                  comment);
                       }),
              py::arg_v("name"_a = std::string()),
              "marked_range"_a = TimeRange(),
              "color"_a = std::string(Marker::Color::red),
-             py::arg_v("metadata"_a = py::none()))
+             py::arg_v("metadata"_a = py::none()),
+             "comment"_a = std::string())
         .def_property("color", &Marker::color, &Marker::set_color, "Color string for this marker (for example: 'RED'), based on the :class:`~Color` enum.")
-        .def_property("marked_range", &Marker::marked_range, &Marker::set_marked_range, "Range this marker applies to, relative to the :class:`.Item` this marker is attached to (e.g. the :class:`.Clip` or :class:`.Track` that owns this marker).");
+        .def_property("marked_range", &Marker::marked_range, &Marker::set_marked_range, "Range this marker applies to, relative to the :class:`.Item` this marker is attached to (e.g. the :class:`.Clip` or :class:`.Track` that owns this marker).")
+        .def_property("comment", &Marker::comment, &Marker::set_comment, "Optional comment for this marker.");
 
     py::class_<Marker::Color>(marker_class, "Color")
         .def_property_readonly_static("PINK", [](py::object /* self */) { return Marker::Color::pink; })

--- a/tests/baselines/empty_marker.json
+++ b/tests/baselines/empty_marker.json
@@ -3,6 +3,7 @@
     "metadata" : {},
     "name" : "",
     "color" : "RED",
+    "comment" : "",
     "marked_range" : {
         "FROM_TEST_FILE" : "empty_timerange.json"
     }

--- a/tests/test_marker.py
+++ b/tests/test_marker.py
@@ -88,6 +88,47 @@ class MarkerTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
         self.assertEqual(repr(m), expected)
 
+    def test_comment(self):
+        src = """
+        {
+            "OTIO_SCHEMA" : "Marker.1",
+            "metadata" : {},
+            "name" : null,
+            "comment": "foo bar",
+            "range" : {
+                "OTIO_SCHEMA" : "TimeRange.1",
+                "start_time" : {
+                    "OTIO_SCHEMA" : "RationalTime.1",
+                    "rate" : 5,
+                    "value" : 0
+                },
+                "duration" : {
+                    "OTIO_SCHEMA" : "RationalTime.1",
+                    "rate" : 5,
+                    "value" : 0
+                }
+            }
+
+        }
+        """
+        marker = otio.adapters.read_from_string(src, "otio_json")
+        self.assertEqual(marker.comment, "foo bar")
+
+        tr = otio.opentime.TimeRange(
+            otio.opentime.RationalTime(5, 24),
+            otio.opentime.RationalTime(10, 24)
+        )
+        m = otio.schema.Marker(
+            name="marker_1",
+            marked_range=tr,
+            metadata={'foo': 'bar'},
+            comment="foo bar2")
+        self.assertEqual(m.comment, "foo bar2")
+
+        encoded = otio.adapters.otio_json.write_to_string(m)
+        decoded = otio.adapters.otio_json.read_from_string(encoded)
+        self.assertEqual(decoded.comment, "foo bar2")
+
     def test_str(self):
         tr = otio.opentime.TimeRange(
             otio.opentime.RationalTime(5, 24),


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**

Fixes #744

**Summarize your change.**

This adds an optional comment field to the Marker object as requested in #744 

**Reference associated tests.**

Added new tests that specifically test to make sure the comment is being added and serialized/deserialized successfully 
