### PR TITLE
fix: Bumped cibuildwheel action to 2.16.5 to address windows build issues

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -168,7 +168,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build wheels (Python 3)
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.16.5
         with:
           output-dir: wheelhouse
         env:


### PR DESCRIPTION
Windows builds have been failing with the message: `Invalid --only='""', must be a build selector with a known platform`

cibuildwheel version 2.16.5 addresses this.

See pypa/cibuildwheel/issues/1740 for details.