### PR TITLE
Add Doxygen comments to opentime

### DIFF
--- a/doxygen/config/dox_config
+++ b/doxygen/config/dox_config
@@ -494,7 +494,7 @@ EXTRACT_ALL            = NO
 # be included in the documentation.
 # The default value is: NO.
 
-EXTRACT_PRIVATE        = YES
+EXTRACT_PRIVATE        = NO
 
 # If the EXTRACT_PRIV_VIRTUAL tag is set to YES, documented private virtual
 # methods of a class will be included in the documentation.
@@ -520,7 +520,7 @@ EXTRACT_STATIC         = NO
 # for Java sources.
 # The default value is: YES.
 
-EXTRACT_LOCAL_CLASSES  = YES
+EXTRACT_LOCAL_CLASSES  = NO
 
 # This flag is only useful for Objective-C code. If set to YES, local methods,
 # which are defined in the implementation section but not in the interface are
@@ -643,7 +643,7 @@ INLINE_INFO            = YES
 # name. If set to NO, the members will appear in declaration order.
 # The default value is: YES.
 
-SORT_MEMBER_DOCS       = YES
+SORT_MEMBER_DOCS       = NO
 
 # If the SORT_BRIEF_DOCS tag is set to YES then doxygen will sort the brief
 # descriptions of file, namespace and class members alphabetically by member
@@ -867,7 +867,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../src/opentimelineio/ ../README.md 
+INPUT                  = ../src/opentime ../src/opentimelineio/ ../README.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/doxygen/config/dox_config
+++ b/doxygen/config/dox_config
@@ -643,7 +643,7 @@ INLINE_INFO            = YES
 # name. If set to NO, the members will appear in declaration order.
 # The default value is: YES.
 
-SORT_MEMBER_DOCS       = NO
+SORT_MEMBER_DOCS       = NO # Keep the same order as the header files
 
 # If the SORT_BRIEF_DOCS tag is set to YES then doxygen will sort the brief
 # descriptions of file, namespace and class members alphabetically by member

--- a/src/opentime/errorStatus.h
+++ b/src/opentime/errorStatus.h
@@ -8,8 +8,10 @@
 
 namespace opentime { namespace OPENTIME_VERSION {
 
+/// @brief This struct represents the return status of a function.
 struct ErrorStatus
 {
+    /// @brief This enumeration represents the possible outcomes.
     enum Outcome
     {
         OK = 0,
@@ -21,34 +23,41 @@ struct ErrorStatus
         INVALID_RATE_FOR_DROP_FRAME_TIMECODE,
     };
 
+    /// @brief Construct a new status with no error.
     ErrorStatus()
         : outcome{ OK }
     {}
 
+    /// @brief Construct a new status with the given outcome.
     ErrorStatus(Outcome in_outcome)
         : outcome{ in_outcome }
         , details{ outcome_to_string(in_outcome) }
     {}
 
+    /// @brief Construct a new status with the given outcome and details.
     ErrorStatus(Outcome in_outcome, std::string const& in_details)
         : outcome{ in_outcome }
         , details{ in_details }
     {}
 
-    Outcome     outcome;
+    /// @brief The outcome of the function.
+    Outcome outcome;
+
+    /// @brief A human readable string that provides details about the outcome.
     std::string details;
 
+    ///! @brief Return a human readable string for the given outcome.
     static std::string outcome_to_string(Outcome);
 };
 
-// Check whether the given ErrorStatus is an error.
+///! @brief Check whether the given ErrorStatus is an error.
 constexpr bool
 is_error(const ErrorStatus& es) noexcept
 {
     return ErrorStatus::Outcome::OK != es.outcome;
 }
 
-// Check whether the given ErrorStatus is non-null and an error.
+///! @brief Check whether the given ErrorStatus is non-null and an error.
 constexpr bool
 is_error(const ErrorStatus* es) noexcept
 {

--- a/src/opentime/rationalTime.h
+++ b/src/opentime/rationalTime.h
@@ -93,7 +93,7 @@ public:
         return value_rescaled_to(rt._rate);
     }
 
-    /// @brief Returns whether time is almost equal to another time.
+    /// @brief Returns whether this time is almost equal to another time.
     ///
     /// @param other The other time for comparison.
     /// @param delta The tolerance used for the comparison.
@@ -103,10 +103,10 @@ public:
         return fabs(value_rescaled_to(other._rate) - other._value) <= delta;
     }
 
-    /// @brief Returns whether the value and rate are equal to another time.
+    /// @brief Returns whether this value and rate are exactly equal to another time.
     ///
-    /// This is different from the operator "==" that rescales the time before
-    /// comparison.
+    /// Note that this is different from the equality operator that rescales the time
+    /// before comparison.
     constexpr bool strictly_equal(RationalTime other) const noexcept
     {
         return _value == other._value && _rate == other._rate;

--- a/src/opentime/stringPrintf.h
+++ b/src/opentime/stringPrintf.h
@@ -10,6 +10,7 @@
 
 namespace opentime { namespace OPENTIME_VERSION {
 
+/// @brief This provides printf style functionality for std::string.
 template <typename... Args>
 std::string
 string_printf(char const* format, Args... args)

--- a/src/opentime/timeRange.h
+++ b/src/opentime/timeRange.h
@@ -10,36 +10,38 @@
 
 namespace opentime { namespace OPENTIME_VERSION {
 
-/**
- * It is possible to construct TimeRange object with a negative duration.
- * However, the logical predicates are written as if duration is positive,
- * and have undefined behavior for negative durations.
- *
- * The duration on a TimeRange indicates a time range that is inclusive of the start time,
- * and exclusive of the end time. All of the predicates are computed accordingly.
- */
-
-/**
- * This default epsilon_s value is used in comparison between floating numbers.
- * It is computed to be twice 192khz, the fastest commonly used audio rate.
- * It can be changed in the future if necessary due to higher sampling rates
- * or some other kind of numeric tolerance detected in the library.
- */
+/// @brief This default epsilon_s value is used in comparison between floating numbers.
+///
+/// It is computed to be twice 192khz, the fastest commonly used audio rate. It
+/// can be changed in the future if necessary due to higher sampling rates or
+/// some other kind of numeric tolerance detected in the library.
 constexpr double DEFAULT_EPSILON_s = 1.0 / (2 * 192000.0);
 
+/// @brief This class represents a time range defined by a start time and duration.
+///
+/// It is possible to construct a TimeRange object with a negative duration.
+/// However, the logical predicates are written as if duration is positive,
+/// and have undefined behavior for negative durations.
+///
+/// The duration on a TimeRange indicates a time range that is inclusive of the
+/// start time, and exclusive of the end time. All of the predicates are
+/// computed accordingly.
 class TimeRange
 {
 public:
+    /// @brief Construct a new time range with a zero start time and duration.
     constexpr TimeRange() noexcept
         : _start_time{}
         , _duration{}
     {}
 
+    /// @brief Construct a new time range with the given start time and duration of zero.
     explicit constexpr TimeRange(RationalTime start_time) noexcept
         : _start_time{ start_time }
         , _duration{ RationalTime{ 0, start_time.rate() } }
     {}
 
+    /// @brief Construct a new time range with the given start time and duration.
     constexpr TimeRange(
         RationalTime start_time,
         RationalTime duration) noexcept
@@ -47,6 +49,7 @@ public:
         , _duration{ duration }
     {}
 
+    /// @brief Construct a new time range with the given start time, duration, and rate.
     constexpr TimeRange(
         double start_time,
         double duration,
@@ -74,10 +77,13 @@ public:
         return _start_time.is_valid_time() && _duration.is_valid_time() && _duration.value() >= 0.0;
     }
 
+    /// @brief Returns the start time.
     constexpr RationalTime start_time() const noexcept { return _start_time; }
 
+    /// @brief Returns the duration.
     constexpr RationalTime duration() const noexcept { return _duration; }
 
+    /// @brief Returns the inclusive end time.
     RationalTime end_time_inclusive() const noexcept
     {
         const RationalTime et = end_time_exclusive();
@@ -94,16 +100,21 @@ public:
         }
     }
 
+    /// @brief Returns the exclusive end time.
     constexpr RationalTime end_time_exclusive() const noexcept
     {
         return _duration + _start_time.rescaled_to(_duration);
     }
 
+    /// @brief Extend a time range's duration by the given time. The extended
+    /// time range is returned.
     constexpr TimeRange duration_extended_by(RationalTime other) const noexcept
     {
         return TimeRange{ _start_time, _duration + other };
     }
 
+    /// @brief Extend a time range by the given time. The extended time range
+    /// is returned.
     constexpr TimeRange extended_by(TimeRange other) const noexcept
     {
         const RationalTime new_start_time{
@@ -119,11 +130,14 @@ public:
                               new_end_time) };
     }
 
+    /// @brief Clamp a time to this time range. The clamped time is returned.
     RationalTime clamped(RationalTime other) const noexcept
     {
         return std::min(std::max(other, _start_time), end_time_inclusive());
     }
 
+    /// @brief Clamp a time range to this time range. The clamped time range
+    /// is returned.
     constexpr TimeRange clamped(TimeRange other) const noexcept
     {
         const TimeRange    r{ std::max(other._start_time, _start_time),
@@ -134,41 +148,43 @@ public:
         return TimeRange{ r._start_time, end - r._start_time };
     }
 
-    /**
-     * These relations implement James F. Allen's thirteen basic time interval relations.
-     * Detailed background can be found here: https://dl.acm.org/doi/10.1145/182.358434
-     * Allen, James F. "Maintaining knowledge about temporal intervals".
-     * Communications of the ACM 26(11) pp.832-843, Nov. 1983.
-     */
+    /// @name Time Range Relations
+    ///
+    /// These relations implement James F. Allen's thirteen basic time interval relations.
+    /// Detailed background can be found here: https://dl.acm.org/doi/10.1145/182.358434
+    /// Allen, James F. "Maintaining knowledge about temporal intervals".
+    /// Communications of the ACM 26(11) pp.832-843, Nov. 1983.
+    ///
+    /// In the relations that follow, epsilon_s indicates the tolerance, in the sense
+    /// that if abs(a-b) < epsilon_s, we consider a and b to be equal. The time
+    /// comparison is done in double seconds.
+    ///
+    ///@{
 
-    /**
-     * In the relations that follow, epsilon_s indicates the tolerance,in the sense that if abs(a-b) < epsilon_s,
-     * we consider a and b to be equal.
-     * The time comparison is done in double seconds.
-     */
-
-    /**
-     * The start of <b>this</b> precedes <b>other</b>.
-     * <b>other</b> precedes the end of this.
-     *                    other
-     *                      ↓
-     *                      *
-     *              [      this      ]
-     * @param other
-     */
+    /// @brief Returns whether this time range contains the given time.
+    ///
+    /// The start of <b>this</b> precedes <b>other</b>.
+    /// <b>other</b> precedes the end of this.
+    /// <pre>
+    ///                    other
+    ///                      ↓
+    ///                      *
+    ///              [      this      ]
+    /// </pre>
     constexpr bool contains(RationalTime other) const noexcept
     {
         return _start_time <= other && other < end_time_exclusive();
     }
 
-    /**
-     * The start of <b>this</b> precedes start of <b>other</b>.
-     * The end of <b>this</b> antecedes end of <b>other</b>.
-     *                   [ other ]
-     *              [      this      ]
-     * The converse would be <em>other.contains(this)</em>
-     * @param other
-     */
+    /// @brief Returns whether this time range contains the given time range.
+    ///
+    /// The start of <b>this</b> precedes start of <b>other</b>.
+    /// The end of <b>this</b> antecedes end of <b>other</b>.
+    /// <pre>
+    ///                   [ other ]
+    ///              [      this      ]
+    /// </pre>
+    /// The converse would be <em>other.contains(this)</em>
     constexpr bool contains(
         TimeRange other,
         double    epsilon_s = DEFAULT_EPSILON_s) const noexcept
@@ -181,28 +197,29 @@ public:
                && lesser_than(otherEnd, thisEnd, epsilon_s);
     }
 
-    /**
-     * <b>this</b> contains <b>other</b>.
-     *                   other
-     *                    ↓
-     *                    *
-     *              [    this    ]
-     * @param other
-     */
+    /// @brief Returns whether this time range overlaps the given time.
+    ///
+    /// <b>this</b> contains <b>other</b>.
+    /// <pre>
+    ///                   other
+    ///                    ↓
+    ///                    *
+    ///              [    this    ]
+    /// </pre>
     constexpr bool overlaps(RationalTime other) const noexcept
     {
         return contains(other);
     }
 
-    /**
-     * The start of <b>this</b> strictly precedes end of <b>other</b> by a value >= <b>epsilon_s</b>.
-     * The end of <b>this</b> strictly antecedes start of <b>other</b> by a value >= <b>epsilon_s</b>.
-     *              [ this ]
-     *                  [ other ]
-     * The converse would be <em>other.overlaps(this)</em>
-     * @param other
-     * @param epsilon_s
-     */
+    /// @brief Returns whether this and the given time range overlap.
+    ///
+    /// The start of <b>this</b> strictly precedes end of <b>other</b> by a value >= <b>epsilon_s</b>.
+    /// The end of <b>this</b> strictly antecedes start of <b>other</b> by a value >= <b>epsilon_s</b>.
+    /// <pre>
+    ///              [ this ]
+    ///                  [ other ]
+    /// </pre>
+    /// The converse would be <em>other.overlaps(this)</em>
     constexpr bool overlaps(
         TimeRange other,
         double    epsilon_s = DEFAULT_EPSILON_s) const noexcept
@@ -216,13 +233,13 @@ public:
                && greater_than(otherEnd, thisEnd, epsilon_s);
     }
 
-    /**
-     * The end of <b>this</b> strictly precedes the start of <b>other</b> by a value >= <b>epsilon_s</b>.
-     *              [ this ]    [ other ]
-     * The converse would be <em>other.before(this)</em>
-     * @param other
-     * @param epsilon_s
-     */
+    /// @brief Returns whether this time range precedes the given time range.
+    ///
+    /// The end of <b>this</b> strictly precedes the start of <b>other</b> by a value >= <b>epsilon_s</b>.
+    /// <pre>
+    ///              [ this ]    [ other ]
+    /// </pre>
+    /// The converse would be <em>other.before(this)</em>
     constexpr bool
     before(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept
     {
@@ -231,14 +248,14 @@ public:
         return greater_than(otherStart, thisEnd, epsilon_s);
     }
 
-    /**
-     * The end of <b>this</b> strictly precedes <b>other</b> by a value >= <b>epsilon_s</b>.
-     *                        other
-     *                          ↓
-     *              [ this ]    *
-     * @param other
-     * @param epsilon_s
-     */
+    /// @brief Returns whether this time range precedes the given time.
+    ///
+    /// The end of <b>this</b> strictly precedes <b>other</b> by a value >= <b>epsilon_s</b>.
+    /// <pre>
+    ///                        other
+    ///                          ↓
+    ///              [ this ]    *
+    /// </pre>
     constexpr bool before(
         RationalTime other,
         double       epsilon_s = DEFAULT_EPSILON_s) const noexcept
@@ -248,14 +265,14 @@ public:
         return lesser_than(thisEnd, otherTime, epsilon_s);
     }
 
-    /**
-     * The end of <b>this</b> strictly equals the start of <b>other</b> and
-     * the start of <b>this</b> strictly equals the end of <b>other</b>.
-     *              [this][other]
-     * The converse would be <em>other.meets(this)</em>
-     * @param other
-     * @param epsilon_s
-     */
+    /// @brief Returns whether this time range meets the given time range.
+    ///
+    /// The end of <b>this</b> strictly equals the start of <b>other</b> and
+    /// the start of <b>this</b> strictly equals the end of <b>other</b>.
+    /// <pre>
+    ///              [this][other]
+    /// </pre>
+    /// The converse would be <em>other.meets(this)</em>
     constexpr bool
     meets(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept
     {
@@ -264,15 +281,15 @@ public:
         return otherStart - thisEnd <= epsilon_s && otherStart - thisEnd >= 0;
     }
 
-    /**
-     * The start of <b>this</b> strictly equals the start of <b>other</b>.
-     * The end of <b>this</b> strictly precedes the end of <b>other</b> by a value >= <b>epsilon_s</b>.
-     *              [ this ]
-     *              [    other    ]
-     * The converse would be <em>other.begins(this)</em>
-     * @param other
-     * @param epsilon_s
-     */
+    /// @brief Returns whether this time range begins in the given time range.
+    ///
+    /// The start of <b>this</b> strictly equals the start of <b>other</b>.
+    /// The end of <b>this</b> strictly precedes the end of <b>other</b> by a value >= <b>epsilon_s</b>.
+    /// <pre>
+    ///              [ this ]
+    ///              [    other    ]
+    /// </pre>
+    /// The converse would be <em>other.begins(this)</em>
     constexpr bool
     begins(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept
     {
@@ -284,14 +301,15 @@ public:
                && lesser_than(thisEnd, otherEnd, epsilon_s);
     }
 
-    /**
-     * The start of <b>this</b> strictly equals <b>other</b>.
-     *            other
-     *              ↓
-     *              *
-     *              [ this ]
-     * @param other
-     */
+    /// @brief Returns whether this range begins at the given time.
+    ///
+    /// The start of <b>this</b> strictly equals <b>other</b>.
+    /// <pre>
+    ///            other
+    ///              ↓
+    ///              *
+    ///              [ this ]
+    /// </pre>
     constexpr bool begins(
         RationalTime other,
         double       epsilon_s = DEFAULT_EPSILON_s) const noexcept
@@ -301,15 +319,15 @@ public:
         return fabs(otherStart - thisStart) <= epsilon_s;
     }
 
-    /**
-     * The start of <b>this</b> strictly antecedes the start of <b>other</b> by a value >= <b>epsilon_s</b>.
-     * The end of <b>this</b> strictly equals the end of <b>other</b>.
-     *                      [ this ]
-     *              [     other    ]
-     * The converse would be <em>other.finishes(this)</em>
-     * @param other
-     * @param epsilon_s
-     */
+    /// @brief Returns whether this time range finishes in the given time range.
+    ///
+    /// The start of <b>this</b> strictly antecedes the start of <b>other</b> by a value >= <b>epsilon_s</b>.
+    /// The end of <b>this</b> strictly equals the end of <b>other</b>.
+    /// <pre>
+    ///                      [ this ]
+    ///              [     other    ]
+    /// </pre>
+    /// The converse would be <em>other.finishes(this)</em>
     constexpr bool finishes(
         TimeRange other,
         double    epsilon_s = DEFAULT_EPSILON_s) const noexcept
@@ -322,15 +340,15 @@ public:
                && greater_than(thisStart, otherStart, epsilon_s);
     }
 
-    /**
-     * The end of <b>this</b> strictly equals <b>other</b>.
-     *                   other
-     *                     ↓
-     *                     *
-     *              [ this ]
-     * @param other
-     * @param epsilon_s
-     */
+    /// @brief Return whether this time range finishes at the given time.
+    ///
+    /// The end of <b>this</b> strictly equals <b>other</b>.
+    /// <pre>
+    ///                   other
+    ///                     ↓
+    ///                     *
+    ///              [ this ]
+    /// </pre>
     constexpr bool finishes(
         RationalTime other,
         double       epsilon_s = DEFAULT_EPSILON_s) const noexcept
@@ -340,15 +358,15 @@ public:
         return fabs(thisEnd - otherEnd) <= epsilon_s;
     }
 
-    /**
-     * The start of <b>this</b> precedes or equals the end of <b>other</b> by a value >= <b>epsilon_s</b>.
-     * The end of <b>this</b> antecedes or equals the start of <b>other</b> by a value >= <b>epsilon_s</b>.
-     *         [    this    ]           OR      [    other    ]
-     *              [     other    ]                    [     this    ]
-     * The converse would be <em>other.finishes(this)</em>
-     * @param other
-     * @param epsilon_s
-     */
+    /// Return whether this time range intersects the given time range.
+    ///
+    /// The start of <b>this</b> precedes or equals the end of <b>other</b> by a value >= <b>epsilon_s</b>.
+    /// The end of <b>this</b> antecedes or equals the start of <b>other</b> by a value >= <b>epsilon_s</b>.
+    /// <pre>
+    ///         [    this    ]           OR      [    other    ]
+    ///              [     other    ]                    [     this    ]
+    /// </pre>
+    /// The converse would be <em>other.finishes(this)</em>
     constexpr bool intersects(
         TimeRange other,
         double    epsilon_s = DEFAULT_EPSILON_s) const noexcept
@@ -361,14 +379,16 @@ public:
                && greater_than(thisEnd, otherStart, epsilon_s);
     }
 
-    /**
-     * The start of <b>lhs</b> strictly equals the start of <b>rhs</b>.
-     * The end of <b>lhs</b> strictly equals the end of <b>rhs</b>.
-     *              [ lhs ]
-     *              [ rhs ]
-     * @param lhs
-     * @param rhs
-     */
+    ///@}
+
+    /// @brief Returns whether two time ranges are strictly equal.
+    ///
+    /// The start of <b>lhs</b> strictly equals the start of <b>rhs</b>.
+    /// The end of <b>lhs</b> strictly equals the end of <b>rhs</b>.
+    /// <pre>
+    ///              [ lhs ]
+    ///              [ rhs ]
+    /// </pre>
     friend constexpr bool operator==(TimeRange lhs, TimeRange rhs) noexcept
     {
         const RationalTime start    = lhs._start_time - rhs._start_time;
@@ -377,16 +397,13 @@ public:
                && fabs(duration.to_seconds()) < DEFAULT_EPSILON_s;
     }
 
-    /**
-     * Converse of <em>equals()</em> operator
-     * @param lhs
-     * @param rhs
-     */
+    /// @brief Returns whether two time ranges are not equal.
     friend constexpr bool operator!=(TimeRange lhs, TimeRange rhs) noexcept
     {
         return !(lhs == rhs);
     }
 
+    /// @brief Create a time range from a start time and exclusive end time.
     static constexpr TimeRange range_from_start_end_time(
         RationalTime start_time,
         RationalTime end_time_exclusive) noexcept
@@ -397,6 +414,7 @@ public:
                               end_time_exclusive) };
     }
 
+    /// @brief Create a time range from a start time and inclusive end time.
     static constexpr TimeRange range_from_start_end_time_inclusive(
         RationalTime start_time,
         RationalTime end_time_inclusive) noexcept

--- a/src/opentime/timeRange.h
+++ b/src/opentime/timeRange.h
@@ -12,9 +12,10 @@ namespace opentime { namespace OPENTIME_VERSION {
 
 /// @brief This default epsilon_s value is used in comparison between floating numbers.
 ///
-/// It is computed to be twice 192khz, the fastest commonly used audio rate. It
-/// can be changed in the future if necessary due to higher sampling rates or
-/// some other kind of numeric tolerance detected in the library.
+/// It is computed to be twice 192kHz, the fastest commonly used audio rate. That gives
+/// a resolution of half a frame at 192kHz. The value can be changed in the future if
+/// necessary, due to higher sampling rates or some other kind of numeric tolerance
+/// detected in the library.
 constexpr double DEFAULT_EPSILON_s = 1.0 / (2 * 192000.0);
 
 /// @brief This class represents a time range defined by a start time and duration.

--- a/src/opentime/timeTransform.h
+++ b/src/opentime/timeTransform.h
@@ -10,9 +10,11 @@
 
 namespace opentime { namespace OPENTIME_VERSION {
 
+/// @brief One-dimensional time transform.
 class TimeTransform
 {
 public:
+    /// @brief Construct a new transform with an optional offset, scale, and rate.
     explicit constexpr TimeTransform(
         RationalTime offset = RationalTime{},
         double       scale  = 1,
@@ -22,12 +24,17 @@ public:
         , _rate{ rate }
     {}
 
+    /// @brief Return the offset.
     constexpr RationalTime offset() const noexcept { return _offset; }
 
+    /// @brief Return the scale.
     constexpr double scale() const noexcept { return _scale; }
 
+    /// @brief Return the rate.
     constexpr double rate() const noexcept { return _rate; }
 
+    /// @brief Apply the transform to a TimeRange. The transformed TimeRange is
+    /// returned.
     constexpr TimeRange applied_to(TimeRange other) const noexcept
     {
         return TimeRange::range_from_start_end_time(
@@ -35,6 +42,8 @@ public:
             applied_to(other.end_time_exclusive()));
     }
 
+    /// @brief Apply the transform to another TimeTransform. The transformed
+    /// TimeTransform is returned.
     constexpr TimeTransform applied_to(TimeTransform other) const noexcept
     {
         return TimeTransform{ _offset + other._offset,
@@ -42,6 +51,8 @@ public:
                               _rate > 0 ? _rate : other._rate };
     }
 
+    /// @brief Apply the transform to a RationalTime. The transformed
+    /// RationalTime is returned.
     constexpr RationalTime applied_to(RationalTime other) const noexcept
     {
         RationalTime result{ RationalTime{ other._value * _scale, other._rate }
@@ -50,6 +61,7 @@ public:
         return target_rate > 0 ? result.rescaled_to(target_rate) : result;
     }
 
+    /// @brief Return whether two transforms are equal.
     friend constexpr bool
     operator==(TimeTransform lhs, TimeTransform rhs) noexcept
     {
@@ -57,6 +69,7 @@ public:
                && lhs._rate == rhs._rate;
     }
 
+    /// @brief Return whether two transforms are not equal.
     friend constexpr bool
     operator!=(TimeTransform lhs, TimeTransform rhs) noexcept
     {


### PR DESCRIPTION
This change completes adding Doxygen style comments to the opentime API. The changes are just comments, there are no functional changes to the API.

Most of the comments were straightforward, but any feedback to help improve them is welcome.

I added a Doxygen group for the TimeRange "relations" and `<pre>` tags to keep the ASCII diagrams intact in the Doxygen HTML.

I also made a couple of tweaks to the Doxygen configuration to remove non-public info and keep the sorting order the same as the header files.