### PR TITLE
Add Python build for Linux on ARM architecture

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -193,11 +193,8 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.python-build }}
           CIBW_SKIP: '*musllinux*'
-          # configure cibuildwheel to build native archs ('auto'), and some
-          # emulated ones
-          CIBW_ARCHS_LINUX: auto aarch64
+          CIBW_ARCHS_LINUX: x86_64 aarch64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_MANYLINUX_I686_IMAGE: manylinux2014
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -182,6 +182,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+
       - name: Build wheels (Python 3)
         uses: pypa/cibuildwheel@v2.16.5
         with:
@@ -189,8 +193,12 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.python-build }}
           CIBW_SKIP: '*musllinux*'
+          # configure cibuildwheel to build native archs ('auto'), and some
+          # emulated ones
+          CIBW_ARCHS_LINUX: auto aarch64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
 
       - uses: actions/upload-artifact@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel.linux]
-archs = ["x86_64"]
+archs = ["x86_64", "aarch64"]
 
 [tool.cibuildwheel.windows]
 archs = ["AMD64"]


### PR DESCRIPTION
**Summarize your change.**

Add support for building wheels for Linux on ARM architecture.

This covers both ARM64 hardware running Linux directly, as well as Docker containers running under other operating systems, such as Docker on MacOS.

Our use case is to speed up installs of the package in Docker running on Apple M1 MacBooks.

See docs https://cibuildwheel.pypa.io/en/stable/faq/#emulation
Note there is a time penalty to building this wheel under emulation.

<!--
Important: If this is your first contribution to OpenTimelineIO, you will need to submit a Contributor License Agreement. For a step-by-step instructions on the pull request process, see
https://github.com/AcademySoftwareFoundation/OpenTimelineIO/tree/main/CONTRIBUTING.md
-->
