### PR TITLE
Fixed freeze script github yaml parsing and unfroze the ci versions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,7 +6,7 @@ name: OpenTimelineIO
 # for configuring which build will be a C++ coverage build / coverage report
 env:
   GH_COV_PY: "3.10"
-  GH_COV_OS: ubuntu-22.04
+  GH_COV_OS: ubuntu-latest
   GH_DEPENDABOT: dependabot
 
 on:
@@ -24,17 +24,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-12, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
         # Unfortunately the CMake test target is OS dependent so we set it as
         # a variable here.
         include:
-        - os: ubuntu-22.04
+        - os: ubuntu-latest
           OTIO_TEST_TARGET: test
-        - os: windows-2022
+        - os: windows-latest
           OTIO_TEST_TARGET: RUN_TESTS
-        - os: macos-12
+        - os: macos-latest
           OTIO_TEST_TARGET: test
-        - os: macos-14
+        - os: macos-13
           OTIO_TEST_TARGET: test
 
     env:
@@ -94,18 +94,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-12, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         include:
-          - { os: ubuntu-22.04, shell: bash }
-          - { os: macos-12, shell: bash }
-          - { os: macos-14, shell: bash }
-          - { os: windows-2022, shell: pwsh }
-          - { os: windows-2022, shell: msys2, python-version: 'mingw64' }
+          - { os: ubuntu-latest, shell: bash }
+          - { os: macos-latest, shell: bash }
+          - { os: macos-13, shell: bash }
+          - { os: windows-latest, shell: pwsh }
+          - { os: windows-latest, shell: msys2, python-version: 'mingw64' }
         exclude:
-          - { os: macos-14, python-version: 3.7 }
-          - { os: macos-14, python-version: 3.8 }
-          - { os: macos-14, python-version: 3.9 }
+          - { os: macos-latest, python-version: 3.7 }
+          - { os: macos-latest, python-version: 3.8 }
+          - { os: macos-latest, python-version: 3.9 }
 
     defaults:
       run:
@@ -175,10 +175,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-12, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
         python-build: ['cp37*', 'cp38*', 'cp39*', 'cp310*', 'cp311*', 'cp312*']
         exclude:
-          - { os: macos-14, python-build: 'cp37*' }
+          - { os: macos-latest, python-build: 'cp37*' }
     steps:
       - uses: actions/checkout@v4
 
@@ -199,7 +199,7 @@ jobs:
 
   package_sdist:
     needs: py_build_test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:

--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,7 @@ update-contributors: check-github-token
 	@echo "Updating CONTRIBUTORS.md..."
 	@python maintainers/fetch_contributors.py \
 		--repo AcademySoftwareFoundation/OpenTimelineIO \
-		--token $(OTIO_RELEASE_GITHUB_TOKEN)
+		--token "${OTIO_RELEASE_GITHUB_TOKEN}"
 
 dev-python-install:
 	@python setup.py install

--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,7 @@ update-contributors: check-github-token
 	@echo "Updating CONTRIBUTORS.md..."
 	@python maintainers/fetch_contributors.py \
 		--repo AcademySoftwareFoundation/OpenTimelineIO \
-		--token "${OTIO_RELEASE_GITHUB_TOKEN}"
+		--token $(OTIO_RELEASE_GITHUB_TOKEN)
 
 dev-python-install:
 	@python setup.py install

--- a/maintainers/freeze_ci_versions.py
+++ b/maintainers/freeze_ci_versions.py
@@ -49,7 +49,7 @@ def _parsed_args():
     return parser.parse_args()
 
 
-def fetch_plat_map():
+def _fetch_plat_map():
     # HACK: pull the image version corresponding to -latest out of the
     #       README.md for the github repo where they are stored
     request = urllib.request.Request(GITHUB_README_URL)
@@ -111,7 +111,7 @@ def fetch_plat_map():
 def main():
     args = _parsed_args()
 
-    plat_map = fetch_plat_map()
+    plat_map = _fetch_plat_map()
 
     if args.freeze:
         freeze_ci(plat_map, args.dryrun)

--- a/maintainers/freeze_ci_versions.py
+++ b/maintainers/freeze_ci_versions.py
@@ -98,7 +98,7 @@ def fetch_plat_map():
 
         label = next(
             label for label in available_labels
-            if label.split("-")[-1] not in {"xl", "latest"}
+            if label.split("-")[-1] not in {"xl", "xlarge", "latest"}
         )
         platform = label.split("-")[0]
         if platform not in PLATFORMS:


### PR DESCRIPTION
The freeze CI versions script had broken with an update to the GitHub documentation formatting. This update uses a slightly more markdown-aware approach to extract the needed info.

Also addressed minor escaping issue in Makefile I'd discovered while cutting the 0.16.0 release.