### PR TITLE
Add macos-14 arm64 runners

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-12]
+        os: [ubuntu-22.04, windows-2022, macos-12, macos-14]
         # Unfortunately the CMake test target is OS dependent so we set it as
         # a variable here.
         include:
@@ -33,6 +33,8 @@ jobs:
         - os: windows-2022
           OTIO_TEST_TARGET: RUN_TESTS
         - os: macos-12
+          OTIO_TEST_TARGET: test
+        - os: macos-14
           OTIO_TEST_TARGET: test
 
     env:
@@ -92,13 +94,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-12]
+        os: [ubuntu-22.04, windows-2022, macos-12, macos-14]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         include:
           - { os: ubuntu-22.04, shell: bash }
           - { os: macos-12, shell: bash }
+          - { os: macos-14, shell: bash }
           - { os: windows-2022, shell: pwsh }
           - { os: windows-2022, shell: msys2, python-version: 'mingw64' }
+        exclude:
+          - { os: macos-14, python-version: 3.7 }
+          - { os: macos-14, python-version: 3.8 }
+          - { os: macos-14, python-version: 3.9 }
 
     defaults:
       run:
@@ -153,7 +160,7 @@ jobs:
       if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != env.GH_DEPENDABOT
       uses: codecov/codecov-action@v4
       with:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ secrets.CODECOV_TOKEN }}
         flags: py-unittests
         name: py-opentimelineio-codecov
         fail_ci_if_error: true
@@ -163,8 +170,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-12]
+        os: [ubuntu-22.04, windows-2022, macos-12, macos-14]
         python-build: ['cp37*', 'cp38*', 'cp39*', 'cp310*', 'cp311*', 'cp312*']
+        exclude:
+          - { os: macos-14, python-build: 'cp37*' }
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
This PR adds macOS arm64 runners for #1672

The only issue I'm facing is python 3.8 and 3.9 aren't working with the current `setup-python` action.
https://github.com/actions/setup-python/issues/696

Wheels can still be made, python 3.8 and 3.9 are supported with the `cibuildwheel` action. 

python-3.9 is the version of python included on macOS, so its annoying the test aren't running.

As for python-3.7, it was never supported for apple silicon as far as I understand.