### PR TITLE
Allow to use rapidjson from the system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ option(OTIO_INSTALL_COMMANDLINE_TOOLS "Install the OTIO command line tools" ON)
 option(OTIO_INSTALL_CONTRIB           "Install the opentimelineio_contrib Python package" ON)
 set(OTIO_IMATH_LIBS "" CACHE STRING   "Imath library overrides to use instead of src/deps or find_package")
 option(OTIO_FIND_IMATH                "Find Imath using find_package, ignored if OTIO_IMATH_LIBS is set" OFF)
+option(OTIO_FIND_RAPIDJSON            "Find RapidJSON using find_package" OFF)
 set(OTIO_PYTHON_INSTALL_DIR "" CACHE STRING "Python installation dir (such as the site-packages dir)")
 
 # Build options
@@ -238,6 +239,17 @@ endif()
 
 if(USE_DEPS_IMATH)
     include_directories("${PROJECT_SOURCE_DIR}/src/deps/Imath/src")
+endif()
+
+#----- RapidJSON
+
+if(OTIO_FIND_RAPIDJSON)
+    find_package(RapidJSON CONFIG REQUIRED)
+    if (RapidJSON_FOUND)
+        message(STATUS "Found RapidJSON at ${RapidJSON_CONFIG}")
+    endif()
+else()
+    message(STATUS "Using src/deps/rapidjson by default")
 endif()
 
 # set up the internally hosted dependencies

--- a/src/deps/CMakeLists.txt
+++ b/src/deps/CMakeLists.txt
@@ -4,7 +4,12 @@
 #----- Other dependencies
 
 # detect if the submodules haven't been updated
-set(DEPS_SUBMODULES pybind11 rapidjson)
+set(DEPS_SUBMODULES pybind11)
+
+if(NOT OTIO_FIND_RAPIDJSON)
+    set(DEPS_SUBMODULES ${DEPS_SUBMODULES} rapidjson)
+endif()
+
 foreach(submodule IN LISTS DEPS_SUBMODULES)
     file(GLOB SUBMOD_CONTENTS ${submodule})
     list(LENGTH SUBMOD_CONTENTS SUBMOD_CONTENT_LEN)

--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -78,9 +78,15 @@ add_library(opentimelineio ${OTIO_SHARED_OR_STATIC_LIB}
 add_library(OTIO::opentimelineio ALIAS opentimelineio)
 
 target_include_directories(opentimelineio
-    PRIVATE       "${PROJECT_SOURCE_DIR}/src"
-                  "${PROJECT_SOURCE_DIR}/src/deps"
-                  "${PROJECT_SOURCE_DIR}/src/deps/rapidjson/include")
+    PRIVATE "${PROJECT_SOURCE_DIR}/src")
+
+if(OTIO_FIND_RAPIDJSON)
+    target_include_directories(opentimelineio
+        PRIVATE "${RapidJSON_INCLUDE_DIRS}")
+else()
+    target_include_directories(opentimelineio
+        PRIVATE "${PROJECT_SOURCE_DIR}/src/deps/rapidjson/include")
+endif()
 
 
 target_link_libraries(opentimelineio 


### PR DESCRIPTION
**Summarize your change.**

For (Linux) distro packaging it is common to use system packages instead of submodules and co.

With this option one can ask to use the system rapidjson with CMake flag instead of maintaining custom patches such as https://build.opensuse.org/projects/KDE:Applications/packages/opentimelineio/files/0001-Use-system-rapidjson.patch?expand=1

Note: if `OTIO_FIND_RAPIDJSON` is `ON` but rapidjson is not found cmake fails. This behavior is different to `OTIO_FIND_IMATH` where it will just continue with `src/deps` as a fallback. However I think if the user explicitly request the system package it makes more sense to fail if not found. In my opinion this should be changed for Imath as well, but that is offtopic for this PR