### PR TITLE
bumps sphinx and myst-parser pinned versions to play nicely with Python 3.13

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==5.3.0
+sphinx==7.3.7
 readthedocs-sphinx-ext==2.1.9 # ??
 sphinx-rtd-theme
-myst-parser==0.18.1
+myst-parser==3.0.1


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**


If there is an associated issue, link it in the form:

Fixes #1807

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

**Summarize your change.**

Building docs on Python 3.13 fails due to Sphinx pinned version requiring imghdr which is deprecated in newer python versions as of 3.13 (deprecated but available in 3.12).

Bumping pinned versions `sphinx==7.3.7` and `myst-parser==3.0.1` allows building docs on Python 3.13.

Add a list of changes, and note any that might need special attention during review.

**Reference associated tests.**

If no new tests are introduced as part of this PR, note the tests that are providing coverage.

<!--
Important: If this is your first contribution to OpenTimelineIO, you will need to submit a Contributor License Agreement. For a step-by-step instructions on the pull request process, see
https://github.com/AcademySoftwareFoundation/OpenTimelineIO/tree/main/CONTRIBUTING.md
-->
