### PR TITLE
constexpr updates

### DIFF
--- a/src/opentime/rationalTime.h
+++ b/src/opentime/rationalTime.h
@@ -39,9 +39,6 @@ public:
         , _rate{ rate }
     {}
 
-    RationalTime(RationalTime const&) noexcept = default;
-    RationalTime& operator=(RationalTime const&) noexcept = default;
-
     bool is_invalid_time() const noexcept
     {
         return (std::isnan(_rate) || std::isnan(_value)) ? true : (_rate <= 0);

--- a/src/opentime/rationalTime.h
+++ b/src/opentime/rationalTime.h
@@ -39,7 +39,7 @@ public:
         , _rate{ rate }
     {}
 
-    constexpr RationalTime(RationalTime const&) noexcept  = default;
+    RationalTime(RationalTime const&) noexcept = default;
     RationalTime& operator=(RationalTime const&) noexcept = default;
 
     bool is_invalid_time() const noexcept

--- a/src/opentime/rationalTime.h
+++ b/src/opentime/rationalTime.h
@@ -105,7 +105,7 @@ public:
         return RationalTime{ std::round(_value), _rate };
     }
 
-    static RationalTime constexpr duration_from_start_end_time(
+    static constexpr RationalTime duration_from_start_end_time(
         RationalTime start_time,
         RationalTime end_time_exclusive) noexcept
     {
@@ -119,7 +119,7 @@ public:
                                    start_time._rate };
     }
 
-    static RationalTime constexpr duration_from_start_end_time_inclusive(
+    static constexpr RationalTime duration_from_start_end_time_inclusive(
         RationalTime start_time,
         RationalTime end_time_inclusive) noexcept
     {
@@ -196,7 +196,7 @@ public:
     // microsecond precision.
     std::string to_time_string() const;
 
-    RationalTime const& operator+=(RationalTime other) noexcept
+    constexpr RationalTime const& operator+=(RationalTime other) noexcept
     {
         if (_rate < other._rate)
         {
@@ -210,7 +210,7 @@ public:
         return *this;
     }
 
-    RationalTime const& operator-=(RationalTime other) noexcept
+    constexpr RationalTime const& operator-=(RationalTime other) noexcept
     {
         if (_rate < other._rate)
         {

--- a/src/opentime/timeRange.h
+++ b/src/opentime/timeRange.h
@@ -96,7 +96,7 @@ public:
                               new_end_time) };
     }
 
-    constexpr RationalTime clamped(RationalTime other) const noexcept
+    RationalTime clamped(RationalTime other) const noexcept
     {
         return std::min(std::max(other, _start_time), end_time_inclusive());
     }

--- a/src/opentime/timeRange.h
+++ b/src/opentime/timeRange.h
@@ -47,10 +47,6 @@ public:
         , _duration{ duration }
     {}
 
-    TimeRange(TimeRange const&) noexcept = default;
-
-    TimeRange& operator=(TimeRange const&) noexcept = default;
-
     constexpr RationalTime start_time() const noexcept { return _start_time; }
 
     constexpr RationalTime duration() const noexcept { return _duration; }

--- a/src/opentime/timeRange.h
+++ b/src/opentime/timeRange.h
@@ -47,9 +47,9 @@ public:
         , _duration{ duration }
     {}
 
-    constexpr TimeRange(TimeRange const&) noexcept = default;
+    TimeRange(TimeRange const&) noexcept = default;
 
-    constexpr TimeRange& operator=(TimeRange const&) noexcept = default;
+    TimeRange& operator=(TimeRange const&) noexcept = default;
 
     constexpr RationalTime start_time() const noexcept { return _start_time; }
 

--- a/src/opentime/timeRange.h
+++ b/src/opentime/timeRange.h
@@ -49,7 +49,7 @@ public:
 
     constexpr TimeRange(TimeRange const&) noexcept = default;
 
-    TimeRange& operator=(TimeRange const&) noexcept = default;
+    constexpr TimeRange& operator=(TimeRange const&) noexcept = default;
 
     constexpr RationalTime start_time() const noexcept { return _start_time; }
 
@@ -96,7 +96,7 @@ public:
                               new_end_time) };
     }
 
-    RationalTime clamped(RationalTime other) const noexcept
+    constexpr RationalTime clamped(RationalTime other) const noexcept
     {
         return std::min(std::max(other, _start_time), end_time_inclusive());
     }
@@ -388,13 +388,13 @@ private:
     RationalTime _start_time, _duration;
     friend class TimeTransform;
 
-    inline constexpr bool
+    constexpr bool
     greater_than(double lhs, double rhs, double epsilon) const noexcept
     {
         return lhs - rhs >= epsilon;
     }
 
-    inline constexpr bool
+    constexpr bool
     lesser_than(double lhs, double rhs, double epsilon) const noexcept
     {
         return rhs - lhs >= epsilon;

--- a/src/opentime/timeTransform.h
+++ b/src/opentime/timeTransform.h
@@ -28,8 +28,8 @@ public:
 
     constexpr double rate() const noexcept { return _rate; }
 
-    constexpr TimeTransform(TimeTransform const&) noexcept  = default;
-    constexpr TimeTransform& operator=(TimeTransform const&) noexcept = default;
+    TimeTransform(TimeTransform const&) noexcept = default;
+    TimeTransform& operator=(TimeTransform const&) noexcept = default;
 
     constexpr TimeRange applied_to(TimeRange other) const noexcept
     {

--- a/src/opentime/timeTransform.h
+++ b/src/opentime/timeTransform.h
@@ -29,9 +29,9 @@ public:
     constexpr double rate() const noexcept { return _rate; }
 
     constexpr TimeTransform(TimeTransform const&) noexcept  = default;
-    TimeTransform& operator=(TimeTransform const&) noexcept = default;
+    constexpr TimeTransform& operator=(TimeTransform const&) noexcept = default;
 
-    TimeRange applied_to(TimeRange other) const noexcept
+    constexpr TimeRange applied_to(TimeRange other) const noexcept
     {
         return TimeRange::range_from_start_end_time(
             applied_to(other._start_time),
@@ -45,7 +45,7 @@ public:
                               _rate > 0 ? _rate : other._rate };
     }
 
-    RationalTime applied_to(RationalTime other) const noexcept
+    constexpr RationalTime applied_to(RationalTime other) const noexcept
     {
         RationalTime result{ RationalTime{ other._value * _scale, other._rate }
                              + _offset };

--- a/src/opentime/timeTransform.h
+++ b/src/opentime/timeTransform.h
@@ -28,9 +28,6 @@ public:
 
     constexpr double rate() const noexcept { return _rate; }
 
-    TimeTransform(TimeTransform const&) noexcept = default;
-    TimeTransform& operator=(TimeTransform const&) noexcept = default;
-
     constexpr TimeRange applied_to(TimeRange other) const noexcept
     {
         return TimeRange::range_from_start_end_time(


### PR DESCRIPTION
Fixes #1720

Changes:
* Add `constexpr` to more functions in OpenTime
* Remove redundant `inline` on `constexpr` functions
* Move `constexpr` before the return type on functions
