### PR TITLE
Fix pylint warning `no-else-return`

### DIFF
--- a/examples/conform.py
+++ b/examples/conform.py
@@ -80,15 +80,14 @@ def _find_matching_media(name, folder):
         return None
     if len(matches) == 1:
         return matches[0]
-    else:
-        print(
-            "WARNING: {} matches found for clip '{}', using '{}'".format(
-                len(matches),
-                name,
-                matches[0]
-            )
+    print(
+        "WARNING: {} matches found for clip '{}', using '{}'".format(
+            len(matches),
+            name,
+            matches[0]
         )
-        return matches[0]
+    )
+    return matches[0]
 
 
 def _conform_timeline(timeline, folder):

--- a/src/py-opentimelineio/opentimelineio/adapters/__init__.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/__init__.py
@@ -78,8 +78,7 @@ def available_adapter_names():
 def _from_filepath_or_name(filepath, adapter_name):
     if adapter_name is not None:
         return plugins.ActiveManifest().from_name(adapter_name)
-    else:
-        return from_filepath(filepath)
+    return from_filepath(filepath)
 
 
 def from_filepath(filepath):

--- a/src/py-opentimelineio/opentimelineio/console/otiostat.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiostat.py
@@ -84,8 +84,7 @@ def _deepest_nesting(input):
         return d
     if isinstance(input, otio.schema.Timeline):
         return depth(input.tracks) + 1
-    else:
-        return depth(input)
+    return depth(input)
 
 
 @stat_check("number of clips")

--- a/src/py-opentimelineio/opentimelineio/console/otiotool.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiotool.py
@@ -614,8 +614,7 @@ def time_from_string(text, rate):
     specifies the rate for the returned RationalTime."""
     if ":" in text:
         return otio.opentime.from_timecode(text, rate)
-    else:
-        return otio.opentime.from_seconds(float(text), rate)
+    return otio.opentime.from_seconds(float(text), rate)
 
 
 def trim_timeline(start, end, timeline):
@@ -725,9 +724,8 @@ def relink_by_name(timeline, path):
         # Turn absolute paths into file:// URIs
         if os.path.isabs(p):
             return pathlib.Path(p).as_uri()
-        else:
-            # Leave relative paths as-is
-            return p
+        # Leave relative paths as-is
+        return p
 
     count = 0
     if os.path.isdir(path):
@@ -742,9 +740,8 @@ def relink_by_name(timeline, path):
         print((f"ERROR: Cannot relink to '{path}':"
                " Please specify a folder instead of a file."))
         return
-    else:
-        print(f"ERROR: Cannot relink to '{path}': No such file or folder.")
-        return
+    print(f"ERROR: Cannot relink to '{path}': No such file or folder.")
+    return
 
     for clip in timeline.find_clips():
         url = name_to_url.get(clip.name)

--- a/src/py-opentimelineio/opentimelineio/core/_core_utils.py
+++ b/src/py-opentimelineio/opentimelineio/core/_core_utils.py
@@ -59,7 +59,7 @@ def _value_to_any(value, ids=None):
             d[k] = _value_to_any(v, ids)
             ids.discard(id(v))
         return PyAny(d)
-    elif _is_nonstring_sequence(value):
+    if _is_nonstring_sequence(value):
         if ids is None:
             ids = set()
         vec = AnyVector()
@@ -72,45 +72,44 @@ def _value_to_any(value, ids=None):
             vec.append(_value_to_any(v, ids))
             ids.discard(id(v))
         return PyAny(vec)
-    else:
-        try:
-            return PyAny(value)
-        except TypeError:
-            # raise an OTIO-specific error
-            raise TypeError(
-                "A value of type '{}' is incompatible with OpenTimelineIO. "
-                "OpenTimelineIO only supports the following value types in "
-                "AnyDictionary containers (like the .metadata dictionary): "
-                "{}.".format(
-                    type(value),
-                    SUPPORTED_VALUE_TYPES,
-                )
+    try:
+        return PyAny(value)
+    except TypeError:
+        # raise an OTIO-specific error
+        raise TypeError(
+            "A value of type '{}' is incompatible with OpenTimelineIO. "
+            "OpenTimelineIO only supports the following value types in "
+            "AnyDictionary containers (like the .metadata dictionary): "
+            "{}.".format(
+                type(value),
+                SUPPORTED_VALUE_TYPES,
             )
-        except RuntimeError:
-            # communicate about integer range first
-            biginttype = int
-            if isinstance(value, biginttype):
-                raise ValueError(
-                    "A value of {} is outside of the range of integers that "
-                    "OpenTimelineIO supports, [{}, {}], which is the range of "
-                    "C++ int64_t.".format(
-                        value,
-                        -9223372036854775808,
-                        9223372036854775807,
-                    )
-                )
-
-            # general catch all for invalid type
+        )
+    except RuntimeError:
+        # communicate about integer range first
+        biginttype = int
+        if isinstance(value, biginttype):
             raise ValueError(
-                "The value '{}' of type '{}' is incompatible with OpenTimelineIO. "
-                "OpenTimelineIO only supports the following value types in "
-                "AnyDictionary containers (like the .metadata dictionary): "
-                "{}.".format(
+                "A value of {} is outside of the range of integers that "
+                "OpenTimelineIO supports, [{}, {}], which is the range of "
+                "C++ int64_t.".format(
                     value,
-                    type(value),
-                    SUPPORTED_VALUE_TYPES,
+                    -9223372036854775808,
+                    9223372036854775807,
                 )
             )
+
+        # general catch all for invalid type
+        raise ValueError(
+            "The value '{}' of type '{}' is incompatible with OpenTimelineIO. "
+            "OpenTimelineIO only supports the following value types in "
+            "AnyDictionary containers (like the .metadata dictionary): "
+            "{}.".format(
+                value,
+                type(value),
+                SUPPORTED_VALUE_TYPES,
+            )
+        )
 
 
 _marker_ = object()
@@ -129,9 +128,8 @@ def _add_mutable_mapping_methods(mapClass):
     def setdefault(self, key, default_value):
         if key in self:
             return self[key]
-        else:
-            self[key] = default_value
-            return self[key]
+        self[key] = default_value
+        return self[key]
 
     def pop(self, key, default=_marker_):
         try:
@@ -140,9 +138,8 @@ def _add_mutable_mapping_methods(mapClass):
             if default is _marker_:
                 raise
             return default
-        else:
-            del self[key]
-            return value
+        del self[key]
+        return value
 
     def __copy__(self):
         m = mapClass()
@@ -202,12 +199,11 @@ def _add_mutable_sequence_methods(
     def __add__(self, other):
         if isinstance(other, list):
             return list(self) + other
-        elif _is_nonstring_sequence(other):
+        if _is_nonstring_sequence(other):
             return list(self) + list(other)
-        else:
-            raise TypeError(
-                f"Cannot add types '{type(self)}' and '{type(other)}'"
-            )
+        raise TypeError(
+            f"Cannot add types '{type(self)}' and '{type(other)}'"
+        )
 
     def __radd__(self, other):
         return self.__add__(other)
@@ -222,10 +218,8 @@ def _add_mutable_sequence_methods(
         if isinstance(index, slice):
             indices = index.indices(len(self))
             return [self.__internal_getitem__(i) for i in range(*indices)]
-        else:
-            return self.__internal_getitem__(index)
+        return self.__internal_getitem__(index)
 
-    # This has to handle slicing
     def __setitem__(self, index, item):
         if not isinstance(index, slice):
             self.__internal_setitem__(index, conversion_func(item))


### PR DESCRIPTION
Changes Made:

- Applied automated fixes for the pylint warning `no-else-return`.
"Used in order to highlight an unnecessary block of code following an if containing a return statement. As such, it will warn when it encounters an else following a chain of ifs, all of them containing a return statement.. See [https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html](https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html)"

Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.