### PR TITLE
Bumped upload-artifact action from v3 to v4

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -22,7 +22,8 @@ jobs:
         workflow: python-package.yml
         workflow_conclusion: success
         commit: ${{ github.sha }}
-        name: wheels
+        name_is_regexp: true
+        name: wheel-.*
         path: dist
 
     - name: Download sdist from commit ${{ github.sha }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -195,7 +195,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheel-{{ matrix.os }}-${{ matrix.python-build }}
+          name: wheel-${{ matrix.os }}-${{ matrix.python-build }}
           path: ./wheelhouse/*.whl
 
   package_sdist:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -195,8 +195,8 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels
-          path: ./wheelhouse/*-${{ matrix.python-build }}.whl
+          name: wheel-{{ matrix.os }}-${{ matrix.python-build }}
+          path: ./wheelhouse/*.whl
 
   package_sdist:
     needs: py_build_test

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -196,7 +196,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: wheels
-          path: ./wheelhouse/*.whl
+          path: ./wheelhouse/*-${{ matrix.python-build }}.whl
 
   package_sdist:
     needs: py_build_test

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -172,9 +172,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
-        python-build: ['cp37*', 'cp38*', 'cp39*', 'cp310*', 'cp311*', 'cp312*']
+        python-build: ['cp37', 'cp38', 'cp39', 'cp310', 'cp311', 'cp312']
         exclude:
-          - { os: macos-latest, python-build: 'cp37*' }
+          - { os: macos-latest, python-build: 'cp37' }
     steps:
       - uses: actions/checkout@v4
 
@@ -187,7 +187,7 @@ jobs:
         with:
           output-dir: wheelhouse
         env:
-          CIBW_BUILD: ${{ matrix.python-build }}
+          CIBW_BUILD: ${{ matrix.python-build }}*
           CIBW_SKIP: '*musllinux*'
           CIBW_ARCHS_LINUX: x86_64 aarch64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -193,7 +193,7 @@ jobs:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: ./wheelhouse/*.whl
@@ -214,7 +214,7 @@ jobs:
     - name: Generate sdist
       run: python -m build -s .
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: sdist
         path: dist


### PR DESCRIPTION
Supersedes #1740 

Bump upload-artifact github action to v4 in line with [deprecation](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).

The V4 update no longer supports implicit merge of matrixed build products into a single uploaded artifact (in v3 all wheel platform/python version variants were implicitly merged into a `wheels` artifact). This update makes a separate artifact for each matrix variant ant then merges them on download when creating a release to push to pypi.