### PR TITLE
Bindings: UnknownSchema added data property

### DIFF
--- a/src/opentimelineio/unknownSchema.h
+++ b/src/opentimelineio/unknownSchema.h
@@ -39,6 +39,11 @@ public:
         return _original_schema_version;
     }
 
+    AnyDictionary data() const noexcept
+    {
+        return _data;
+    }
+
     bool read_from(Reader&) override;
     void write_to(Writer&) const override;
 

--- a/src/opentimelineio/unknownSchema.h
+++ b/src/opentimelineio/unknownSchema.h
@@ -39,6 +39,7 @@ public:
         return _original_schema_version;
     }
 
+    /// @brief Return a copy of the data.
     AnyDictionary data() const noexcept
     {
         return _data;

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -301,6 +301,9 @@ define_bases1(py::module m)
     py::class_<UnknownSchema, SerializableObject, managing_ptr<UnknownSchema>>(
         m,
         "UnknownSchema")
+        .def_property_readonly("data", [](UnknownSchema* schema) {
+                auto ptr = schema->data().get_or_create_mutation_stamp();
+            return (AnyDictionaryProxy*)(ptr); }, py::return_value_policy::take_ownership)
         .def_property_readonly(
             "original_schema_name",
             &UnknownSchema::original_schema_name)

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -302,8 +302,9 @@ define_bases1(py::module m)
         m,
         "UnknownSchema")
         .def_property_readonly("data", [](UnknownSchema* schema) {
-                auto ptr = schema->data().get_or_create_mutation_stamp();
-            return (AnyDictionaryProxy*)(ptr); }, py::return_value_policy::take_ownership)
+                AnyDictionary copy = schema->data();
+                return any_to_py(copy, true /*top_level*/);
+            })
         .def_property_readonly(
             "original_schema_name",
             &UnknownSchema::original_schema_name)

--- a/tests/test_unknown_schema.py
+++ b/tests/test_unknown_schema.py
@@ -63,6 +63,32 @@ class UnknownSchemaTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         unknown = self.orig.media_reference.metadata["stuff"]
         self.assertTrue(unknown.is_unknown_schema)
 
+    def test_unknown_to_dict(self):
+        unknown = self.orig.media_reference.metadata["stuff"]
+        self.assertTrue(unknown.is_unknown_schema)
+        unknown_data = unknown.data
+        self.assertIsNotNone(
+            unknown_data
+        )
+
+        self.assertEqual(
+            unknown_data,
+            {
+                "some_data": 895,
+                "howlongami": otio.opentime.RationalTime(rate=30, value=100)
+            }
+        )
+        
+        # Mutation of unkown_data should not mutate the unknown object.
+        unknown_data["some_data"] = 0
+        self.assertEqual(
+            unknown.data,
+            {
+                "some_data": 895,
+                "howlongami": otio.opentime.RationalTime(rate=30, value=100)
+            }
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_unknown_schema.py
+++ b/tests/test_unknown_schema.py
@@ -78,7 +78,7 @@ class UnknownSchemaTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
                 "howlongami": otio.opentime.RationalTime(rate=30, value=100)
             }
         )
-        
+
         # Mutation of unkown_data should not mutate the unknown object.
         unknown_data["some_data"] = 0
         self.assertEqual(


### PR DESCRIPTION
Fixes #1234 

Python bindings return dictionary-type python object for UnknownSchema data.
