### PR TITLE
Set minimum OS X deployment version to 10.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(OTIO_AUTHOR_EMAIL "otio-discussion@lists.aswf.io")
 set(OTIO_LICENSE      "Modified Apache 2.0 License")
 
 set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "")
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Minimum OS X deployment version")
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14" CACHE STRING "Minimum OS X deployment version")
 
 project(OpenTimelineIO VERSION ${OTIO_VERSION} LANGUAGES C CXX)
 


### PR DESCRIPTION
Fixes #1718

Compiling the latest OTIO with C++17 support gives this error on macOS 10.15.7:
```
'any_cast<const opentimelineio::v1_0::AnyVector &>' is unavailable: introduced in macOS 10.14
AnyVector const& av = std::any_cast<AnyVector const&>(source);
^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/any:581:12: note:
'any_cast<const opentimelineio::v1_0::AnyVector &>' has been explicitly marked unavailable here
```
Bumping CMAKE_OSX_DEPLOYMENT_TARGET to 10.14 fixes the issue.