### PR TITLE
V2d serialization fix

### DIFF
--- a/src/opentimelineio/serialization.cpp
+++ b/src/opentimelineio/serialization.cpp
@@ -77,6 +77,7 @@ public:
     virtual void write_value(class TimeTransform const& value)       = 0;
     virtual void write_value(struct SerializableObject::ReferenceId) = 0;
     virtual void write_value(IMATH_NAMESPACE::Box2d const&)          = 0;
+    virtual void write_value(IMATH_NAMESPACE::V2d const&)            = 0;
 
 protected:
     void _error(ErrorStatus const& error_status)
@@ -269,7 +270,7 @@ public:
         _store(std::any(value));
     }
 
-    void write_value(IMATH_NAMESPACE::V2d const& value)
+    void write_value(IMATH_NAMESPACE::V2d const& value) override
     {
 
         if (_result_object_policy == ResultObjectPolicy::OnlyAnyDictionary)

--- a/tests/test_v2d.py
+++ b/tests/test_v2d.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Contributors to the OpenTimelineIO project
 
-import unittest
+import json
 import sys
+import unittest
+
+import opentimelineio.test_utils as otio_test_utils
 
 import opentimelineio as otio
-import opentimelineio.test_utils as otio_test_utils
 
 
 class V2dTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
@@ -21,15 +23,9 @@ class V2dTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
     def test_str(self):
         v = otio.schema.V2d(1.0, 2.0)
 
-        self.assertMultiLineEqual(
-            str(v),
-            'V2d(1.0, 2.0)'
-        )
+        self.assertMultiLineEqual(str(v), "V2d(1.0, 2.0)")
 
-        self.assertMultiLineEqual(
-            repr(v),
-            'otio.schema.V2d(x=1.0, y=2.0)'
-        )
+        self.assertMultiLineEqual(repr(v), "otio.schema.V2d(x=1.0, y=2.0)")
 
     def test_equality(self):
         v1 = otio.schema.V2d(1.0, 2.0)
@@ -104,6 +100,17 @@ class V2dTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertEqual(otio.schema.V2d.baseTypeSmallest(), sys.float_info.min)
         self.assertEqual(otio.schema.V2d.baseTypeEpsilon(), sys.float_info.epsilon)
 
+    def test_json_serialization(self):
+        serialized = otio.adapters.otio_json.write_to_string(otio.schema.V2d())
+        json_v2d = json.loads(serialized)
+        self.assertEqual(json_v2d["OTIO_SCHEMA"], "V2d.1")
 
-if __name__ == '__main__':
+    def test_serialization_round_trip(self):
+        v2d = otio.schema.V2d()
+        serialized = otio.adapters.otio_json.write_to_string(v2d)
+        deserialized = otio.adapters.otio_json.read_from_string(serialized)
+        self.assertEqual(v2d, deserialized)
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
```Fixes #1855```

**Summarize your change.**

This is a bug fix where V2d was getting serialized into two V2ds inside a Box2d.  The problem was that there was no `write_value` function in the serialization for V2d (I guess it was assumed a V2d would always be inside a Box2d).  Box2d has an implicit ctor taking a V2d, which implicitly converted the V2d to a Box2d to match on the Box2d `write_value` method. 

Notes:
`make test` required me to run `make doc-model-update` which added some whitespace changes to otio-serialized-schema.md
`make lint` changed some whitespacing in the v2d test

**Reference associated tests.**

Two new tests added to `test_v2d.py`
- Check the schema is correct when serializing to json
- Round trip serialization/deserialization ensures we get the original value back
