### PR TITLE
Add AnyDictionary and AnyVector support for V2d and Box2d

### DIFF
--- a/src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp
@@ -14,6 +14,8 @@
 #include "opentimelineio/typeRegistry.h"
 #include "opentimelineio/stackAlgorithm.h"
 
+#include <ImathBox.h>
+
 namespace py = pybind11;
 using namespace pybind11::literals;
 
@@ -270,6 +272,8 @@ PYBIND11_MODULE(_otio, m) {
         .def(py::init([](RationalTime rt) { return new PyAny(rt); }))
         .def(py::init([](TimeRange tr) { return new PyAny(tr); }))
         .def(py::init([](TimeTransform tt) { return new PyAny(tt); }))
+        .def(py::init([](IMATH_NAMESPACE::V2d v2d) { return new PyAny(v2d); }))
+        .def(py::init([](IMATH_NAMESPACE::Box2d box2d) { return new PyAny(box2d); }))
         .def(py::init([](AnyVectorProxy* p) { return new PyAny(p->fetch_any_vector()); }))
         .def(py::init([](AnyDictionaryProxy* p) { return new PyAny(p->fetch_any_dictionary()); }))
         ;

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_utils.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_utils.cpp
@@ -11,6 +11,8 @@
 #include "opentimelineio/safely_typed_any.h"
 #include "opentimelineio/stringUtils.h"
 
+#include <ImathBox.h>
+
 #include <map>
 #include <cstring>
 
@@ -60,6 +62,8 @@ void _build_any_to_py_dispatch_table() {
     t[&typeid(RationalTime)] = [](std::any const& a, bool) { return py::cast(safely_cast_rational_time_any(a)); };
     t[&typeid(TimeRange)] = [](std::any const& a, bool) { return py::cast(safely_cast_time_range_any(a)); };
     t[&typeid(TimeTransform)] = [](std::any const& a, bool) { return py::cast(safely_cast_time_transform_any(a)); };
+    t[&typeid(IMATH_NAMESPACE::V2d)] = [](std::any const& a, bool) { return py::cast(safely_cast_point_any(a)); };
+    t[&typeid(IMATH_NAMESPACE::Box2d)] = [](std::any const& a, bool) { return py::cast(safely_cast_box_any(a)); };
     t[&typeid(SerializableObject::Retainer<>)] = [](std::any const& a, bool) {
         SerializableObject* so = safely_cast_retainer_any(a);
         return py::cast(managing_ptr<SerializableObject>(so)); };

--- a/tests/test_composable.py
+++ b/tests/test_composable.py
@@ -19,9 +19,11 @@ class ComposableTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertEqual(seqi.metadata, {'foo': 'bar'})
 
     def test_serialize(self):
+        b = otio.schema.Box2d(
+            otio.schema.V2d(0.0, 0.0), otio.schema.V2d(16.0, 9.0))
         seqi = otio.core.Composable(
             name="test",
-            metadata={"foo": "bar"}
+            metadata={"box": b}
         )
         encoded = otio.adapters.otio_json.write_to_string(seqi)
         decoded = otio.adapters.otio_json.read_from_string(encoded)

--- a/tests/test_serializable_object.py
+++ b/tests/test_serializable_object.py
@@ -144,7 +144,8 @@ class SerializableObjTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertEqual(so.metadata["box"], b)
         v = [b.min, b.max]
         so.metadata["vectors"] = v
-        self.assertEqual(so.metadata["vectors"], v)
+        self.assertEqual(so.metadata["vectors"],
+            [otio.schema.V2d(0.0, 0.0), otio.schema.V2d(16.0, 9.0)])
 
 
 class VersioningTests(unittest.TestCase, otio_test_utils.OTIOAssertions):

--- a/tests/test_serializable_object.py
+++ b/tests/test_serializable_object.py
@@ -142,7 +142,7 @@ class SerializableObjTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
         so = otio.core.SerializableObjectWithMetadata()
         so.metadata["box"] = b
         self.assertEqual(so.metadata["box"], b)
-        v = [ b.min, b.max ]
+        v = [b.min, b.max]
         so.metadata["vectors"] = v
         self.assertEqual(so.metadata["vectors"], v)
 

--- a/tests/test_serializable_object.py
+++ b/tests/test_serializable_object.py
@@ -136,6 +136,16 @@ class SerializableObjTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
         with self.assertRaises(ValueError):
             o.clone()
 
+    def test_imath(self):
+        b = otio.schema.Box2d(
+            otio.schema.V2d(0.0, 0.0), otio.schema.V2d(16.0, 9.0))
+        so = otio.core.SerializableObjectWithMetadata()
+        so.metadata["box"] = b
+        self.assertEqual(so.metadata["box"], b)
+        v = [ b.min, b.max ]
+        so.metadata["vectors"] = v
+        self.assertEqual(so.metadata["vectors"], v)
+
 
 class VersioningTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
     def test_schema_definition(self):

--- a/tests/test_serializable_object.py
+++ b/tests/test_serializable_object.py
@@ -141,13 +141,10 @@ class SerializableObjTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
             otio.schema.V2d(0.0, 0.0), otio.schema.V2d(16.0, 9.0))
         so = otio.core.SerializableObjectWithMetadata()
         so.metadata["box"] = b
-        self.assertEqual(so.metadata["box"], b)
+        self.assertEqual(repr(so.metadata["box"]), repr(b))
         v = [b.min, b.max]
         so.metadata["vectors"] = v
-        self.assertEqual(
-            so.metadata["vectors"],
-            [otio.schema.V2d(0.0, 0.0), otio.schema.V2d(16.0, 9.0)]
-        )
+        self.assertEqual(repr(so.metadata["vectors"]), repr(v))
 
 
 class VersioningTests(unittest.TestCase, otio_test_utils.OTIOAssertions):

--- a/tests/test_serializable_object.py
+++ b/tests/test_serializable_object.py
@@ -144,8 +144,10 @@ class SerializableObjTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertEqual(so.metadata["box"], b)
         v = [b.min, b.max]
         so.metadata["vectors"] = v
-        self.assertEqual(so.metadata["vectors"],
-            [otio.schema.V2d(0.0, 0.0), otio.schema.V2d(16.0, 9.0)])
+        self.assertEqual(
+            so.metadata["vectors"],
+            [otio.schema.V2d(0.0, 0.0), otio.schema.V2d(16.0, 9.0)]
+        )
 
 
 class VersioningTests(unittest.TestCase, otio_test_utils.OTIOAssertions):


### PR DESCRIPTION
Fixes #1714

**Summarize your change.**

Add Imath V2d and Box2d types so they can be added as metadata in AnyDictionary and AnyVector containers.

**Reference associated tests.**

Add basic tests for V2d and Box2d to serializable object tests. Also, adapt the composable object test, to test metadata serialization.