### PR TITLE
Resolve CI issues and bump actions/checkout from v3->v4

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -41,7 +41,7 @@ tag-template: 'v$RESOLVED_VERSION'
 #       - 'docs'
 #       - 'style'
 
-# automatically a label into a pull request
+# automatically label pull requests
 # https://github.com/release-drafter/release-drafter#autolabeler
 autolabeler:
   - label: 'feat'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ jobs:
   check-links:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
 

--- a/.github/workflows/pr-tools.yml
+++ b/.github/workflows/pr-tools.yml
@@ -24,7 +24,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3 # https://github.com/actions/checkout/tree/main#usage
+        uses: actions/checkout@v4 # https://github.com/actions/checkout/tree/main#usage
 
       # https://github.com/actions/labeler#usage
       - uses: actions/labeler@v4

--- a/.github/workflows/pr-tools.yml
+++ b/.github/workflows/pr-tools.yml
@@ -2,7 +2,7 @@ name: Pull Request Tools
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     types: [
         opened, # pr is created
         reopened, # pr is reopened after being closed

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,7 +44,7 @@ jobs:
       OTIO_CONSUMER_TEST_BUILD_DIR: ${{ github.workspace }}/consumertest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Install coverage dependency
@@ -116,7 +116,7 @@ jobs:
       OTIO_CXX_BUILD_TMP_DIR: ${{ github.workspace }}/build
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Set up MSYS2
@@ -180,7 +180,7 @@ jobs:
         exclude:
           - { os: macos-14, python-build: 'cp37*' }
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build wheels (Python 3)
         uses: pypa/cibuildwheel@v2.16.5
@@ -201,7 +201,7 @@ jobs:
     needs: py_build_test
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
 

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -28,12 +28,12 @@ jobs:
     outputs:
       branch-name: ${{ steps.get-branch-name.outputs.branch-name }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Create Branch
         shell: bash
         run: |
-          sh ./github/scripts/release-branch.sh
+          sh .github/scripts/release-branch.sh
 
       - name: Get New Branch Name
         id: get-branch-name

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
   announce-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow-up to -> #1690 

**Summarize your change.**
- Update `actions/checkout@v3` -> `actions/checkout@v4`
- Fix path of the `release-branch.sh` script

<!--
Important: If this is your first contribution to OpenTimelineIO, you will need to submit a Contributor License Agreement. For a step-by-step instructions on the pull request process, see
https://github.com/AcademySoftwareFoundation/OpenTimelineIO/tree/main/CONTRIBUTING.md
-->
