### PR TITLE
Remove unused path from the C++ install

### DIFF
--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -123,9 +123,6 @@ if(OTIO_CXX_INSTALL)
             DESTINATION "${OTIO_RESOLVED_CXX_INSTALL_DIR}/include/opentimelineio")
 
     set(OPENTIMELINEIO_INCLUDES ${OTIO_RESOLVED_CXX_INSTALL_DIR}/include)
-    if(OTIO_DEPENDENCIES_INSTALL)
-        list(APPEND OPENTIMELINEIO_INCLUDES ${OTIO_RESOLVED_CXX_INSTALL_DIR}/include/opentimelineio/deps)
-    endif()
 
     install(TARGETS opentimelineio
            EXPORT OpenTimelineIOTargets


### PR DESCRIPTION
This change removes an unused path from the C++ installation. Previously the "any" and "optional" headers were installed into `${OTIO_RESOLVED_CXX_INSTALL_DIR}/include/opentimelineio/deps)`, but they were removed with the transition to C++17.

Currently trying to use the OTIO CMake config gives this error:
```
CMake Error in CMakeLists.txt:
  Imported target "OTIO::opentimelineio" includes non-existent path

    "install/include/opentimelineio/deps"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.
```

It looks like the Imath dependency is not installed to `deps`, but alongside OTIO:
```
$ ls install/include/
Imath  opentime  opentimelineio
```
An alternative fix would be to install Imath into `deps`, but I'm not sure which is more appropriate.