### PR TITLE
Added support for custom adapter hooks

### DIFF
--- a/src/py-opentimelineio/opentimelineio/adapters/adapter.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/adapter.py
@@ -338,8 +338,9 @@ class Adapter(plugins.PythonPlugin):
         result["supported features"] = features
 
         for feature in sorted(_FEATURE_MAP.keys()):
-            if feature in ["read", "write"]:
+            if feature in ["read", "write", "hooks"]:
                 continue
+
             if self.has_feature(feature):
                 features[feature] = collections.OrderedDict()
 
@@ -355,6 +356,14 @@ class Adapter(plugins.PythonPlugin):
                 if args:
                     features[feature]["args"] = args.args
                     features[feature]["doc"] = docs
+
+        # check if there are any adapter specific-hooks and get their names
+        if self.has_feature("hooks"):
+            adapter_hooks_names_fn = getattr(
+                self.module(), _FEATURE_MAP["hooks"][0], None
+            )
+            if adapter_hooks_names_fn:
+                features["hooks"] = adapter_hooks_names_fn()
 
         return result
 

--- a/src/py-opentimelineio/opentimelineio/console/otiopluginfo.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiopluginfo.py
@@ -75,7 +75,16 @@ def _supported_features_formatted(feature_map, _):
     if feature_map:
         print("    explicit supported features:")
     for thing, args in feature_map.items():
+        # skip hooks, they are treated separately, see below
+        if thing == "hooks":
+            continue
         print("      {} args: {}".format(thing, args['args']))
+
+    # check if there are any adapter specific-hooks implemented
+    adapter_hook_names = feature_map.get("hooks", [])
+    if adapter_hook_names:
+        print("      adapter hooks: {}".format(adapter_hook_names))
+
     extra_features = []
     for kind in ["read", "write"]:
         if (

--- a/tests/baselines/adapter_plugin_manifest.plugin_manifest.json
+++ b/tests/baselines/adapter_plugin_manifest.plugin_manifest.json
@@ -16,13 +16,17 @@
         },
         {
             "FROM_TEST_FILE" : "post_write_hookscript_example.json"
+        },
+        {
+            "FROM_TEST_FILE" : "custom_adapter_hookscript_example.json"
         }
     ],
     "hooks" : {
         "pre_adapter_write" : ["example hook", "example hook"],
         "post_adapter_read" : [],
         "post_adapter_write" : ["post write example hook"],
-        "post_media_linker" : ["example hook"]
+        "post_media_linker" : ["example hook"],
+        "custom_adapter_hook": ["custom adapter hook"]
     },
     "version_manifests" : {
         "TEST_FAMILY_NAME": {

--- a/tests/baselines/custom_adapter_hookscript_example.json
+++ b/tests/baselines/custom_adapter_hookscript_example.json
@@ -1,0 +1,5 @@
+{
+    "OTIO_SCHEMA" : "HookScript.1",
+    "name" : "custom adapter hook",
+    "filepath" : "custom_adapter_hookscript_example.py"
+}

--- a/tests/baselines/custom_adapter_hookscript_example.py
+++ b/tests/baselines/custom_adapter_hookscript_example.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the OpenTimelineIO project
+
+"""This file is here to support the test_adapter_plugin unittest, specifically adapters
+that implement their own hooks.
+If you want to learn how to write your own adapter plugin, please read:
+https://opentimelineio.readthedocs.io/en/latest/tutorials/write-an-adapter.html
+"""
+
+
+def hook_function(in_timeline, argument_map=None):
+    in_timeline.metadata["custom_hook"] = dict(argument_map)
+    return in_timeline

--- a/tests/baselines/example.py
+++ b/tests/baselines/example.py
@@ -6,23 +6,41 @@ If you want to learn how to write your own adapter plugin, please read:
 https://opentimelineio.readthedocs.io/en/latest/tutorials/write-an-adapter.html
 """
 
-import opentimelineio as otio
 
+# `hook_function_argument_map` is only a required argument for adapters that implement
+# custom hooks.
+def read_from_file(filepath, suffix="", hook_function_argument_map=None):
+    import opentimelineio as otio
 
-def read_from_file(filepath, suffix=""):
     fake_tl = otio.schema.Timeline(name=filepath + str(suffix))
     fake_tl.tracks.append(otio.schema.Track())
     fake_tl.tracks[0].append(otio.schema.Clip(name=filepath + "_clip"))
+
+    if (hook_function_argument_map and
+            hook_function_argument_map.get("run_custom_hook", False)):
+        return otio.hooks.run(hook="custom_adapter_hook", tl=fake_tl,
+                              extra_args=hook_function_argument_map)
+
     return fake_tl
 
 
-def read_from_string(input_str, suffix=""):
-    return read_from_file(input_str, suffix)
+# `hook_function_argument_map` is only a required argument for adapters that implement
+# custom hooks.
+def read_from_string(input_str, suffix="", hook_function_argument_map=None):
+    tl = read_from_file(input_str, suffix, hook_function_argument_map)
+    return tl
+
+
+# this is only required for adapters that implement custom hooks
+def adapter_hook_names():
+    return ["custom_adapter_hook"]
 
 
 # in practice, these will be in separate plugins, but for simplicity in the
 # unit tests, we put this in the same file as the example adapter.
 def link_media_reference(in_clip, media_linker_argument_map):
+    import opentimelineio as otio
+
     d = {'from_test_linker': True}
     d.update(media_linker_argument_map)
     return otio.schema.MissingReference(

--- a/tests/test_adapter_plugin.py
+++ b/tests/test_adapter_plugin.py
@@ -89,6 +89,7 @@ class TestPluginAdapters(unittest.TestCase):
         self.assertTrue(self.adp.has_feature("read"))
         self.assertTrue(self.adp.has_feature("read_from_file"))
         self.assertFalse(self.adp.has_feature("write"))
+        self.assertTrue(self.adp.has_feature("hooks"))
 
     def test_pass_arguments_to_adapter(self):
         self.assertEqual(self.adp.read_from_file("foo", suffix=3).name, "foo3")


### PR DESCRIPTION
**Summarize your change.**

_Rebased PR #1711_

Required by https://github.com/OpenTimelineIO/otio-aaf-adapter/pull/43

This adds support for attributing custom hooks to adapters and executing them with `hook_function_argument_map` being passed along through the adapter IO functions.

**Describe the reason for the change.**

I added two custom hooks to the OTIO AAF adapter (https://github.com/OpenTimelineIO/otio-aaf-adapter/pull/43), allowing for embedding of media essence into the resulting AAF. This was needed to facilitate just-in-time DNXHR transcoding of the media for the AAF creation and adding a certain level of control and flexibility to the feature. 

These features to the core are required in order to properly pass the hook argument map along to potential custom hooks run by the adapter. I tried to work with `_FEATURE_MAP` instead of creating a new version of the Adapter schema in order to minimize the impact of this change, while adding the necessary changes to facilitate custom hooks for adapters.

**Reference associated tests.**

```
tests/test_adapter_plugin.py
tests/test_hooks_plugins.py
```