### PR TITLE
Update GH actions to fix CI builds

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -22,7 +22,8 @@ jobs:
         workflow: python-package.yml
         workflow_conclusion: success
         commit: ${{ github.sha }}
-        name: wheels
+        name_is_regexp: true
+        name: wheel-.*
         path: dist
 
     - name: Download sdist from commit ${{ github.sha }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -23,7 +23,7 @@ jobs:
         workflow_conclusion: success
         commit: ${{ github.sha }}
         name_is_regexp: true
-        name: wheel-.*
+        name: `wheel-.*`
         path: dist
 
     - name: Download sdist from commit ${{ github.sha }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -17,7 +17,7 @@ jobs:
     # happen for this actual commit (the commit that the tag points to).
     # It also restores the files timestamps.
     - name: Download wheels from commit ${{ github.sha }}
-      uses: dawidd6/action-download-artifact@v2
+      uses: dawidd6/action-download-artifact@v8
       with:
         workflow: python-package.yml
         workflow_conclusion: success
@@ -27,7 +27,7 @@ jobs:
         path: dist
 
     - name: Download sdist from commit ${{ github.sha }}
-      uses: dawidd6/action-download-artifact@v2
+      uses: dawidd6/action-download-artifact@v8
       with:
         workflow: python-package.yml
         workflow_conclusion: success

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -133,7 +133,7 @@ jobs:
           git
     - name: Set up Python ${{ matrix.python-version }}
       if: matrix.python-version != 'mingw64'
-      uses: actions/setup-python@v4.3.0
+      uses: actions/setup-python@v5.4.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install coverage dependency
@@ -206,7 +206,7 @@ jobs:
       with:
         submodules: 'recursive'
 
-    - uses: actions/setup-python@v4.3.0
+    - uses: actions/setup-python@v5.4.0
 
     - name: Install pypa/build
       run: python -m pip install build --user

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -171,16 +171,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
+        os: [ubuntu-24.04-arm, windows-latest, macos-13, macos-latest]
         python-build: ['cp37', 'cp38', 'cp39', 'cp310', 'cp311', 'cp312']
         exclude:
           - { os: macos-latest, python-build: 'cp37' }
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
 
       - name: Build wheels (Python 3)
         uses: pypa/cibuildwheel@v2.22.0

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -185,8 +185,6 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.python-build }}*
           CIBW_SKIP: '*musllinux*'
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
           MACOSX_DEPLOYMENT_TARGET: 10.14
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -171,7 +171,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04-arm, windows-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-latest]
         python-build: ['cp37', 'cp38', 'cp39', 'cp310', 'cp311', 'cp312']
         exclude:
           - { os: macos-latest, python-build: 'cp37' }
@@ -185,7 +185,6 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.python-build }}*
           CIBW_SKIP: '*musllinux*'
-          CIBW_ARCHS_LINUX: x86_64 aarch64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -191,6 +191,8 @@ jobs:
           CIBW_BUILD: ${{ matrix.python-build }}*
           CIBW_SKIP: '*musllinux*'
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
           MACOSX_DEPLOYMENT_TARGET: 10.14
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -187,6 +187,7 @@ jobs:
           CIBW_SKIP: '*musllinux*'
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
+          MACOSX_DEPLOYMENT_TARGET: 10.14
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -173,6 +173,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-latest]
         python-build: ['cp37', 'cp38', 'cp39', 'cp310', 'cp311', 'cp312']
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: ubuntu-24.04-arm
+            arch: aarch64
         exclude:
           - { os: macos-latest, python-build: 'cp37' }
     steps:
@@ -185,7 +190,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.python-build }}*
           CIBW_SKIP: '*musllinux*'
-          CIBW_ARCHS_LINUX: auto
+          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           MACOSX_DEPLOYMENT_TARGET: 10.14
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -172,9 +172,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
-        python-build: ['cp37*', 'cp38*', 'cp39*', 'cp310*', 'cp311*', 'cp312*']
+        python-build: ['cp37', 'cp38', 'cp39', 'cp310', 'cp311', 'cp312']
         exclude:
-          - { os: macos-latest, python-build: 'cp37*' }
+          - { os: macos-latest, python-build: 'cp37' }
     steps:
       - uses: actions/checkout@v4
 
@@ -187,15 +187,15 @@ jobs:
         with:
           output-dir: wheelhouse
         env:
-          CIBW_BUILD: ${{ matrix.python-build }}
+          CIBW_BUILD: ${{ matrix.python-build }}*
           CIBW_SKIP: '*musllinux*'
           CIBW_ARCHS_LINUX: x86_64 aarch64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheel-${{ matrix.os }}-${{ matrix.python-build }}
           path: ./wheelhouse/*.whl
 
   package_sdist:
@@ -214,7 +214,7 @@ jobs:
     - name: Generate sdist
       run: python -m build -s .
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: sdist
         path: dist

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -185,6 +185,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.python-build }}*
           CIBW_SKIP: '*musllinux*'
+          CIBW_ARCHS_LINUX: auto
           MACOSX_DEPLOYMENT_TARGET: 10.14
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -183,7 +183,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Build wheels (Python 3)
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.22.0
         with:
           output-dir: wheelhouse
         env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -190,7 +190,6 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.python-build }}*
           CIBW_SKIP: '*musllinux*'
-          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
           MACOSX_DEPLOYMENT_TARGET: 10.14

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -173,11 +173,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-latest]
         python-build: ['cp37', 'cp38', 'cp39', 'cp310', 'cp311', 'cp312']
-        include:
-          - os: ubuntu-latest
-            arch: x86_64
-          - os: ubuntu-24.04-arm
-            arch: aarch64
         exclude:
           - { os: macos-latest, python-build: 'cp37' }
     steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -190,6 +190,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.python-build }}*
           CIBW_SKIP: '*musllinux*'
+          CIBW_ARCHS_LINUX: native
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
           MACOSX_DEPLOYMENT_TARGET: 10.14


### PR DESCRIPTION
**Summarize your change.**

This PR includes the changes from #1827 plus some additional changes to fix the CI:
* Update dawidd6/action-download-artifact to v8
* Update actions/setup-python to v5.4.0
* Use `ubuntu-24.04-arm` for native Linux ARM builds (replacing the QEMU emulator builds)
* Update pypa/cibuildwheel to v2.22.0