### PR TITLE
do not break the build if codecov fails

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -162,7 +162,7 @@ jobs:
       with:
         flags: py-unittests
         name: py-opentimelineio-codecov
-        fail_ci_if_error: true
+        fail_ci_if_error: false
       env:
         # based on: https://github.com/codecov/codecov-action?tab=readme-ov-file#usage
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Make sure that problems uploading to codecov do not indicate broken PRs.