### PR TITLE
Deprecate c++ demangling.

### DIFF
--- a/src/opentimelineio/stringUtils.cpp
+++ b/src/opentimelineio/stringUtils.cpp
@@ -2,30 +2,9 @@
 // Copyright Contributors to the OpenTimelineIO project
 
 #include "opentimelineio/serializableObject.h"
-#if defined(__GNUC__) || defined(__clang__)
-#    include <cstdlib>
-#    include <cxxabi.h>
-#    include <memory>
-#else
-#    include <typeinfo>
-#endif
-
-namespace {
-#if defined(__GNUC__) || defined(__clang__)
-std::string
-cxxabi_type_name_for_error_mesage(const char* name)
-{
-    int status = -4; // some arbitrary value to eliminate the compiler warning
-
-    std::unique_ptr<char, void (*)(void*)> res{
-        abi::__cxa_demangle(name, NULL, NULL, &status),
-        std::free
-    };
-
-    return (status == 0) ? res.get() : name;
-}
-#endif
-} // namespace
+#include <cstdlib>
+#include <memory>
+#include <typeinfo>
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
@@ -41,12 +20,7 @@ type_name_for_error_message(std::type_info const& t)
         return "None";
     }
 
-#if defined(__GNUC__) || defined(__clang__)
-    return ::cxxabi_type_name_for_error_mesage(t.name());
-#else
-    // On Windows std::type_info.name() returns a human readable string.
     return t.name();
-#endif
 }
 
 std::string


### PR DESCRIPTION
**Summarize your change.**

Remove the C++ demangling.

- Removes the include for `<cxxabi.h>`
- Removes any demangling logic that utilized that header.

**Reference associated tests.**

All tests pass.
<!--
Important: If this is your first contribution to OpenTimelineIO, you will need to submit a Contributor License Agreement. For a step-by-step instructions on the pull request process, see
https://github.com/AcademySoftwareFoundation/OpenTimelineIO/tree/main/CONTRIBUTING.md
-->
