### PR TITLE
Fix for find_children() with stacks #2

### DIFF
--- a/src/opentimelineio/composition.h
+++ b/src/opentimelineio/composition.h
@@ -101,7 +101,7 @@ public:
         bool                shallow_search = false) const;
 
     // Return all objects within the given search_range.
-    std::vector<Retainer<Composable>> children_in_range(
+    virtual std::vector<Retainer<Composable>> children_in_range(
         TimeRange const& search_range,
         ErrorStatus*     error_status = nullptr) const;
 

--- a/src/opentimelineio/stack.cpp
+++ b/src/opentimelineio/stack.cpp
@@ -85,12 +85,12 @@ Stack::children_in_range(
     ErrorStatus* error_status) const
 {
     std::vector<SerializableObject::Retainer<Composable>> children;
-    for (auto child : this->children())
+    for (const auto& child : this->children())
     {
-        if (auto item = dynamic_retainer_cast<Item>(child))
+        if (const auto& item = dynamic_retainer_cast<Item>(child))
         {
-            TimeRange range = item->trimmed_range(error_status);
-            if (range.intersects(search_range))
+            const auto range = item->trimmed_range_in_parent(error_status);
+            if (range.has_value() && range.value().intersects(search_range))
             {
                 children.push_back(child);
             }

--- a/src/opentimelineio/stack.cpp
+++ b/src/opentimelineio/stack.cpp
@@ -79,6 +79,26 @@ Stack::range_of_all_children(ErrorStatus* error_status) const
     return result;
 }
 
+std::vector<SerializableObject::Retainer<Composable>>
+Stack::children_in_range(
+    TimeRange const& search_range,
+    ErrorStatus* error_status) const
+{
+    std::vector<SerializableObject::Retainer<Composable>> children;
+    for (auto child : this->children())
+    {
+        if (auto item = dynamic_retainer_cast<Item>(child))
+        {
+            TimeRange range = item->trimmed_range(error_status);
+            if (range.intersects(search_range))
+            {
+                children.push_back(child);
+            }
+        }
+    }
+    return children;
+}
+
 TimeRange
 Stack::trimmed_range_of_child_at_index(int index, ErrorStatus* error_status)
     const

--- a/src/opentimelineio/stack.h
+++ b/src/opentimelineio/stack.h
@@ -40,6 +40,10 @@ public:
     std::map<Composable*, TimeRange>
     range_of_all_children(ErrorStatus* error_status = nullptr) const override;
 
+    std::vector<Retainer<Composable>> children_in_range(
+        TimeRange const& search_range,
+        ErrorStatus*     error_status = nullptr) const override;
+
     std::optional<IMATH_NAMESPACE::Box2d>
     available_image_bounds(ErrorStatus* error_status) const override;
 

--- a/tests/test_track.cpp
+++ b/tests/test_track.cpp
@@ -108,6 +108,40 @@ main(int argc, char** argv)
         assertEqual(result[1].value, cl1.value);
     });
 
+    tests.add_test(
+        "test_find_children_stack", [] {
+        using namespace otio;
+        SerializableObject::Retainer<Clip> video_clip = new Clip(
+            "video_0",
+            nullptr,
+            TimeRange(RationalTime(0.0, 30.0), RationalTime(700.0, 30.0)));
+        SerializableObject::Retainer<Clip> audio_clip = new Clip(
+            "audio_0",
+            nullptr,
+            TimeRange(RationalTime(0.0, 30.0), RationalTime(704.0, 30.0)));
+        SerializableObject::Retainer<Track> video_track = new Track("Video");
+        SerializableObject::Retainer<Track> audio_track = new Track("Audio");
+        SerializableObject::Retainer<Stack> stack = new Stack();
+        video_track->append_child(video_clip);
+        audio_track->append_child(audio_clip);
+        stack->append_child(video_track);
+        stack->append_child(audio_track);
+
+        RationalTime      time(703.0, 30.0);
+        RationalTime      one_frame(1.0, 30.0);
+        TimeRange         range(time, one_frame);
+        otio::ErrorStatus err;
+        auto              items = stack->find_children(&err, range);
+        assertFalse(is_error(err));
+        assertEqual(items.size(), 2);
+        assertTrue(
+            std::find(items.begin(), items.end(), audio_clip.value) !=
+            items.end());
+        assertTrue(
+            std::find(items.begin(), items.end(), audio_track.value) !=
+            items.end());
+    });
+
     tests.run(argc, argv);
     return 0;
 }

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -52,6 +52,31 @@ class TrackTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertEqual(result[0], cl0)
         self.assertEqual(result[1], cl1)
 
+    def test_find_children_stack(self):
+        video_clip = otio.schema.Clip()
+        video_clip.source_range = otio.opentime.TimeRange(
+            otio.opentime.RationalTime(0.0, 30.0),
+            otio.opentime.RationalTime(700.0, 30.0))
+        audio_clip = otio.schema.Clip()
+        audio_clip.source_range = otio.opentime.TimeRange(
+            otio.opentime.RationalTime(0.0, 30.0),
+            otio.opentime.RationalTime(704.0, 30.0))
+        video_track = otio.schema.Track()
+        audio_track = otio.schema.Track()
+        stack = otio.schema.Stack()
+        video_track.append(video_clip)
+        audio_track.append(audio_clip)
+        stack.append(video_track)
+        stack.append(audio_track)
+
+        time = otio.opentime.RationalTime(703.0, 30.0)
+        one_frame = otio.opentime.RationalTime(1.0, 30.0)
+        range = otio.opentime.TimeRange(time, one_frame)
+        items = stack.find_children(search_range=range)
+        self.assertEqual(len(items), 2)
+        self.assertTrue(audio_clip in items)
+        self.assertTrue(audio_track in items)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #1652

This PR is a replacement for #1755 which has some trouble with the git history.

After some investigation, it looks like the find_children() function was not working with stacks when given a search range. To fix this, an override is added for the function children_in_range() that works with "stacks" of children.
