### PR TITLE
Remove vfx platform 2020 support from README.md, add 2024 and 2025, note that 3.12 is also supported

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -93,19 +93,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         include:
           - { os: ubuntu-latest, shell: bash }
-          - { os: ubuntu-22.04, shell: bash, python-version: 3.7 }
           - { os: macos-latest, shell: bash }
           - { os: macos-13, shell: bash }
           - { os: windows-latest, shell: pwsh }
           - { os: windows-latest, shell: msys2, python-version: 'mingw64' }
         exclude:
-          - { os: macos-latest, python-version: 3.7 }
-          - { os: macos-latest, python-version: 3.8 }
           - { os: macos-latest, python-version: 3.9 }
-          - { os: ubuntu-latest, python-version: 3.7 }
 
     defaults:
       run:
@@ -151,7 +147,7 @@ jobs:
         pip install .[dev] -v --break-system-packages
     - name: Run tests w/ python coverage
       run: make ci-postbuild
-    # (only on ubuntu/pyhton3.7)
+    # (only on GH_COV_OS and GH_COV_PY)
     - name: Generate C++ coverage report
       if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != env.GH_DEPENDABOT
       run: make lcov
@@ -172,9 +168,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-latest]
-        python-build: ['cp37', 'cp38', 'cp39', 'cp310', 'cp311', 'cp312']
+        python-build: ['cp39', 'cp310', 'cp311', 'cp312']
         exclude:
-          - { os: macos-latest, python-build: 'cp37' }
+          # none currently
+          # - { os: macos-latest, python-build: 'cp37' }
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ OpenTimelineIO
 ==============
 
 [![Supported VFX Platform Versions](https://img.shields.io/badge/vfx%20platform-2022--2025-lightgrey.svg)](http://www.vfxplatform.com/)
-![Supported Versions](https://img.shields.io/badge/python-3.9%2C%203.10%2C%203.11-blue)
+![Supported Versions](https://img.shields.io/badge/python-3.9%2C%203.10%2C%203.11-%2C%203.12-blue)
 [![Build Status](https://github.com/AcademySoftwareFoundation/OpenTimelineIO/actions/workflows/python-package.yml/badge.svg)](https://github.com/AcademySoftwareFoundation/OpenTimelineIO/actions/workflows/python-package.yml)
 [![codecov](https://codecov.io/gh/AcademySoftwareFoundation/OpenTimelineIO/branch/main/graph/badge.svg)](https://codecov.io/gh/AcademySoftwareFoundation/OpenTimelineIO)
 [![docs](https://readthedocs.org/projects/opentimelineio/badge/?version=latest)](https://opentimelineio.readthedocs.io/en/latest/index.html)
@@ -56,7 +56,7 @@ Supported VFX Platforms
 -----------------
 The current release supports:
 - VFX platform 2025, 2024, 2023, 2022
-- Python 3.9 - 3.11
+- Python 3.9 - 3.12
 
 For more information on our vfxplatform support policy: [Contribution Guidelines Documentation Page](https://opentimelineio.readthedocs.io/en/latest/tutorials/contributing.html)
 For more information on the vfxplatform: [VFX Platform Homepage](https://vfxplatform.com)
@@ -154,7 +154,7 @@ You can also install the PySide2 dependency with `python -m pip install .[view]`
 
 You may need to escape the `[` depending on your shell, `\[view\]` .
 
-Currently the code base is written against python 3.9, 3.10 and 3.11,
+Currently the code base is written against python 3.9-3.12,
 in keeping with the pep8 style.  We ask that before developers submit pull
 request, they:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ OpenTimelineIO
 ==============
 
 [![Supported VFX Platform Versions](https://img.shields.io/badge/vfx%20platform-2021--2023-lightgrey.svg)](http://www.vfxplatform.com/)
-![Supported Versions](https://img.shields.io/badge/python-3.7%2C%203.8%2C%203.9%2C%203.10%2C%203.11-blue)
+![Supported Versions](https://img.shields.io/badge/python-3.7%2C%203.8%2C%203.9%2C%203.11%2C%203.11-blue)
 [![Build Status](https://github.com/AcademySoftwareFoundation/OpenTimelineIO/actions/workflows/python-package.yml/badge.svg)](https://github.com/AcademySoftwareFoundation/OpenTimelineIO/actions/workflows/python-package.yml)
 [![codecov](https://codecov.io/gh/AcademySoftwareFoundation/OpenTimelineIO/branch/main/graph/badge.svg)](https://codecov.io/gh/AcademySoftwareFoundation/OpenTimelineIO)
 [![docs](https://readthedocs.org/projects/opentimelineio/badge/?version=latest)](https://opentimelineio.readthedocs.io/en/latest/index.html)
@@ -56,7 +56,7 @@ Supported VFX Platforms
 -----------------
 The current release supports:
 - VFX platform 2023, 2022, 2021
-- Python 3.7 - 3.10
+- Python 3.7 - 3.11
 
 For more information on our vfxplatform support policy: [Contribution Guidelines Documentation Page](https://opentimelineio.readthedocs.io/en/latest/tutorials/contributing.html)
 For more information on the vfxplatform: [VFX Platform Homepage](https://vfxplatform.com)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ OpenTimelineIO
 [![OpenTimelineIO](docs/_static/OpenTimelineIO@3xDark.png)](http://opentimeline.io)
 ==============
 
-[![Supported VFX Platform Versions](https://img.shields.io/badge/vfx%20platform-2020--2023-lightgrey.svg)](http://www.vfxplatform.com/)
+[![Supported VFX Platform Versions](https://img.shields.io/badge/vfx%20platform-2021--2023-lightgrey.svg)](http://www.vfxplatform.com/)
 ![Supported Versions](https://img.shields.io/badge/python-3.7%2C%203.8%2C%203.9%2C%203.10%2C%203.11-blue)
 [![Build Status](https://github.com/AcademySoftwareFoundation/OpenTimelineIO/actions/workflows/python-package.yml/badge.svg)](https://github.com/AcademySoftwareFoundation/OpenTimelineIO/actions/workflows/python-package.yml)
 [![codecov](https://codecov.io/gh/AcademySoftwareFoundation/OpenTimelineIO/branch/main/graph/badge.svg)](https://codecov.io/gh/AcademySoftwareFoundation/OpenTimelineIO)
@@ -55,7 +55,7 @@ Documentation, including quick start, architecture, use cases, API docs, and muc
 Supported VFX Platforms
 -----------------
 The current release supports:
-- VFX platform 2023, 2022, 2021, 2020
+- VFX platform 2023, 2022, 2021
 - Python 3.7 - 3.10
 
 For more information on our vfxplatform support policy: [Contribution Guidelines Documentation Page](https://opentimelineio.readthedocs.io/en/latest/tutorials/contributing.html)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ OpenTimelineIO
 ==============
 
 [![Supported VFX Platform Versions](https://img.shields.io/badge/vfx%20platform-2022--2025-lightgrey.svg)](http://www.vfxplatform.com/)
-![Supported Versions](https://img.shields.io/badge/python-3.9%2C%203.10%2C%203.11-%2C%203.12-blue)
+![Supported Versions](https://img.shields.io/badge/python-3.9%2C%203.10%2C%203.11%2C%203.12-blue)
 [![Build Status](https://github.com/AcademySoftwareFoundation/OpenTimelineIO/actions/workflows/python-package.yml/badge.svg)](https://github.com/AcademySoftwareFoundation/OpenTimelineIO/actions/workflows/python-package.yml)
 [![codecov](https://codecov.io/gh/AcademySoftwareFoundation/OpenTimelineIO/branch/main/graph/badge.svg)](https://codecov.io/gh/AcademySoftwareFoundation/OpenTimelineIO)
 [![docs](https://readthedocs.org/projects/opentimelineio/badge/?version=latest)](https://opentimelineio.readthedocs.io/en/latest/index.html)

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ OpenTimelineIO
 [![OpenTimelineIO](docs/_static/OpenTimelineIO@3xDark.png)](http://opentimeline.io)
 ==============
 
-[![Supported VFX Platform Versions](https://img.shields.io/badge/vfx%20platform-2021--2023-lightgrey.svg)](http://www.vfxplatform.com/)
-![Supported Versions](https://img.shields.io/badge/python-3.7%2C%203.8%2C%203.9%2C%203.11%2C%203.11-blue)
+[![Supported VFX Platform Versions](https://img.shields.io/badge/vfx%20platform-2022--2025-lightgrey.svg)](http://www.vfxplatform.com/)
+![Supported Versions](https://img.shields.io/badge/python-3.9%2C%203.10%2C%203.11-blue)
 [![Build Status](https://github.com/AcademySoftwareFoundation/OpenTimelineIO/actions/workflows/python-package.yml/badge.svg)](https://github.com/AcademySoftwareFoundation/OpenTimelineIO/actions/workflows/python-package.yml)
 [![codecov](https://codecov.io/gh/AcademySoftwareFoundation/OpenTimelineIO/branch/main/graph/badge.svg)](https://codecov.io/gh/AcademySoftwareFoundation/OpenTimelineIO)
 [![docs](https://readthedocs.org/projects/opentimelineio/badge/?version=latest)](https://opentimelineio.readthedocs.io/en/latest/index.html)
@@ -55,8 +55,8 @@ Documentation, including quick start, architecture, use cases, API docs, and muc
 Supported VFX Platforms
 -----------------
 The current release supports:
-- VFX platform 2023, 2022, 2021
-- Python 3.7 - 3.11
+- VFX platform 2025, 2024, 2023, 2022
+- Python 3.9 - 3.11
 
 For more information on our vfxplatform support policy: [Contribution Guidelines Documentation Page](https://opentimelineio.readthedocs.io/en/latest/tutorials/contributing.html)
 For more information on the vfxplatform: [VFX Platform Homepage](https://vfxplatform.com)
@@ -154,7 +154,7 @@ You can also install the PySide2 dependency with `python -m pip install .[view]`
 
 You may need to escape the `[` depending on your shell, `\[view\]` .
 
-Currently the code base is written against python 3.7, 3.8, 3.9, 3.10 and 3.11,
+Currently the code base is written against python 3.9, 3.10 and 3.11,
 in keeping with the pep8 style.  We ask that before developers submit pull
 request, they:
 

--- a/setup.py
+++ b/setup.py
@@ -205,10 +205,10 @@ class OTIO_build_ext(setuptools.command.build_ext.build_ext):
 # check the python version first
 if (
     sys.version_info[0] < 3 or
-    (sys.version_info[0] == 3 and sys.version_info[1] < 7)
+    (sys.version_info[0] == 3 and sys.version_info[1] < 9)
 ):
     sys.exit(
-        'OpenTimelineIO requires python3.7 or greater, detected version:'
+        'OpenTimelineIO requires python3.9 or greater, detected version:'
         ' {}.{}'.format(
             sys.version_info[0],
             sys.version_info[1]
@@ -317,8 +317,6 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
@@ -357,10 +355,9 @@ setup(
     },
 
     # Disallow 3.9.0 because of https://github.com/python/cpython/pull/22670
-    python_requires='>=3.7, !=3.9.0',  # noqa: E501
+    python_requires='>=3.9, !=3.9.0',  # noqa: E501
 
     install_requires=[
-        'importlib_metadata>=1.4; python_version < "3.8"',
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -355,7 +355,7 @@ setup(
     },
 
     # Disallow 3.9.0 because of https://github.com/python/cpython/pull/22670
-    python_requires='>=3.9, !=3.9.0',  # noqa: E501
+    python_requires='>3.9.0',  # noqa: E501
 
     install_requires=[
     ],

--- a/setup.py
+++ b/setup.py
@@ -320,6 +320,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Operating System :: OS Independent',
         'Natural Language :: English',
     ],

--- a/src/py-opentimelineio/opentimelineio/plugins/manifest.py
+++ b/src/py-opentimelineio/opentimelineio/plugins/manifest.py
@@ -7,13 +7,8 @@ from importlib import resources
 import inspect
 import logging
 import os
-from pathlib import Path
 
-try:
-    from importlib import metadata
-except ImportError:
-    # For python 3.7
-    import importlib_metadata as metadata
+from importlib import metadata
 
 from .. import (
     core,
@@ -287,12 +282,7 @@ def load_manifest():
                 except AttributeError:
                     name = plugin_entry_point.__name__
 
-                    try:
-                        filepath = resources.files(name) / "plugin_manifest.json"
-                    except AttributeError:
-                        # For python <= 3.7
-                        with resources.path(name, "plugin_manifest.json") as p:
-                            filepath = Path(p)
+                    filepath = resources.files(name) / "plugin_manifest.json"
 
                     if filepath.as_posix() in result.source_files:
                         continue
@@ -317,18 +307,10 @@ def load_manifest():
         )
 
     # the builtin plugin manifest
-    try:
-        builtin_manifest_path = (
-            resources.files("opentimelineio.adapters")
-            / "builtin_adapters.plugin_manifest.json"
-        ).as_posix()
-    except AttributeError:
-        # For python <= 3.7
-        with resources.path(
-            "opentimelineio.adapters",
-            "builtin_adapters.plugin_manifest.json"
-        ) as p:
-            builtin_manifest_path = p.as_posix()
+    builtin_manifest_path = (
+        resources.files("opentimelineio.adapters")
+        / "builtin_adapters.plugin_manifest.json"
+    ).as_posix()
 
     if os.path.abspath(builtin_manifest_path) not in result.source_files:
         plugin_manifest = manifest_from_file(builtin_manifest_path)

--- a/src/py-opentimelineio/opentimelineio/plugins/manifest.py
+++ b/src/py-opentimelineio/opentimelineio/plugins/manifest.py
@@ -8,6 +8,7 @@ import inspect
 import logging
 import os
 
+# for python <= 3.9
 from importlib import metadata
 
 from .. import (

--- a/tests/baselines/plugin_module/otio_mockplugin/__init__.py
+++ b/tests/baselines/plugin_module/otio_mockplugin/__init__.py
@@ -2,7 +2,6 @@
 # Copyright Contributors to the OpenTimelineIO project
 
 from importlib import resources
-from pathlib import Path
 
 from opentimelineio.plugins import manifest
 
@@ -21,12 +20,10 @@ a non-standard json file path.
 
 
 def plugin_manifest():
-    try:
-        filepath = resources.files(__package__) / "unusually_named_plugin_manifest.json"
-    except AttributeError:
-        # For python <= 3.7
-        with resources.path(__package__, "unusually_named_plugin_manifest.json") as p:
-            filepath = Path(p)
+    filepath = (
+        resources.files(__package__) 
+        / "unusually_named_plugin_manifest.json"
+    )
 
     return manifest.manifest_from_string(
         filepath.read_text()

--- a/tests/baselines/plugin_module/otio_mockplugin/__init__.py
+++ b/tests/baselines/plugin_module/otio_mockplugin/__init__.py
@@ -21,7 +21,7 @@ a non-standard json file path.
 
 def plugin_manifest():
     filepath = (
-        resources.files(__package__) 
+        resources.files(__package__)
         / "unusually_named_plugin_manifest.json"
     )
 

--- a/tests/test_plugin_detection.py
+++ b/tests/test_plugin_detection.py
@@ -12,11 +12,7 @@ from unittest import mock
 
 from importlib import reload as import_reload
 
-try:
-    import importlib.metadata as metadata
-except ImportError:
-    # For python 3.7
-    import importlib_metadata as metadata
+import importlib.metadata as metadata
 
 import opentimelineio as otio
 from tests import baseline_reader


### PR DESCRIPTION
Fixes #1876 
Fixes #1804 

* Removes VFX Platform 2020 from the badge, adds 2024 and 2025
* stripped out code blocks that indicated they were present for python versions before 3.9.
* Adds notes that Pyhon 3.12 is supported (CI is already running on 3.12, binaries are already built)

As noted in the comments below by @JeanChristopheMorinPerso, this PR doesn't fully cover #1094, it doesn't add any of the VFX platform container related testing stuff.