### PR TITLE
#1677 otiotool verify ranges

### DIFF
--- a/src/py-opentimelineio/opentimelineio/console/otiotool.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiotool.py
@@ -870,8 +870,8 @@ def summarize_timeline(list_tracks, list_clips, list_media, verify_media,
                 print(f"TRACK: {child.name} ({child.kind})")
         if isinstance(child, otio.schema.Clip):
             if list_clips or verify_ranges:
-                range_msg = ""
                 if verify_ranges:
+                    range_msg = ""
                     try:
                         source = child.source_range
                         available = child.available_range()
@@ -889,7 +889,9 @@ def summarize_timeline(list_tracks, list_clips, list_media, verify_media,
                             range_msg = "IN BOUNDS"
                     except Exception:  # available range is, well, unavailable
                         pass
-                print("  CLIP:", child.name, range_msg)
+                    print("  CLIP:", child.name, range_msg)
+                else:
+                    print("  CLIP:", child.name)
             if list_media or verify_media:
                 try:
                     url = child.media_reference.target_url

--- a/src/py-opentimelineio/opentimelineio/console/otiotool.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiotool.py
@@ -137,7 +137,8 @@ def main():
                         args.list_media or
                         args.verify_media or
                         args.list_tracks or
-                        args.list_markers)
+                        args.list_markers or
+                        args.verify_ranges)
     if should_summarize:
         for timeline in timelines:
             summarize_timeline(
@@ -146,6 +147,7 @@ def main():
                 args.list_media,
                 args.verify_media,
                 args.list_markers,
+                args.verify_ranges,
                 timeline)
 
     # Final Phase: Output
@@ -207,7 +209,7 @@ This tool works in phases, as follows:
 
 6. Inspect
     Options such as --stats, --list-clips, --list-tracks, --list-media,
-    --verify-media, --list-markers, and --inspect will examine the OTIO and
+    --verify-media, --list-markers, --verify-ranges, and --inspect will examine the OTIO and
     print information to standard output.
 
 7. Output
@@ -396,6 +398,12 @@ otiotool -i playlist.otio --only-audio --list-tracks --inspect "Interview"
         "--list-markers",
         action='store_true',
         help="List summary of all markers"
+    )
+    parser.add_argument(
+        "--verify-ranges",
+        action='store_true',
+        help="""Verify that each clip in a timeline has a source range 
+        within the available range of media"""
     )
     parser.add_argument(
         "--inspect",
@@ -852,7 +860,7 @@ def inspect_timelines(name_regex, timeline):
 
 
 def summarize_timeline(list_tracks, list_clips, list_media, verify_media,
-                       list_markers, timeline):
+                       list_markers, verify_ranges, timeline):
     """Print a summary of a timeline, optionally listing the tracks, clips, media,
     and/or markers inside it."""
     print("TIMELINE:", timeline.name)
@@ -861,8 +869,22 @@ def summarize_timeline(list_tracks, list_clips, list_media, verify_media,
             if list_tracks:
                 print(f"TRACK: {child.name} ({child.kind})")
         if isinstance(child, otio.schema.Clip):
-            if list_clips:
-                print("  CLIP:", child.name)
+            if list_clips or verify_ranges:
+                range_msg = ""
+                if verify_ranges:
+                    try:
+                        source = child.source_range
+                        available = child.available_range()
+
+                        starts_early = source.start_time.value < available.start_time.value
+                        ends_late = (source.duration.value - source.start_time.value) > (available.duration.value - available.start_time.value)
+                        if starts_early or ends_late:
+                            range_msg = "SOURCE MEDIA OUT OF BOUNDS"
+                        else:
+                            range_msg = "IN BOUNDS"
+                    except Exception as e: # available range is, well, unavailable
+                        pass
+                print("  CLIP:", child.name, range_msg)
             if list_media or verify_media:
                 try:
                     url = child.media_reference.target_url

--- a/src/py-opentimelineio/opentimelineio/console/otiotool.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiotool.py
@@ -403,7 +403,8 @@ otiotool -i playlist.otio --only-audio --list-tracks --inspect "Interview"
         "--verify-ranges",
         action='store_true',
         help="""Verify that each clip in a timeline has a source range
-        within the available range of media"""
+        within the available range of media
+        (acceptable in some use cases, not in others)"""
     )
     parser.add_argument(
         "--inspect",

--- a/src/py-opentimelineio/opentimelineio/console/otiotool.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiotool.py
@@ -209,8 +209,8 @@ This tool works in phases, as follows:
 
 6. Inspect
     Options such as --stats, --list-clips, --list-tracks, --list-media,
-    --verify-media, --list-markers, --verify-ranges, and --inspect will examine the OTIO and
-    print information to standard output.
+    --verify-media, --list-markers, --verify-ranges, and --inspect
+    will examine the OTIO and print information to standard output.
 
 7. Output
     Finally, if the "--output <filename>" option is specified, the resulting
@@ -402,7 +402,7 @@ otiotool -i playlist.otio --only-audio --list-tracks --inspect "Interview"
     parser.add_argument(
         "--verify-ranges",
         action='store_true',
-        help="""Verify that each clip in a timeline has a source range 
+        help="""Verify that each clip in a timeline has a source range
         within the available range of media"""
     )
     parser.add_argument(
@@ -876,13 +876,18 @@ def summarize_timeline(list_tracks, list_clips, list_media, verify_media,
                         source = child.source_range
                         available = child.available_range()
 
-                        starts_early = source.start_time.value < available.start_time.value
-                        ends_late = (source.duration.value - source.start_time.value) > (available.duration.value - available.start_time.value)
+                        src_start = source.start_time.value
+                        src_dur = source.duration.value
+                        avail_start = available.start_time.value
+                        avail_dur = available.duration.value
+
+                        starts_early = src_start < avail_start
+                        ends_late = (src_dur - src_start) > (avail_dur - avail_start)
                         if starts_early or ends_late:
                             range_msg = "SOURCE MEDIA OUT OF BOUNDS"
                         else:
                             range_msg = "IN BOUNDS"
-                    except Exception as e: # available range is, well, unavailable
+                    except Exception:  # available range is, well, unavailable
                         pass
                 print("  CLIP:", child.name, range_msg)
             if list_media or verify_media:

--- a/src/py-opentimelineio/opentimelineio/console/otiotool.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiotool.py
@@ -877,14 +877,15 @@ def summarize_timeline(list_tracks, list_clips, list_media, verify_media,
                         source = child.source_range
                         available = child.available_range()
 
-                        src_start = source.start_time.value
-                        src_dur = source.duration.value
-                        avail_start = available.start_time.value
-                        avail_dur = available.duration.value
-
-                        starts_early = src_start < avail_start
-                        ends_late = (src_dur - src_start) > (avail_dur - avail_start)
-                        if starts_early or ends_late:
+                        # contains() uses end_time_exclusive(),
+                        # does not handle case when
+                        # the end of the source range
+                        # meets available range exactly
+                        available_start = available.start_time
+                        available_end = available.end_time_inclusive()
+                        src_start = source.start_time
+                        src_end = source.end_time_inclusive()
+                        if src_start < available_start or available_end < src_end:
                             range_msg = "SOURCE MEDIA OUT OF BOUNDS"
                         else:
                             range_msg = "IN BOUNDS"


### PR DESCRIPTION
Fixes #1677

**Summary**

Adds `--verify-ranges` option for otiotool's inspection feature, verifies that the clip's source range doesn't start before the available start range or ends beyond it (if the available range exists).