### PR TITLE
Fix bug w/ url_utils.filepath_from_url + rel paths with a single "/"

### DIFF
--- a/src/py-opentimelineio/opentimelineio/url_utils.py
+++ b/src/py-opentimelineio/opentimelineio/url_utils.py
@@ -76,7 +76,6 @@ def filepath_from_url(urlstr):
     elif pathlib.PureWindowsPath(filepath.parts[0]).drive:
         filepath = pathlib.PurePosixPath(filepath.drive, *filepath.parts[1:])
 
-
     # If the specified index is a windows drive, then offset the path
     elif (
         # relative paths may not have a parts[1]

--- a/src/py-opentimelineio/opentimelineio/url_utils.py
+++ b/src/py-opentimelineio/opentimelineio/url_utils.py
@@ -76,8 +76,13 @@ def filepath_from_url(urlstr):
     elif pathlib.PureWindowsPath(filepath.parts[0]).drive:
         filepath = pathlib.PurePosixPath(filepath.drive, *filepath.parts[1:])
 
+
     # If the specified index is a windows drive, then offset the path
-    elif pathlib.PureWindowsPath(filepath.parts[1]).drive:
+    elif (
+        # relative paths may not have a parts[1]
+        len(filepath.parts) > 1
+        and pathlib.PureWindowsPath(filepath.parts[1]).drive
+    ):
         # Remove leading "/" if/when `request.url2pathname` yields
         # "/S:/path/file.ext"
         filepath = pathlib.PurePosixPath(*filepath.parts[1:])

--- a/tests/test_url_conversions.py
+++ b/tests/test_url_conversions.py
@@ -79,6 +79,14 @@ class TestConversions(unittest.TestCase):
             processed_url = otio.url_utils.filepath_from_url(url)
             self.assertEqual(processed_url, POSIX_PATH)
 
+    def test_relative_url(self):
+        # see github issue #1817 - when a relative URL has only one name after
+        # the "." (ie ./blah but not ./blah/blah)
+        self.assertEqual(
+            otio.url_utils.filepath_from_url(os.path.join(".", "docs")),
+            "docs",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
* Fix traceback when using relative paths with one "/" and not two "/" were triggering a traceback - ie "./blah" but not "./blah/blah" in url_utils. 
* url_utils is used by the otioz adapter (Which is where this was originally reported)

Fixes #1817 
