### PR TITLE
Fix for find_children() with stacks

### DIFF
--- a/src/opentimelineio/composition.h
+++ b/src/opentimelineio/composition.h
@@ -101,7 +101,7 @@ public:
         bool                shallow_search = false) const;
 
     // Return all objects within the given search_range.
-    std::vector<Retainer<Composable>> children_in_range(
+    virtual std::vector<Retainer<Composable>> children_in_range(
         TimeRange const& search_range,
         ErrorStatus*     error_status = nullptr) const;
 

--- a/src/opentimelineio/stack.cpp
+++ b/src/opentimelineio/stack.cpp
@@ -79,6 +79,26 @@ Stack::range_of_all_children(ErrorStatus* error_status) const
     return result;
 }
 
+std::vector<SerializableObject::Retainer<Composable>>
+Stack::children_in_range(
+    TimeRange const& search_range,
+    ErrorStatus* error_status) const
+{
+    std::vector<SerializableObject::Retainer<Composable>> children;
+    for (auto child : this->children())
+    {
+        if (auto item = dynamic_retainer_cast<Item>(child))
+        {
+            TimeRange range = item->trimmed_range(error_status);
+            if (range.intersects(search_range))
+            {
+                children.push_back(child);
+            }
+        }
+    }
+    return children;
+}
+
 TimeRange
 Stack::trimmed_range_of_child_at_index(int index, ErrorStatus* error_status)
     const

--- a/src/opentimelineio/stack.h
+++ b/src/opentimelineio/stack.h
@@ -40,6 +40,10 @@ public:
     std::map<Composable*, TimeRange>
     range_of_all_children(ErrorStatus* error_status = nullptr) const override;
 
+    std::vector<Retainer<Composable>> children_in_range(
+        TimeRange const& search_range,
+        ErrorStatus*     error_status = nullptr) const override;
+
     std::optional<IMATH_NAMESPACE::Box2d>
     available_image_bounds(ErrorStatus* error_status) const override;
 

--- a/tests/test_track.cpp
+++ b/tests/test_track.cpp
@@ -5,7 +5,6 @@
 
 #include <opentimelineio/clip.h>
 #include <opentimelineio/stack.h>
-#include <opentimelineio/timeline.h>
 #include <opentimelineio/track.h>
 
 #include <iostream>
@@ -119,24 +118,22 @@ main(int argc, char** argv)
         SerializableObject::Retainer<Clip> audio_clip = new Clip(
             "audio_0",
             nullptr,
-            TimeRange(RationalTime(5.0, 24.0), RationalTime(20.0, 24.0)));
+            TimeRange(RationalTime(0.0, 30.0), RationalTime(700.0, 30.0)));
         SerializableObject::Retainer<Track> video_track = new Track("Video");
         SerializableObject::Retainer<Track> audio_track = new Track("Audio");
         SerializableObject::Retainer<Stack> stack = new Stack();
-        SerializableObject::Retainer<Timeline> timeline = new Timeline();
         video_track->append_child(video_clip);
         audio_track->append_child(audio_clip);
         stack->append_child(video_track);
         stack->append_child(audio_track);
-        timeline->set_tracks(stack);
 
-        RationalTime      time(703.0, 30.0);
-        RationalTime      one_frame(1.0, 30.0);
-        TimeRange         range(time, one_frame);
-        otio::ErrorStatus errorStatus;
-        auto              items = timeline->find_children(&errorStatus, range);
-        assert(!otio::is_error(errorStatus));
-        assert(!items.empty());
+        RationalTime time(703.0, 30.0);
+        RationalTime one_frame(1.0, 30.0);
+        TimeRange    range(time, one_frame);
+        ErrorStatus  err;
+        auto         items = stack->find_children(&err, range);
+        assert(!is_error(err));
+        assert(items.size() == 2);
     });
 
     tests.run(argc, argv);

--- a/tests/test_track.cpp
+++ b/tests/test_track.cpp
@@ -114,11 +114,11 @@ main(int argc, char** argv)
         SerializableObject::Retainer<Clip> video_clip = new Clip(
             "video_0",
             nullptr,
-            TimeRange(RationalTime(0.0, 30.0), RationalTime(704.0, 30.0)));
+            TimeRange(RationalTime(0.0, 30.0), RationalTime(700.0, 30.0)));
         SerializableObject::Retainer<Clip> audio_clip = new Clip(
             "audio_0",
             nullptr,
-            TimeRange(RationalTime(0.0, 30.0), RationalTime(700.0, 30.0)));
+            TimeRange(RationalTime(0.0, 30.0), RationalTime(704.0, 30.0)));
         SerializableObject::Retainer<Track> video_track = new Track("Video");
         SerializableObject::Retainer<Track> audio_track = new Track("Audio");
         SerializableObject::Retainer<Stack> stack = new Stack();
@@ -132,8 +132,14 @@ main(int argc, char** argv)
         TimeRange         range(time, one_frame);
         otio::ErrorStatus err;
         auto              items = stack->find_children(&err, range);
-        assert(!is_error(err));
-        assert(items.size() == 2);
+        assertFalse(is_error(err));
+        assertEqual(items.size(), 2);
+        assertTrue(
+            std::find(items.begin(), items.end(), audio_clip.value) !=
+            items.end());
+        assertTrue(
+            std::find(items.begin(), items.end(), audio_track.value) !=
+            items.end());
     });
 
     tests.run(argc, argv);

--- a/tests/test_track.cpp
+++ b/tests/test_track.cpp
@@ -109,7 +109,7 @@ main(int argc, char** argv)
     });
 
     tests.add_test(
-        "test_find_children_two_tracks", [] {
+        "test_find_children_stack", [] {
         using namespace otio;
         SerializableObject::Retainer<Clip> video_clip = new Clip(
             "video_0",
@@ -127,11 +127,11 @@ main(int argc, char** argv)
         stack->append_child(video_track);
         stack->append_child(audio_track);
 
-        RationalTime time(703.0, 30.0);
-        RationalTime one_frame(1.0, 30.0);
-        TimeRange    range(time, one_frame);
-        ErrorStatus  err;
-        auto         items = stack->find_children(&err, range);
+        RationalTime      time(703.0, 30.0);
+        RationalTime      one_frame(1.0, 30.0);
+        TimeRange         range(time, one_frame);
+        otio::ErrorStatus err;
+        auto              items = stack->find_children(&err, range);
         assert(!is_error(err));
         assert(items.size() == 2);
     });

--- a/tests/test_track.cpp
+++ b/tests/test_track.cpp
@@ -5,6 +5,7 @@
 
 #include <opentimelineio/clip.h>
 #include <opentimelineio/stack.h>
+#include <opentimelineio/timeline.h>
 #include <opentimelineio/track.h>
 
 #include <iostream>
@@ -106,6 +107,36 @@ main(int argc, char** argv)
         assertEqual(result.size(), 2);
         assertEqual(result[0].value, cl0.value);
         assertEqual(result[1].value, cl1.value);
+    });
+
+    tests.add_test(
+        "test_find_children_two_tracks", [] {
+        using namespace otio;
+        SerializableObject::Retainer<Clip> video_clip = new Clip(
+            "video_0",
+            nullptr,
+            TimeRange(RationalTime(0.0, 30.0), RationalTime(704.0, 30.0)));
+        SerializableObject::Retainer<Clip> audio_clip = new Clip(
+            "audio_0",
+            nullptr,
+            TimeRange(RationalTime(5.0, 24.0), RationalTime(20.0, 24.0)));
+        SerializableObject::Retainer<Track> video_track = new Track("Video");
+        SerializableObject::Retainer<Track> audio_track = new Track("Audio");
+        SerializableObject::Retainer<Stack> stack = new Stack();
+        SerializableObject::Retainer<Timeline> timeline = new Timeline();
+        video_track->append_child(video_clip);
+        audio_track->append_child(audio_clip);
+        stack->append_child(video_track);
+        stack->append_child(audio_track);
+        timeline->set_tracks(stack);
+
+        RationalTime      time(703.0, 30.0);
+        RationalTime      one_frame(1.0, 30.0);
+        TimeRange         range(time, one_frame);
+        otio::ErrorStatus errorStatus;
+        auto              items = timeline->find_children(&errorStatus, range);
+        assert(!otio::is_error(errorStatus));
+        assert(!items.empty());
     });
 
     tests.run(argc, argv);

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -52,6 +52,28 @@ class TrackTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertEqual(result[0], cl0)
         self.assertEqual(result[1], cl1)
 
+    def test_find_children_two_tracks(self):
+        video_clip = otio.schema.Clip();
+        video_clip.source_range = otio.opentime.TimeRange(
+            otio.opentime.RationalTime(0.0, 30.0),
+            otio.opentime.RationalTime(704.0, 30.0))
+        audio_clip = otio.schema.Clip();
+        audio_clip.source_range = otio.opentime.TimeRange(
+            otio.opentime.RationalTime(0.0, 30.0),
+            otio.opentime.RationalTime(700.0, 30.0))
+        video_track = otio.schema.Track()
+        audio_track = otio.schema.Track()
+        stack = otio.schema.Stack()
+        video_track.append(video_clip)
+        audio_track.append(audio_clip)
+        stack.append(video_track)
+        stack.append(audio_track)
+
+        time = otio.opentime.RationalTime(704.0, 30.0)
+        one_frame = otio.opentime.RationalTime(1.0, 30.0)
+        range = otio.opentime.TimeRange(time, one_frame)
+        items = stack.find_children(range)
+        self.assertEqual(len(items), 2)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -52,15 +52,15 @@ class TrackTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertEqual(result[0], cl0)
         self.assertEqual(result[1], cl1)
 
-    def test_find_children_two_tracks(self):
+    def test_find_children_stack(self):
         video_clip = otio.schema.Clip();
         video_clip.source_range = otio.opentime.TimeRange(
             otio.opentime.RationalTime(0.0, 30.0),
-            otio.opentime.RationalTime(704.0, 30.0))
+            otio.opentime.RationalTime(700.0, 30.0))
         audio_clip = otio.schema.Clip();
         audio_clip.source_range = otio.opentime.TimeRange(
             otio.opentime.RationalTime(0.0, 30.0),
-            otio.opentime.RationalTime(700.0, 30.0))
+            otio.opentime.RationalTime(704.0, 30.0))
         video_track = otio.schema.Track()
         audio_track = otio.schema.Track()
         stack = otio.schema.Stack()
@@ -69,11 +69,13 @@ class TrackTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         stack.append(video_track)
         stack.append(audio_track)
 
-        time = otio.opentime.RationalTime(704.0, 30.0)
+        time = otio.opentime.RationalTime(703.0, 30.0)
         one_frame = otio.opentime.RationalTime(1.0, 30.0)
         range = otio.opentime.TimeRange(time, one_frame)
-        items = stack.find_children(range)
+        items = stack.find_children(search_range=range)
         self.assertEqual(len(items), 2)
+        self.assertTrue(audio_clip in items)
+        self.assertTrue(audio_track in items)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #1652

After some investigation, it looks like the `find_children()` function was not working with stacks when given a search range. To fix this, an override is added for the function `children_in_range()` that works with "stacks" of children.