### PR TITLE
Fix sign-compare warning when compiling with GCC 14

### DIFF
--- a/src/opentimelineio/stackAlgorithm.cpp
+++ b/src/opentimelineio/stackAlgorithm.cpp
@@ -7,6 +7,8 @@
 #include "opentimelineio/trackAlgorithm.h"
 #include "opentimelineio/transition.h"
 
+#include <cstddef>
+
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
 typedef std::map<Track*, std::map<Composable*, TimeRange>> RangeTrackMap;
@@ -144,7 +146,7 @@ _normalize_tracks_lengths(
         }
     }
 
-    for (int i = 0; i < tracks.size(); i++)
+    for (std::size_t i = 0; i < tracks.size(); i++)
     {
         Track*       old_track      = tracks[i];
         RationalTime track_duration = old_track->duration(error_status);

--- a/src/opentimelineio/stackAlgorithm.cpp
+++ b/src/opentimelineio/stackAlgorithm.cpp
@@ -7,8 +7,6 @@
 #include "opentimelineio/trackAlgorithm.h"
 #include "opentimelineio/transition.h"
 
-#include <cstddef>
-
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
 typedef std::map<Track*, std::map<Composable*, TimeRange>> RangeTrackMap;
@@ -146,7 +144,7 @@ _normalize_tracks_lengths(
         }
     }
 
-    for (std::size_t i = 0; i < tracks.size(); i++)
+    for (size_t i = 0; i < tracks.size(); i++)
     {
         Track*       old_track      = tracks[i];
         RationalTime track_duration = old_track->duration(error_status);


### PR DESCRIPTION
Simple pull request to remove a new warning under GCC 14.

The warning is
```
/home/jcmorin/jcmenv/aswf/OpenTimelineIO/src/opentimelineio/stackAlgorithm.cpp: In function ‘void opentimelineio::v1_0::_normalize_tracks_lengths(std::vector<Track*>&, TrackRetainerVector&, ErrorStatus*)’:
/home/jcmorin/jcmenv/aswf/OpenTimelineIO/src/opentimelineio/stackAlgorithm.cpp:147:23: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<opentimelineio::v1_0::Track*>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
  147 |     for (int i = 0; i < tracks.size(); i++)
      |                     ~~^~~~~~~~~~~~~~~
```
