### PR TITLE
Fix CI issues with readthedocs, python 3.7, and broken clip test

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -98,6 +98,7 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         include:
           - { os: ubuntu-latest, shell: bash }
+          - { os: ubuntu-22.04, shell: bash, python-version: 3.7 }
           - { os: macos-latest, shell: bash }
           - { os: macos-13, shell: bash }
           - { os: windows-latest, shell: pwsh }
@@ -106,6 +107,7 @@ jobs:
           - { os: macos-latest, python-version: 3.7 }
           - { os: macos-latest, python-version: 3.8 }
           - { os: macos-latest, python-version: 3.9 }
+          - { os: ubuntu-latest, python-version: 3.7 }
 
     defaults:
       run:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,10 @@
 # required by RTD
 version: 2
 
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: docs/conf.py
+
 build:
   os: "ubuntu-20.04"
   tools:

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -63,7 +63,8 @@ class ClipTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
         self.assertMultiLineEqual(
             str(cl),
-            'Clip("test_clip", MissingReference(\'\', None, None, {}), None, {})'
+            'Clip("test_clip", '
+            'MissingReference(\'\', None, None, {}), None, {}, [], [])'
         )
         self.assertMultiLineEqual(
             repr(cl),
@@ -71,7 +72,9 @@ class ClipTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             "name='test_clip', "
             'media_reference={}, '
             'source_range=None, '
-            'metadata={{}}'
+            'metadata={{}}, '
+            'effects=[], '
+            'markers=[]'
             ')'.format(
                 repr(cl.media_reference)
             )
@@ -87,7 +90,8 @@ class ClipTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertMultiLineEqual(
             str(cl),
             'Clip('
-            '"test_clip", ExternalReference("/var/tmp/foo.mov"), None, {}'
+            '"test_clip", '
+            'ExternalReference("/var/tmp/foo.mov"), None, {}, [], []'
             ')'
         )
         self.assertMultiLineEqual(
@@ -98,7 +102,9 @@ class ClipTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             "target_url='/var/tmp/foo.mov'"
             "), "
             'source_range=None, '
-            'metadata={}'
+            'metadata={}, '
+            'effects=[], '
+            'markers=[]'
             ')'
         )
 


### PR DESCRIPTION
**Summarize your change.**

A grab-bag of fixes for issues causing failing CI, including:

1. Updated the CI to run linux python 3.7 checks on ubuntu 22.04 - the last version that includes python 3.7 in github runners- (see [this version manifest](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json) for reference.
1. Added an explicit path for the sphinx configuration in accordance with [this blog post](https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/).
1. Updated some clip unittests to account to effects and markers being included in the `__str__` and `__repr__` methods as of #1808
