### PR TITLE
Drop Imath2 support and modernize Imath includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,10 @@ else()
     set(USE_DEPS_IMATH ON)
 endif()
 
+if(USE_DEPS_IMATH)
+    include_directories("${PROJECT_SOURCE_DIR}/src/deps/Imath/src")
+endif()
+
 # set up the internally hosted dependencies
 add_subdirectory(src/deps)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,16 +228,8 @@ elseif(OTIO_FIND_IMATH)
         message(STATUS "Found Imath 3 at ${Imath_CONFIG}")
         set(USE_DEPS_IMATH OFF)
     else()
-        find_package(IlmBase QUIET)
-        if (IlmBase_FOUND)
-            message(STATUS "Imath 3 not found, found Imath 2 at ${IlmBase_CONFIG}")
-            message(STATUS "You may need to point to the Imath headers by setting IMATH_INCLUDES")
-            set(USE_DEPS_IMATH_OFF)
-            set(OTIO_RESOLVED_IMATH_LIBRARIES "${IlmBase_LIBRARIES")
-        else()
-            message(STATUS "Imath 3 and 2 were not found, using src/deps/Imath")
-            set(USE_DEPS_IMATH ON)
-        endif()
+        message(STATUS "Imath 3 was not found, using src/deps/Imath")
+        set(USE_DEPS_IMATH ON)
     endif()
 else()
     message(STATUS "Using src/deps/Imath by default")
@@ -246,17 +238,6 @@ endif()
 
 # set up the internally hosted dependencies
 add_subdirectory(src/deps)
-
-set (OTIO_IMATH_TARGETS
-    # For OpenEXR/Imath 3.x:
-    $<TARGET_NAME_IF_EXISTS:Imath::Imath>
-    $<TARGET_NAME_IF_EXISTS:Imath::Half>
-    # For OpenEXR >= 2.4/2.5 with reliable exported targets
-    $<TARGET_NAME_IF_EXISTS:IlmBase::Imath>
-    $<TARGET_NAME_IF_EXISTS:IlmBase::Half>
-    $<TARGET_NAME_IF_EXISTS:IlmBase::Iex>
-    # For OpenEXR <= 2.3:
-    ${ILMBASE_LIBRARIES})
 
 add_subdirectory(src/opentime)
 add_subdirectory(src/opentimelineio)
@@ -272,4 +253,3 @@ endif()
 if(OTIO_CXX_EXAMPLES)
     add_subdirectory(examples)
 endif()
-

--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -78,14 +78,12 @@ add_library(opentimelineio ${OTIO_SHARED_OR_STATIC_LIB}
 add_library(OTIO::opentimelineio ALIAS opentimelineio)
 
 target_include_directories(opentimelineio
-    PRIVATE       "${IMATH_INCLUDES}"
-                  "${PROJECT_SOURCE_DIR}/src"
+    PRIVATE       "${PROJECT_SOURCE_DIR}/src"
                   "${PROJECT_SOURCE_DIR}/src/deps"
-                  "${PROJECT_SOURCE_DIR}/src/deps/rapidjson/include"
-                  "${IMATH_INCLUDES}")
+                  "${PROJECT_SOURCE_DIR}/src/deps/rapidjson/include")
 
 target_link_libraries(opentimelineio 
-    PUBLIC opentime ${OTIO_IMATH_TARGETS})
+    PUBLIC opentime Imath::Imath)
 
 set_target_properties(opentimelineio PROPERTIES
     DEBUG_POSTFIX "${OTIO_DEBUG_POSTFIX}"

--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -82,9 +82,6 @@ target_include_directories(opentimelineio
                   "${PROJECT_SOURCE_DIR}/src/deps"
                   "${PROJECT_SOURCE_DIR}/src/deps/rapidjson/include")
 
-if(USE_DEPS_IMATH)
-    target_include_directories(opentimelineio PRIVATE "${PROJECT_SOURCE_DIR}/src/deps/Imath/src")
-endif()
 
 target_link_libraries(opentimelineio 
     PUBLIC opentime Imath::Imath)

--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -82,6 +82,10 @@ target_include_directories(opentimelineio
                   "${PROJECT_SOURCE_DIR}/src/deps"
                   "${PROJECT_SOURCE_DIR}/src/deps/rapidjson/include")
 
+if(USE_DEPS_IMATH)
+    target_include_directories(opentimelineio PRIVATE "${PROJECT_SOURCE_DIR}/src/deps/Imath/src")
+endif()
+
 target_link_libraries(opentimelineio 
     PUBLIC opentime Imath::Imath)
 

--- a/src/opentimelineio/OpenTimelineIOConfig.cmake.in
+++ b/src/opentimelineio/OpenTimelineIOConfig.cmake.in
@@ -2,5 +2,6 @@
 
 include(CMakeFindDependencyMacro)
 find_dependency(OpenTime)
+find_dependency(Imath)
 
 include("${CMAKE_CURRENT_LIST_DIR}/OpenTimelineIOTargets.cmake")

--- a/src/opentimelineio/composable.h
+++ b/src/opentimelineio/composable.h
@@ -6,7 +6,7 @@
 #include "opentimelineio/serializableObjectWithMetadata.h"
 #include "opentimelineio/version.h"
 
-#include <ImathBox.h>
+#include <Imath/ImathBox.h>
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 

--- a/src/opentimelineio/mediaReference.h
+++ b/src/opentimelineio/mediaReference.h
@@ -6,7 +6,7 @@
 #include "opentimelineio/serializableObjectWithMetadata.h"
 #include "opentimelineio/version.h"
 
-#include <ImathBox.h>
+#include <Imath/ImathBox.h>
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 

--- a/src/opentimelineio/serializableObject.h
+++ b/src/opentimelineio/serializableObject.h
@@ -12,7 +12,7 @@
 #include "opentimelineio/typeRegistry.h"
 #include "opentimelineio/version.h"
 
-#include "ImathBox.h"
+#include "Imath/ImathBox.h"
 #include "serialization.h"
 
 #include <list>

--- a/src/py-opentimelineio/opentimelineio-bindings/CMakeLists.txt
+++ b/src/py-opentimelineio/opentimelineio-bindings/CMakeLists.txt
@@ -25,6 +25,10 @@ target_include_directories(_otio
     PRIVATE "${PROJECT_SOURCE_DIR}/src/deps/optional-lite/include"
 )
 
+if(USE_DEPS_IMATH)
+    target_include_directories(_otio PRIVATE "${PROJECT_SOURCE_DIR}/src/deps/Imath/src")
+endif()
+
 target_link_libraries(_otio PUBLIC opentimelineio opentime)
 
 # The version of pybind11 we are currently using generates an overwhelming number of

--- a/src/py-opentimelineio/opentimelineio-bindings/CMakeLists.txt
+++ b/src/py-opentimelineio/opentimelineio-bindings/CMakeLists.txt
@@ -25,10 +25,6 @@ target_include_directories(_otio
     PRIVATE "${PROJECT_SOURCE_DIR}/src/deps/optional-lite/include"
 )
 
-if(USE_DEPS_IMATH)
-    target_include_directories(_otio PRIVATE "${PROJECT_SOURCE_DIR}/src/deps/Imath/src")
-endif()
-
 target_link_libraries(_otio PUBLIC opentimelineio opentime)
 
 # The version of pybind11 we are currently using generates an overwhelming number of

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp
@@ -14,7 +14,7 @@
 #include "opentimelineio/typeRegistry.h"
 #include "opentimelineio/stackAlgorithm.h"
 
-#include <ImathBox.h>
+#include <Imath/ImathBox.h>
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_imath.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_imath.cpp
@@ -6,8 +6,8 @@
 
 #include "otio_utils.h"
 
-#include "ImathBox.h"
-#include "ImathVec.h"
+#include "Imath/ImathBox.h"
+#include "Imath/ImathVec.h"
 
 namespace py = pybind11;
 

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -32,7 +32,7 @@
 #include "otio_utils.h"
 #include "otio_anyDictionary.h"
 
-#include "ImathBox.h"
+#include "Imath/ImathBox.h"
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_utils.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_utils.cpp
@@ -11,7 +11,7 @@
 #include "opentimelineio/safely_typed_any.h"
 #include "opentimelineio/stringUtils.h"
 
-#include <ImathBox.h>
+#include <Imath/ImathBox.h>
 
 #include <map>
 #include <cstring>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,10 @@ include_directories(${PROJECT_SOURCE_DIR}/src
     ${PROJECT_SOURCE_DIR}/src/deps/optional-lite/include
 	${PROJECT_SOURCE_DIR}/src/tests)
 
+if(USE_DEPS_IMATH)
+    include_directories(${PROJECT_SOURCE_DIR}/src/deps/Imath/src)
+endif()
+
 list(APPEND tests_opentime test_opentime)
 foreach(test ${tests_opentime})
 	add_executable(${test} utils.h utils.cpp ${test}.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,10 +3,6 @@ include_directories(${PROJECT_SOURCE_DIR}/src
     ${PROJECT_SOURCE_DIR}/src/deps/optional-lite/include
 	${PROJECT_SOURCE_DIR}/src/tests)
 
-if(USE_DEPS_IMATH)
-    include_directories(${PROJECT_SOURCE_DIR}/src/deps/Imath/src)
-endif()
-
 list(APPEND tests_opentime test_opentime)
 foreach(test ${tests_opentime})
 	add_executable(${test} utils.h utils.cpp ${test}.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,9 +20,6 @@ foreach(test ${tests_opentimelineio})
     add_executable(${test} utils.h utils.cpp ${test}.cpp)
 
     target_link_libraries(${test} opentimelineio)
-    if (NOT "${IMATH_INCLUDES}" STREQUAL "")
-        target_include_directories(${test} "${IMATH_INCLUDES}")
-    endif()
     set_target_properties(${test} PROPERTIES FOLDER tests)
     add_test(NAME ${test} 
            COMMAND ${test}


### PR DESCRIPTION
**Summarize your change.**

As quickly discussed in the Slack channel...

OpenEXR developers [recommend to use full namespace includes](https://github.com/AcademySoftwareFoundation/Imath/issues/136#issuecomment-812671628) like `#include <Imath/ImathBox.h>`, but we still use `#include <ImathBox.h>`.

The support of OpenEXR/Imath 2 blocks changing the includes to full namespace. However Imath 3 has be released 4 years ago and OpenEXR/Imath 2 is no longer on the vfxplatform horizon so it seems appropriated to just remove support for it.
