### PR TITLE
Fix CI issue with gcov

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -98,6 +98,7 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         include:
           - { os: ubuntu-latest, shell: bash }
+          - { os: ubuntu-22.04, shell: bash, python-version: 3.7 }
           - { os: macos-latest, shell: bash }
           - { os: macos-13, shell: bash }
           - { os: windows-latest, shell: pwsh }
@@ -106,6 +107,7 @@ jobs:
           - { os: macos-latest, python-version: 3.7 }
           - { os: macos-latest, python-version: 3.8 }
           - { os: macos-latest, python-version: 3.9 }
+          - { os: ubuntu-latest, python-version: 3.7 }
 
     defaults:
       run:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -65,7 +65,7 @@ jobs:
       if: matrix.os == env.GH_COV_OS && github.actor != env.GH_DEPENDABOT
       run: |
         cd ${{ env.OTIO_BUILD_DIR }}
-        lcov --capture -b . --directory . --output-file=coverage.info -q
+        lcov --capture -b . --directory . --output-file=coverage.info -q --ignore-errors mismatch
         cat coverage.info | sed "s/SF:.*src/SF:src/g" > coverage.filtered.info
         lcov --remove coverage.filtered.info '*/usr/*' --output-file=coverage.filtered.info -q
         lcov --remove coverage.filtered.info '*/deps/*' --output-file=coverage.filtered.info -q

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -65,7 +65,7 @@ jobs:
       if: matrix.os == env.GH_COV_OS && github.actor != env.GH_DEPENDABOT
       run: |
         cd ${{ env.OTIO_BUILD_DIR }}
-        lcov --capture -b . --directory . --output-file=coverage.info -q --ignore-errors mismatch
+        lcov --capture -b . --directory . --output-file=coverage.info -q --ignore-errors gcov
         cat coverage.info | sed "s/SF:.*src/SF:src/g" > coverage.filtered.info
         lcov --remove coverage.filtered.info '*/usr/*' --output-file=coverage.filtered.info -q
         lcov --remove coverage.filtered.info '*/deps/*' --output-file=coverage.filtered.info -q

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -65,7 +65,7 @@ jobs:
       if: matrix.os == env.GH_COV_OS && github.actor != env.GH_DEPENDABOT
       run: |
         cd ${{ env.OTIO_BUILD_DIR }}
-        lcov --capture -b . --directory . --output-file=coverage.info -q
+        lcov --rc lcov_branch_coverage=1 --rc no_exception_branch=1 --capture -b . --directory . --output-file=coverage.info -q
         cat coverage.info | sed "s/SF:.*src/SF:src/g" > coverage.filtered.info
         lcov --remove coverage.filtered.info '*/tests/*' --output-file=coverage.filtered.info -q
         lcov --list coverage.filtered.info

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -148,7 +148,6 @@ jobs:
       run: make ci-prebuild
     - name: Build and Install
       run: |
-        # compile and install into virtualenv/virtual machine (verbosely)
         pip install .[dev] -v --break-system-packages
     - name: Run tests w/ python coverage
       run: make ci-postbuild

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -149,7 +149,7 @@ jobs:
     - name: Build and Install
       run: |
         # compile and install into virtualenv/virtual machine (verbosely)
-        pip install .[dev] -v
+        pip install .[dev] -v --break-system-packages
     - name: Run tests w/ python coverage
       run: make ci-postbuild
     # (only on ubuntu/pyhton3.7)

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -65,7 +65,7 @@ jobs:
       if: matrix.os == env.GH_COV_OS && github.actor != env.GH_DEPENDABOT
       run: |
         cd ${{ env.OTIO_BUILD_DIR }}
-        lcov --rc lcov_branch_coverage=1 --rc no_exception_branch=1 --capture -b . --directory . --output-file=coverage.info -q
+        lcov --rc lcov_branch_coverage=1 --rc no_exception_branch=1 --ignore-errors mismatch --capture -b . --directory . --output-file=coverage.info -q
         cat coverage.info | sed "s/SF:.*src/SF:src/g" > coverage.filtered.info
         lcov --remove coverage.filtered.info '*/tests/*' --output-file=coverage.filtered.info -q
         lcov --list coverage.filtered.info

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -67,8 +67,6 @@ jobs:
         cd ${{ env.OTIO_BUILD_DIR }}
         lcov --capture -b . --directory . --output-file=coverage.info -q
         cat coverage.info | sed "s/SF:.*src/SF:src/g" > coverage.filtered.info
-        lcov --remove coverage.filtered.info '*/usr/*' --output-file=coverage.filtered.info -q
-        lcov --remove coverage.filtered.info '*/deps/*' --output-file=coverage.filtered.info -q
         lcov --remove coverage.filtered.info '*/tests/*' --output-file=coverage.filtered.info -q
         lcov --list coverage.filtered.info
 # \todo Should the Codecov web pages show the results of the C++ or Python tests?

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -65,7 +65,7 @@ jobs:
       if: matrix.os == env.GH_COV_OS && github.actor != env.GH_DEPENDABOT
       run: |
         cd ${{ env.OTIO_BUILD_DIR }}
-        lcov --capture -b . --directory . --output-file=coverage.info -q --ignore-errors gcov
+        lcov --capture -b . --directory . --output-file=coverage.info -q
         cat coverage.info | sed "s/SF:.*src/SF:src/g" > coverage.filtered.info
         lcov --remove coverage.filtered.info '*/usr/*' --output-file=coverage.filtered.info -q
         lcov --remove coverage.filtered.info '*/deps/*' --output-file=coverage.filtered.info -q

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -131,9 +131,6 @@ jobs:
           mingw-w64-x86_64-cmake
           make
           git
-    - name: Ensure MSYS2 pip is updated
-      if: matrix.python-version == 'mingw64'
-      run: curl -sS https://bootstrap.pypa.io/get-pip.py | python
     - name: Set up Python ${{ matrix.python-version }}
       if: matrix.python-version != 'mingw64'
       uses: actions/setup-python@v4.3.0

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,10 @@
 # required by RTD
 version: 2
 
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: docs/conf.py
+
 build:
   os: "ubuntu-20.04"
   tools:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(OTIO_CXX_COVERAGE AND NOT MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files='/usr/*;src/deps/*;src/opentimelineio/typeRegistry.h;src/opentimelineio/serialization.cpp;src/py-opentimelineio/opentime-bindings/opentime_bindings.cpp;src/py-opentimelineio/opentimelineio-bindings/otio_tests.cpp;src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp'")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-update=atomic -fprofile-exclude-files='/usr/*;src/deps/*;src/opentimelineio/typeRegistry.h;src/opentimelineio/serialization.cpp;src/py-opentimelineio/opentime-bindings/opentime_bindings.cpp;src/py-opentimelineio/opentimelineio-bindings/otio_tests.cpp;src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp'")
     # this causes cmake to produce file.gcno instead of file.cpp.gcno
     set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
     message(STATUS "Building C++ with Coverage: ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ if(OTIO_CXX_COVERAGE AND NOT MSVC)
     # Note that we exclude some OTIO files from code coverage since they are
     # causing errors like this:
     # geninfo: ERROR: "typeRegistry.h":63: mismatched exception tag for id 3, 3: '0' -> '1'
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-update=atomic -fprofile-exclude-files='/usr/*;src/deps/*;src/opentimelineio/typeRegistry.h;src/opentimelineio/serialization.cpp;src/py-opentimelineio/opentime-bindings/opentime_bindings.cpp;src/py-opentimelineio/opentimelineio-bindings/otio_tests.cpp;src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp'")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-update=atomic -fprofile-exclude-files='/usr/*;src/deps/*'")
     # this causes cmake to produce file.gcno instead of file.cpp.gcno
     set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
     message(STATUS "Building C++ with Coverage: ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(OTIO_CXX_COVERAGE AND NOT MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files='/usr/*;src/deps/*;src/opentimelineio/typeRegistry.h;src/opentimelineio/serialization.cpp;src/py-opentimelineio/opentime-bindings/opentime_bindings.cpp'")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files='/usr/*;src/deps/*;src/opentimelineio/typeRegistry.h;src/opentimelineio/serialization.cpp;src/py-opentimelineio/opentime-bindings/opentime_bindings.cpp;src/py-opentimelineio/opentimelineio-bindings/otio_tests.cpp'")
     # this causes cmake to produce file.gcno instead of file.cpp.gcno
     set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
     message(STATUS "Building C++ with Coverage: ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(OTIO_CXX_COVERAGE AND NOT MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files='*/rapidjson/*'")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files='rapidjson/*'")
     # this causes cmake to produce file.gcno instead of file.cpp.gcno
     set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
     message(STATUS "Building C++ with Coverage: ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(OTIO_CXX_COVERAGE AND NOT MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files='rapidjson/*'")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files='rapidjson/*' -fprofile-exclude-files=src/opentimelineio/typeRegistry.h")
     # this causes cmake to produce file.gcno instead of file.cpp.gcno
     set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
     message(STATUS "Building C++ with Coverage: ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(OTIO_CXX_COVERAGE AND NOT MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files='src/deps/rapidjson/*' -fprofile-exclude-files=src/opentimelineio/typeRegistry.h")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files='${PROJECT_SOURCE_DIR}/src/deps/rapidjson/*' -fprofile-exclude-files=${PROJECT_SOURCE_DIR}/src/opentimelineio/typeRegistry.h")
     # this causes cmake to produce file.gcno instead of file.cpp.gcno
     set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
     message(STATUS "Building C++ with Coverage: ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ if(OTIO_CXX_COVERAGE AND NOT MSVC)
     # Note that we exclude some OTIO files from code coverage since they are
     # causing errors like this:
     # geninfo: ERROR: mismatched end line for PyInit__opentime at opentime_bindings.cpp:
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-update=atomic -fprofile-exclude-files='/usr/*;src/deps/*;src/py-opentimelineio/opentime-bindings/opentime_bindings.cpp'")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-update=atomic -fprofile-exclude-files='/usr/*;src/deps/*;src/py-opentimelineio/opentime-bindings/opentime_bindings.cpp;src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp'")
     # this causes cmake to produce file.gcno instead of file.cpp.gcno
     set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
     message(STATUS "Building C++ with Coverage: ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ if(OTIO_CXX_COVERAGE AND NOT MSVC)
     # Note that we exclude some OTIO files from code coverage since they are
     # causing errors like this:
     # geninfo: ERROR: mismatched end line for PyInit__opentime at opentime_bindings.cpp:
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-update=atomic -fprofile-exclude-files='/usr/*;src/deps/*;src/py-opentimelineio/opentime-bindings/opentime_bindings.cpp;src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp'")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-update=atomic -fprofile-exclude-files='/usr/*;src/deps/*'")
     # this causes cmake to produce file.gcno instead of file.cpp.gcno
     set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
     message(STATUS "Building C++ with Coverage: ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(OTIO_CXX_COVERAGE AND NOT MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files='${PROJECT_SOURCE_DIR}/src/deps/rapidjson/*' -fprofile-exclude-files=${PROJECT_SOURCE_DIR}/src/opentimelineio/typeRegistry.h")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files=${PROJECT_SOURCE_DIR}/src/deps/rapidjson/* -fprofile-exclude-files=${PROJECT_SOURCE_DIR}/src/opentimelineio/typeRegistry.h")
     # this causes cmake to produce file.gcno instead of file.cpp.gcno
     set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
     message(STATUS "Building C++ with Coverage: ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(OTIO_CXX_COVERAGE AND NOT MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files='src/deps/rapidjson/*;src/opentimelineio/typeRegistry.h'")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files='src/deps/rapidjson/*;src/opentimelineio/typeRegistry.h;src/opentimelineio/serialization.cpp'")
     # this causes cmake to produce file.gcno instead of file.cpp.gcno
     set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
     message(STATUS "Building C++ with Coverage: ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(OTIO_CXX_COVERAGE AND NOT MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files='*/rapidjson/*'")
     # this causes cmake to produce file.gcno instead of file.cpp.gcno
     set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
     message(STATUS "Building C++ with Coverage: ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(OTIO_CXX_COVERAGE AND NOT MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files='/usr/*;src/deps/rapidjson/*;src/opentimelineio/typeRegistry.h;src/opentimelineio/serialization.cpp;src/py-opentimelineio/opentime-bindings/opentime_bindings.cpp'")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files='/usr/*;src/deps/*;src/opentimelineio/typeRegistry.h;src/opentimelineio/serialization.cpp;src/py-opentimelineio/opentime-bindings/opentime_bindings.cpp'")
     # this causes cmake to produce file.gcno instead of file.cpp.gcno
     set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
     message(STATUS "Building C++ with Coverage: ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(OTIO_CXX_COVERAGE AND NOT MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files='src/deps/rapidjson/*;src/opentimelineio/typeRegistry.h;src/opentimelineio/serialization.cpp'")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files='/usr/*;src/deps/rapidjson/*;src/opentimelineio/typeRegistry.h;src/opentimelineio/serialization.cpp'")
     # this causes cmake to produce file.gcno instead of file.cpp.gcno
     set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
     message(STATUS "Building C++ with Coverage: ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(OTIO_CXX_COVERAGE AND NOT MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-update=atomic -fprofile-exclude-files='/usr/*;src/deps/*'")
+    # Note that we exclude some OTIO files from code coverage since they are
+    # causing errors like this:
+    # geninfo: ERROR: "typeRegistry.h":63: mismatched exception tag for id 3, 3: '0' -> '1'
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-update=atomic -fprofile-exclude-files='/usr/*;src/deps/*;src/opentimelineio/typeRegistry.h;src/opentimelineio/serialization.cpp;src/py-opentimelineio/opentime-bindings/opentime_bindings.cpp;src/py-opentimelineio/opentimelineio-bindings/otio_tests.cpp;src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp'")
     # this causes cmake to produce file.gcno instead of file.cpp.gcno
     set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
     message(STATUS "Building C++ with Coverage: ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,9 +150,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(OTIO_CXX_COVERAGE AND NOT MSVC)
-    # Note that we exclude some OTIO files from code coverage since they are
-    # causing errors like this:
-    # geninfo: ERROR: mismatched end line for PyInit__opentime at opentime_bindings.cpp:
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-update=atomic -fprofile-exclude-files='/usr/*;src/deps/*'")
     # this causes cmake to produce file.gcno instead of file.cpp.gcno
     set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(OTIO_CXX_COVERAGE AND NOT MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files=${PROJECT_SOURCE_DIR}/src/deps/rapidjson/* -fprofile-exclude-files=${PROJECT_SOURCE_DIR}/src/opentimelineio/typeRegistry.h")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files='src/deps/rapidjson/*;src/opentimelineio/typeRegistry.h'")
     # this causes cmake to produce file.gcno instead of file.cpp.gcno
     set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
     message(STATUS "Building C++ with Coverage: ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(OTIO_CXX_COVERAGE AND NOT MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files='/usr/*;src/deps/rapidjson/*;src/opentimelineio/typeRegistry.h;src/opentimelineio/serialization.cpp'")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files='/usr/*;src/deps/rapidjson/*;src/opentimelineio/typeRegistry.h;src/opentimelineio/serialization.cpp;src/py-opentimelineio/opentime-bindings/opentime_bindings.cpp'")
     # this causes cmake to produce file.gcno instead of file.cpp.gcno
     set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
     message(STATUS "Building C++ with Coverage: ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,8 +152,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 if(OTIO_CXX_COVERAGE AND NOT MSVC)
     # Note that we exclude some OTIO files from code coverage since they are
     # causing errors like this:
-    # geninfo: ERROR: "typeRegistry.h":63: mismatched exception tag for id 3, 3: '0' -> '1'
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-update=atomic -fprofile-exclude-files='/usr/*;src/deps/*'")
+    # geninfo: ERROR: mismatched end line for PyInit__opentime at opentime_bindings.cpp:
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-update=atomic -fprofile-exclude-files='/usr/*;src/deps/*;src/py-opentimelineio/opentime-bindings/opentime_bindings.cpp'")
     # this causes cmake to produce file.gcno instead of file.cpp.gcno
     set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
     message(STATUS "Building C++ with Coverage: ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(OTIO_CXX_COVERAGE AND NOT MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files='rapidjson/*' -fprofile-exclude-files=src/opentimelineio/typeRegistry.h")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files='src/deps/rapidjson/*' -fprofile-exclude-files=src/opentimelineio/typeRegistry.h")
     # this causes cmake to produce file.gcno instead of file.cpp.gcno
     set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
     message(STATUS "Building C++ with Coverage: ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(OTIO_CXX_COVERAGE AND NOT MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files='/usr/*;src/deps/*;src/opentimelineio/typeRegistry.h;src/opentimelineio/serialization.cpp;src/py-opentimelineio/opentime-bindings/opentime_bindings.cpp;src/py-opentimelineio/opentimelineio-bindings/otio_tests.cpp'")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-exclude-files='/usr/*;src/deps/*;src/opentimelineio/typeRegistry.h;src/opentimelineio/serialization.cpp;src/py-opentimelineio/opentime-bindings/opentime_bindings.cpp;src/py-opentimelineio/opentimelineio-bindings/otio_tests.cpp;src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp'")
     # this causes cmake to produce file.gcno instead of file.cpp.gcno
     set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
     message(STATUS "Building C++ with Coverage: ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(OTIO_CXX_COVERAGE AND NOT MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-update=atomic -fprofile-exclude-files='/usr/*;src/deps/*;src/opentimelineio/typeRegistry.h;src/opentimelineio/serialization.cpp;src/py-opentimelineio/opentime-bindings/opentime_bindings.cpp;src/py-opentimelineio/opentimelineio-bindings/otio_tests.cpp;src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp'")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-update=atomic -fprofile-exclude-files='/usr/*;src/deps/*'")
     # this causes cmake to produce file.gcno instead of file.cpp.gcno
     set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
     message(STATUS "Building C++ with Coverage: ON")

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ ifndef OTIO_CXX_BUILD_TMP_DIR
 		C++ coverage will not work, because intermediate build products will \
 		not be found.)
 endif
-	lcov --rc lcov_branch_coverage=1 --rc no_exception_branch=1 --capture -b . --directory ${OTIO_CXX_BUILD_TMP_DIR} \
+	lcov --rc lcov_branch_coverage=1 --rc no_exception_branch=1 --ignore-errors mismatch --capture -b . --directory ${OTIO_CXX_BUILD_TMP_DIR} \
 		--output-file=${OTIO_CXX_BUILD_TMP_DIR}/coverage.info -q
 	cat ${OTIO_CXX_BUILD_TMP_DIR}/coverage.info | sed "s/SF:.*src/SF:src/g" \
 		> ${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info

--- a/Makefile
+++ b/Makefile
@@ -93,8 +93,7 @@ ifndef OTIO_CXX_BUILD_TMP_DIR
 		not be found.)
 endif
 	lcov --rc lcov_branch_coverage=1 --capture -b . --directory ${OTIO_CXX_BUILD_TMP_DIR} \
-		--output-file=${OTIO_CXX_BUILD_TMP_DIR}/coverage.info -q \
-		--ignore-errors gcov
+		--output-file=${OTIO_CXX_BUILD_TMP_DIR}/coverage.info -q
 	cat ${OTIO_CXX_BUILD_TMP_DIR}/coverage.info | sed "s/SF:.*src/SF:src/g"\
 		> ${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info
 	lcov --rc lcov_branch_coverage=1 --remove ${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info '/usr/*' \

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,8 @@ ifndef OTIO_CXX_BUILD_TMP_DIR
 		not be found.)
 endif
 	lcov --rc lcov_branch_coverage=1 --capture -b . --directory ${OTIO_CXX_BUILD_TMP_DIR} \
-		--output-file=${OTIO_CXX_BUILD_TMP_DIR}/coverage.info -q
+		--output-file=${OTIO_CXX_BUILD_TMP_DIR}/coverage.info -q \
+		--ignore-errors mismatch
 	cat ${OTIO_CXX_BUILD_TMP_DIR}/coverage.info | sed "s/SF:.*src/SF:src/g"\
 		> ${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info
 	lcov --rc lcov_branch_coverage=1 --remove ${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info '/usr/*' \

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ ifndef OTIO_CXX_BUILD_TMP_DIR
 		C++ coverage will not work, because intermediate build products will \
 		not be found.)
 endif
-	lcov --rc lcov_branch_coverage=1 --capture -b . --directory ${OTIO_CXX_BUILD_TMP_DIR} \
+	lcov --rc lcov_branch_coverage=1 --rc no_exception_branch=1 --capture -b . --directory ${OTIO_CXX_BUILD_TMP_DIR} \
 		--output-file=${OTIO_CXX_BUILD_TMP_DIR}/coverage.info -q
 	cat ${OTIO_CXX_BUILD_TMP_DIR}/coverage.info | sed "s/SF:.*src/SF:src/g" \
 		> ${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ ifndef OTIO_CXX_BUILD_TMP_DIR
 endif
 	lcov --rc lcov_branch_coverage=1 --capture -b . --directory ${OTIO_CXX_BUILD_TMP_DIR} \
 		--output-file=${OTIO_CXX_BUILD_TMP_DIR}/coverage.info -q \
-		--ignore-errors mismatch
+		--ignore-errors gcov
 	cat ${OTIO_CXX_BUILD_TMP_DIR}/coverage.info | sed "s/SF:.*src/SF:src/g"\
 		> ${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info
 	lcov --rc lcov_branch_coverage=1 --remove ${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info '/usr/*' \

--- a/Makefile
+++ b/Makefile
@@ -94,12 +94,8 @@ ifndef OTIO_CXX_BUILD_TMP_DIR
 endif
 	lcov --rc lcov_branch_coverage=1 --capture -b . --directory ${OTIO_CXX_BUILD_TMP_DIR} \
 		--output-file=${OTIO_CXX_BUILD_TMP_DIR}/coverage.info -q
-	cat ${OTIO_CXX_BUILD_TMP_DIR}/coverage.info | sed "s/SF:.*src/SF:src/g"\
+	cat ${OTIO_CXX_BUILD_TMP_DIR}/coverage.info | sed "s/SF:.*src/SF:src/g" \
 		> ${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info
-	lcov --rc lcov_branch_coverage=1 --remove ${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info '/usr/*' \
-		--output-file=${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info -q
-	lcov --rc lcov_branch_coverage=1 --remove ${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info '*/deps/*' \
-		--output-file=${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info -q
 	rm ${OTIO_CXX_BUILD_TMP_DIR}/coverage.info
 	lcov --list ${OTIO_CXX_BUILD_TMP_DIR}/coverage.filtered.info
 

--- a/src/opentimelineio/typeRegistry.h
+++ b/src/opentimelineio/typeRegistry.h
@@ -60,8 +60,8 @@ public:
             CLASS::Schema::name,
             CLASS::Schema::version,
             &typeid(CLASS),
-            []() -> SerializableObject* { return new CLASS; },
-            CLASS::Schema::name); // LCOV_EXCL_EXCEPTION_BR_LINE
+            []() -> SerializableObject* { return new CLASS; }, // LCOV_EXCL_EXCEPTION_BR_LINE
+            CLASS::Schema::name);
     }
 
     /// Register a new schema.

--- a/src/opentimelineio/typeRegistry.h
+++ b/src/opentimelineio/typeRegistry.h
@@ -60,7 +60,7 @@ public:
             CLASS::Schema::name,
             CLASS::Schema::version,
             &typeid(CLASS),
-            []() -> SerializableObject* { return new CLASS; }, // LCOV_EXCL_EXCEPTION_BR_LINE
+            []() -> SerializableObject* { return new CLASS; },
             CLASS::Schema::name);
     }
 

--- a/src/opentimelineio/typeRegistry.h
+++ b/src/opentimelineio/typeRegistry.h
@@ -61,7 +61,7 @@ public:
             CLASS::Schema::version,
             &typeid(CLASS),
             []() -> SerializableObject* { return new CLASS; },
-            CLASS::Schema::name);
+            CLASS::Schema::name); // LCOV_EXCL_EXCEPTION_BR_LINE
     }
 
     /// Register a new schema.

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -63,7 +63,8 @@ class ClipTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
         self.assertMultiLineEqual(
             str(cl),
-            'Clip("test_clip", MissingReference(\'\', None, None, {}), None, {})'
+            'Clip("test_clip", '
+            'MissingReference(\'\', None, None, {}), None, {}, [], [])'
         )
         self.assertMultiLineEqual(
             repr(cl),
@@ -71,7 +72,9 @@ class ClipTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             "name='test_clip', "
             'media_reference={}, '
             'source_range=None, '
-            'metadata={{}}'
+            'metadata={{}}, '
+            'effects=[], '
+            'markers=[]'
             ')'.format(
                 repr(cl.media_reference)
             )
@@ -87,7 +90,8 @@ class ClipTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertMultiLineEqual(
             str(cl),
             'Clip('
-            '"test_clip", ExternalReference("/var/tmp/foo.mov"), None, {}'
+            '"test_clip", '
+            'ExternalReference("/var/tmp/foo.mov"), None, {}, [], []'
             ')'
         )
         self.assertMultiLineEqual(
@@ -98,7 +102,9 @@ class ClipTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             "target_url='/var/tmp/foo.mov'"
             "), "
             'source_range=None, '
-            'metadata={}'
+            'metadata={}, '
+            'effects=[], '
+            'markers=[]'
             ')'
         )
 


### PR DESCRIPTION
**Summarize your change.**

It looks like the gcc version in the CI may have changed which is causing issues with gcov/geninfo:
```
geninfo: ERROR: "/home/runner/work/OpenTimelineIO/OpenTimelineIO/src/deps/rapidjson/include/rapidjson/reader.h":271: mismatched exception tag for id 1, 1: '0' -> '1'
```

This PR fixes the issue by removing rapidjson from the coverage. It also includes other build fixes from this PR:
https://github.com/AcademySoftwareFoundation/OpenTimelineIO/pull/1820