### PR TITLE
Offer alternative for cxxabi on Windows (Swift+Clang).

### DIFF
--- a/src/opentimelineio/stringUtils.cpp
+++ b/src/opentimelineio/stringUtils.cpp
@@ -4,14 +4,20 @@
 #include "opentimelineio/serializableObject.h"
 #if defined(__GNUC__) || defined(__clang__)
 #    include <cstdlib>
-#    include <cxxabi.h>
+#    if __has_include(<cxxabi.h>)
+#       define OTIO_HAVE_DEMANGLER 1
+#       include <cxxabi.h>
+#    else // !__has_include(<cxxabi.h>)
+#       define OTIO_HAVE_DEMANGLER 0
+#    endif // __has_include(<cxxabi.h>)
 #    include <memory>
 #else
+#    define OTIO_HAVE_DEMANGLER 0
 #    include <typeinfo>
 #endif
 
 namespace {
-#if defined(__GNUC__) || defined(__clang__)
+#if OTIO_HAVE_DEMANGLER
 std::string
 cxxabi_type_name_for_error_mesage(const char* name)
 {
@@ -41,10 +47,10 @@ type_name_for_error_message(std::type_info const& t)
         return "None";
     }
 
-#if defined(__GNUC__) || defined(__clang__)
+#if OTIO_HAVE_DEMANGLER
     return ::cxxabi_type_name_for_error_mesage(t.name());
 #else
-    // On Windows std::type_info.name() returns a human readable string.
+    // On Windows, or without cxxabi.h, std::type_info.name() returns a human readable string.
     return t.name();
 #endif
 }


### PR DESCRIPTION
**Summarize your change.**

This fixes the clang compilation of **OpenTimelineIO** on **Microsoft Windows**, when compiling with Swift. Previously, the `cxxabi.h` header was erroneously getting included in the Windows clang compilation of OpenTimelineIO's `stringUtils.cpp` file because it was being conditionally compiled for clang across all platforms, and this header does not exist on the Windows platform.

- The include for `cxxabi.h` is now guarded via `__has_include(<cxxabi.h>)`.
- A new preprocessor definition for `OTIO_HAVE_DEMANGLER` is set to **`1`** if `cxxabi.h` exists, and **`0`** if this header does not exist.
- Previous checks against `defined(__GNUC__) || defined(__clang__)` are replaced with conditional compilation checks against the new `OTIO_HAVE_DEMANGLER` preprocessor define.

<!--
Important: If this is your first contribution to OpenTimelineIO, you will need to submit a Contributor License Agreement. For a step-by-step instructions on the pull request process, see
https://github.com/AcademySoftwareFoundation/OpenTimelineIO/tree/main/CONTRIBUTING.md
-->
