### PR TITLE
Add effect and marker initialization to Clip

### DIFF
--- a/src/opentimelineio/clip.cpp
+++ b/src/opentimelineio/clip.cpp
@@ -13,8 +13,10 @@ Clip::Clip(
     MediaReference*                 media_reference,
     std::optional<TimeRange> const& source_range,
     AnyDictionary const&            metadata,
+    std::vector<Effect*> const&     effects,
+    std::vector<Marker*> const&     markers,
     std::string const&              active_media_reference_key)
-    : Parent{ name, source_range, metadata }
+    : Parent{ name, source_range, metadata, effects, markers }
     , _active_media_reference_key(active_media_reference_key)
 {
     set_media_reference(media_reference);

--- a/src/opentimelineio/clip.h
+++ b/src/opentimelineio/clip.h
@@ -27,6 +27,8 @@ public:
         MediaReference*                 media_reference = nullptr,
         std::optional<TimeRange> const& source_range    = std::nullopt,
         AnyDictionary const&            metadata        = AnyDictionary(),
+        std::vector<Effect*> const& effects             = std::vector<Effect*>(),
+        std::vector<Marker*> const& markers             = std::vector<Marker*>(),
         std::string const& active_media_reference_key   = default_media_key);
 
     void            set_media_reference(MediaReference* media_reference);

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -425,13 +425,20 @@ Contains a :class:`.MediaReference` and a trim on that media reference.
 )docstring")
         .def(py::init([](std::string name, MediaReference* media_reference,
                          std::optional<TimeRange> source_range, py::object metadata,
+                         std::optional<std::vector<Effect*>> effects,
+                         std::optional<std::vector<Marker*>> markers,
                          const std::string&  active_media_reference) {
-                          return new Clip(name, media_reference, source_range, py_to_any_dictionary(metadata), active_media_reference);
+                          return new Clip(name, media_reference, source_range, py_to_any_dictionary(metadata),
+                                          vector_or_default<Effect>(effects),
+                                          vector_or_default<Marker>(markers),
+                                          active_media_reference);
                       }),
              py::arg_v("name"_a = std::string()),
              "media_reference"_a = nullptr,
              "source_range"_a = std::nullopt,
              py::arg_v("metadata"_a = py::none()),
+             "effects"_a = py::none(),
+             "markers"_a = py::none(),
              "active_media_reference"_a = std::string(Clip::default_media_key))
         .def_property_readonly_static("DEFAULT_MEDIA_KEY",[](py::object /* self */) { 
             return Clip::default_media_key; 

--- a/src/py-opentimelineio/opentimelineio/schema/clip.py
+++ b/src/py-opentimelineio/opentimelineio/schema/clip.py
@@ -7,11 +7,13 @@ from .. import _otio
 
 @add_method(_otio.Clip)
 def __str__(self):
-    return 'Clip("{}", {}, {}, {})'.format(
+    return 'Clip("{}", {}, {}, {} {} {})'.format(
         self.name,
         self.media_reference,
         self.source_range,
-        self.metadata
+        self.metadata,
+        self.effects,
+        self.markers
     )
 
 
@@ -23,11 +25,15 @@ def __repr__(self):
         'media_reference={}, '
         'source_range={}, '
         'metadata={}'
+        'effects={}'
+        'markers={}'
         ')'.format(
             repr(self.name),
             repr(self.media_reference),
             repr(self.source_range),
             repr(self.metadata),
+            repr(self.effects),
+            repr(self.markers)
         )
     )
 

--- a/src/py-opentimelineio/opentimelineio/schema/clip.py
+++ b/src/py-opentimelineio/opentimelineio/schema/clip.py
@@ -7,7 +7,7 @@ from .. import _otio
 
 @add_method(_otio.Clip)
 def __str__(self):
-    return 'Clip("{}", {}, {}, {} {} {})'.format(
+    return 'Clip("{}", {}, {}, {}, {}, {})'.format(
         self.name,
         self.media_reference,
         self.source_range,
@@ -24,8 +24,8 @@ def __repr__(self):
         'name={}, '
         'media_reference={}, '
         'source_range={}, '
-        'metadata={}'
-        'effects={}'
+        'metadata={}, '
+        'effects={}, '
         'markers={}'
         ')'.format(
             repr(self.name),

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -21,16 +21,34 @@ class ClipTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             target_url="/var/tmp/test.mov"
         )
 
+        ltw = otio.schema.LinearTimeWarp(
+            name="linear_time_warp",
+            time_scalar=1.5);
+        effects = []
+        effects.append(ltw)
+
+        red = otio.schema.MarkerColor.RED
+        m = otio.schema.Marker(
+            name="red_marker", color=red)
+        markers = []
+        markers.append(m)
+
         cl = otio.schema.Clip(
             name=name,
             media_reference=mr,
             source_range=tr,
+            effects=effects,
+            markers=markers,
             # transition_in
             # transition_out
         )
         self.assertEqual(cl.name, name)
         self.assertEqual(cl.source_range, tr)
         self.assertIsOTIOEquivalentTo(cl.media_reference, mr)
+
+        self.assertTrue(isinstance(cl.effects[0], otio.schema.LinearTimeWarp)
+
+        self.assertEqual(cl.markers[0].color, red)
 
         encoded = otio.adapters.otio_json.write_to_string(cl)
         decoded = otio.adapters.otio_json.read_from_string(encoded)

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -46,7 +46,7 @@ class ClipTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertEqual(cl.source_range, tr)
         self.assertIsOTIOEquivalentTo(cl.media_reference, mr)
 
-        self.assertTrue(isinstance(cl.effects[0], otio.schema.LinearTimeWarp)
+        self.assertTrue(isinstance(cl.effects[0], otio.schema.LinearTimeWarp))
 
         self.assertEqual(cl.markers[0].color, red)
 

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -23,7 +23,7 @@ class ClipTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
         ltw = otio.schema.LinearTimeWarp(
             name="linear_time_warp",
-            time_scalar=1.5);
+            time_scalar=1.5)
         effects = []
         effects.append(ltw)
 


### PR DESCRIPTION
**Summarize your change.**

Extend `Clip` to allow effects and markers to be set, matching how `Gap`'s can be initialized.

**Reference associated tests.**

Added basic C++ and Python tests.