### PR TITLE
Disable 32-bit Python builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,9 @@ requires = [
     "cmake>=3.12",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel.linux]
+archs = ["x86_64"]
+
+[tool.cibuildwheel.windows]
+archs = ["AMD64"]


### PR DESCRIPTION
Fixes #1788 

This PR disables x86 builds to help reduce CI time and troubleshooting.

Marking this as WIP to test the changes.