### PR TITLE
Replace backticks with quotes in pypi-publish GHA workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -23,7 +23,7 @@ jobs:
         workflow_conclusion: success
         commit: ${{ github.sha }}
         name_is_regexp: true
-        name: `wheel-.*`
+        name: 'wheel-.*'
         path: dist
 
     - name: Download sdist from commit ${{ github.sha }}


### PR DESCRIPTION
As the title says. Backticks are not valid in YAML.