### PR TITLE
Update codecov to run on python 3.10 builds

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -151,7 +151,7 @@ jobs:
       run: make lcov
     - name: Upload coverage to Codecov
       if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != env.GH_DEPENDABOT
-      uses: codecov/codecov-action@v3.1.4
+      uses: codecov/codecov-action@v4
       with:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         flags: py-unittests

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -153,6 +153,7 @@ jobs:
       if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != env.GH_DEPENDABOT
       uses: codecov/codecov-action@v3.1.4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         flags: py-unittests
         name: py-opentimelineio-codecov
         fail_ci_if_error: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,7 +5,7 @@ name: OpenTimelineIO
 
 # for configuring which build will be a C++ coverage build / coverage report
 env:
-  GH_COV_PY: 3.10
+  GH_COV_PY: "3.10"
   GH_COV_OS: ubuntu-22.04
   GH_DEPENDABOT: dependabot
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -153,7 +153,7 @@ jobs:
       if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != env.GH_DEPENDABOT
       uses: codecov/codecov-action@v3.1.4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         flags: py-unittests
         name: py-opentimelineio-codecov
         fail_ci_if_error: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,7 +5,7 @@ name: OpenTimelineIO
 
 # for configuring which build will be a C++ coverage build / coverage report
 env:
-  GH_COV_PY: 3.7
+  GH_COV_PY: 3.10
   GH_COV_OS: ubuntu-22.04
   GH_DEPENDABOT: dependabot
 


### PR DESCRIPTION
Codecov uploader is no longer compatible w/ python 3.7, which was causing action failures against the python 3.7 target.  This switches it to use the 3.10 version of python instead.  It also updates to the v4 codecov uploader.