### PR TITLE
#1680 fix segmentation fault when appending None

### DIFF
--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -526,9 +526,9 @@ Should be subclassed (for example by :class:`.Track` and :class:`.Stack`), not u
                 index = adjusted_vector_index(index, c->children());
                 c->remove_child(index, ErrorStatusHandler());
             }, "index"_a)
-        .def("__internal_insert", [](Composition* c, int index, Composable* composable) {
+        .def("__internal_insert", [](Composition* c, int index, Composable &composable) {
                 index = adjusted_vector_index(index, c->children());
-                c->insert_child(index, composable, ErrorStatusHandler());
+                c->insert_child(index, &composable, ErrorStatusHandler());
             }, "index"_a, "item"_a)
         .def("__contains__", &Composition::has_child, "composable"_a)
         .def("__len__", [](Composition* c) {

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -10,6 +10,10 @@ import opentimelineio.test_utils as otio_test_utils
 
 class TrackTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
+    def test_append_none(self):
+        tr = otio.schema.Track()
+        self.assertRaises(TypeError, lambda x: tr.append(None))
+
     def test_find_children(self):
         cl = otio.schema.Clip()
         tr = otio.schema.Track()


### PR DESCRIPTION
Fixes #1680

**Summary**

Changes to reference parameter to raise `TypeError` instead of crashing with a segmentation fault. Created `test_append_none` to prevent regression.