### PR TITLE
Per-Track and Per-Clip Color

### DIFF
--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(OPENTIMELINEIO_HEADER_FILES
     anyDictionary.h
     anyVector.h
+    color.h
     clip.h
     composable.h
     composition.h
@@ -38,7 +39,8 @@ set(OPENTIMELINEIO_HEADER_FILES
     vectorIndexing.h
     version.h)
 
-add_library(opentimelineio ${OTIO_SHARED_OR_STATIC_LIB} 
+add_library(opentimelineio ${OTIO_SHARED_OR_STATIC_LIB}
+    color.cpp
     clip.cpp
     composable.cpp
     composition.cpp

--- a/src/opentimelineio/clip.cpp
+++ b/src/opentimelineio/clip.cpp
@@ -15,9 +15,11 @@ Clip::Clip(
     AnyDictionary const&            metadata,
     std::vector<Effect*> const&     effects,
     std::vector<Marker*> const&     markers,
-    std::string const&              active_media_reference_key)
+    std::string const&              active_media_reference_key,
+    Color*                          color)
     : Parent{ name, source_range, metadata, effects, markers }
     , _active_media_reference_key(active_media_reference_key)
+    , _color(color)
 {
     set_media_reference(media_reference);
 }
@@ -144,6 +146,7 @@ Clip::read_from(Reader& reader)
            && reader.read(
                "active_media_reference_key",
                &_active_media_reference_key)
+           && reader.read_if_present("color", &_color)
            && Parent::read_from(reader);
 }
 
@@ -153,6 +156,7 @@ Clip::write_to(Writer& writer) const
     Parent::write_to(writer);
     writer.write("media_references", _media_references);
     writer.write("active_media_reference_key", _active_media_reference_key);
+    writer.write("color", _color);
 }
 
 TimeRange
@@ -209,6 +213,18 @@ Clip::available_image_bounds(ErrorStatus* error_status) const
     }
 
     return active_media->available_image_bounds();
+}
+
+Color*
+Clip::color() const noexcept
+{
+    return _color;
+}
+
+void
+Clip::set_color(Color* color)
+{
+    _color = color ? color : new Color();
 }
 
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/clip.h
+++ b/src/opentimelineio/clip.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "opentimelineio/color.h"
 #include "opentimelineio/item.h"
 #include "opentimelineio/mediaReference.h"
 #include "opentimelineio/version.h"
@@ -46,7 +47,8 @@ public:
         AnyDictionary const&            metadata        = AnyDictionary(),
         std::vector<Effect*> const& effects             = std::vector<Effect*>(),
         std::vector<Marker*> const& markers             = std::vector<Marker*>(),
-        std::string const& active_media_reference_key   = default_media_key);
+        std::string const& active_media_reference_key   = default_media_key,
+        Color* color                                    = nullptr);
 
     /// @name Media References
     ///@{
@@ -86,6 +88,9 @@ public:
     std::optional<IMATH_NAMESPACE::Box2d>
     available_image_bounds(ErrorStatus* error_status) const override;
 
+    Color* color() const noexcept;
+    void set_color(Color* color);
+
 protected:
     virtual ~Clip();
 
@@ -103,6 +108,7 @@ private:
 private:
     std::map<std::string, Retainer<MediaReference>> _media_references;
     std::string                                     _active_media_reference_key;
+    Retainer<Color>                                 _color;
 };
 
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/color.cpp
+++ b/src/opentimelineio/color.cpp
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Contributors to the OpenTimelineIO project
+
+#include <iomanip>
+#include <sstream>
+
+#include "opentimelineio/color.h"
+
+namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
+
+Color::Color(
+    double const r,
+    double const g,
+    double const b,
+    double const a)
+    : _r(r),
+    _g(g),
+    _b(b),
+    _a(a) {}
+
+Color::Color(Color const& other) : _r(other.r()),
+                                   _g(other.g()),
+                                   _b(other.b()),
+                                   _a(other.a()) {}
+
+const Color Color::pink(1.0, 0.0, 1.0, 1.0);
+const Color Color::red(1.0, 0.0, 0.0, 1.0);
+const Color Color::orange(1.0, 0.5, 0.0, 1.0);
+const Color Color::yellow(1.0, 1.0, 0.0, 1.0);
+const Color Color::green(0.0, 1.0, 0.0, 1.0);
+const Color Color::cyan(0.0, 1.0, 1.0, 1.0);
+const Color Color::blue(0.0, 0.0, 1.0, 1.0);
+const Color Color::purple(0.5, 0.0, 0.5, 1.0);
+const Color Color::magenta(1.0, 0.0, 1.0, 1.0);
+const Color Color::black(0.0, 0.0, 0.0, 1.0);
+const Color Color::white(1.0, 1.0, 1.0, 1.0);
+const Color Color::transparent(0.0, 0.0, 0.0, 0.0);
+
+std::string
+Color::to_hex()
+{
+    auto rgba = to_rgba_int_list(8);
+    std::stringstream ss;
+    ss << "#";
+
+    ss << std::hex << std::setfill('0');
+    ss << std::setw(2) << rgba[0];
+    ss << std::setw(2) << rgba[1];
+    ss << std::setw(2) << rgba[2];
+    ss << std::setw(2) << rgba[3];
+    return ss.str();
+}
+
+std::array<int, 4>
+Color::to_rgba_int_list(int base)
+{
+    double math_base = pow(2, base) - 1.0;
+    return {int(_r * math_base), int(_g * math_base), int(_b * math_base), int(_a * math_base)};
+}
+
+unsigned int
+Color::to_agbr_integer()
+{
+    auto rgba = to_rgba_int_list(8);
+    return (rgba[3] << 24) + (rgba[2] << 16) + (rgba[1] << 8) + rgba[0];
+}
+
+std::array<double, 4>
+Color::to_rgba_float_list()
+{
+    return {_r, _g, _b, _a};
+}
+
+Color::~Color()
+{}
+
+bool
+Color::read_from(Reader& reader)
+{
+    return reader.read("r", &_r)
+                && reader.read("g", &_g)
+                && reader.read("b", &_b)
+                && reader.read("a", &_a)
+                && Parent::read_from(reader);
+}
+
+void
+Color::write_to(Writer& writer) const
+{
+    Parent::write_to(writer);
+    writer.write("r", _r);
+    writer.write("g", _g);
+    writer.write("b", _b);
+    writer.write("a", _a);
+}
+}} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/color.h
+++ b/src/opentimelineio/color.h
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Contributors to the OpenTimelineIO project
+
+#pragma once
+
+#include <cmath>
+
+#include "opentimelineio/serializableObjectWithMetadata.h"
+#include "opentimelineio/version.h"
+
+namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
+
+
+
+class Color: public SerializableObjectWithMetadata
+{
+public:
+    struct Schema
+    {
+        static auto constexpr name   = "Color";
+        static int constexpr version = 1;
+    };
+
+    using Parent = SerializableObjectWithMetadata;
+
+    Color(double const r = 1.f,
+          double const g = 1.f,
+          double const b = 1.f,
+          double const a = 1.f);
+
+    Color(Color const& other);
+
+    static const Color pink;
+    static const Color red;
+    static const Color orange;
+    static const Color yellow;
+    static const Color green;
+    static const Color cyan;
+    static const Color blue;
+    static const Color purple;
+    static const Color magenta;
+    static const Color black;
+    static const Color white;
+    static const Color transparent;
+
+    static Color*
+    from_hex(std::string const& color) noexcept
+    {
+        std::string temp = color;
+        if (temp[0] == '#')
+        {
+            temp = temp.substr(1);
+        }
+        else if (temp[0] == '0' and (temp[1] == 'x' or temp[1] == 'X'))
+        {
+            temp = temp.substr(2);
+        }
+
+        double _r, _g, _b, _a;
+        // 0xFFFFFFFF (rgba, 255)
+        int BASE_16 = 16;
+        double BASE_16_DIV = 255.0;
+        double BASE_8_DIV = 15.0;
+        if (temp.length() == 8)
+        {
+            _r = std::stoi(temp.substr(0, 2), nullptr, BASE_16) / BASE_16_DIV;
+            _g = std::stoi(temp.substr(2, 2), nullptr, BASE_16) / BASE_16_DIV;
+            _b = std::stoi(temp.substr(4, 2), nullptr, BASE_16) / BASE_16_DIV;
+            _a = std::stoi(temp.substr(6, 2), nullptr, BASE_16) / BASE_16_DIV;
+        }
+        // 0xFFFFFF (rgb, 255)
+        else if (temp.length() == 6)
+        {
+            _r = std::stoi(temp.substr(0, 2), nullptr, BASE_16) / BASE_16_DIV;
+            _g = std::stoi(temp.substr(2, 2), nullptr, BASE_16) / BASE_16_DIV;
+            _b = std::stoi(temp.substr(4, 2), nullptr, BASE_16) / BASE_16_DIV;
+            _a = 1.0;
+        }
+        // 0xFFF (rgb, 16)
+        else if (temp.length() == 3)
+        {
+            _r = std::stoi(temp.substr(0, 1), nullptr, BASE_16) / BASE_8_DIV;
+            _g = std::stoi(temp.substr(1, 1), nullptr, BASE_16) / BASE_8_DIV;
+            _b = std::stoi(temp.substr(2, 1), nullptr, BASE_16) / BASE_8_DIV;
+            _a = 1.0;
+        }
+        // 0xFFFF (rgba, 16)
+        else if (temp.length() == 4)
+        {
+            _r = std::stoi(temp.substr(0, 1), nullptr, BASE_16) / BASE_8_DIV;
+            _g = std::stoi(temp.substr(1, 1), nullptr, BASE_16) / BASE_8_DIV;
+            _b = std::stoi(temp.substr(2, 1), nullptr, BASE_16) / BASE_8_DIV;
+            _a = std::stoi(temp.substr(3, 1), nullptr, BASE_16) / BASE_8_DIV;
+        }
+        else {
+            throw std::invalid_argument("Invalid hex format");
+        }
+        return new Color(_r, _g, _b, _a);
+    }
+
+    static Color*
+    from_int_list(const std::vector<int>& color, int bit_depth) noexcept
+    {
+        double depth = pow(2, bit_depth) - 1.0;  // e.g. 8 = 255.0
+        if (color.size() == 3)
+            return new Color(color[0] / depth, color[1] / depth, color[2] / depth, 1.0);
+        else if (color.size() == 4)
+            return new Color(color[0] / depth, color[1] / depth, color[2] / depth, color[3] / depth);
+
+        throw std::invalid_argument("List must have exactly 3 or 4 elements");
+    }
+
+    static Color*
+    from_agbr_int(unsigned int agbr) noexcept
+    {
+        auto conv_r = (agbr & 0xFF) / 255.0;
+        auto conv_g = ((agbr >> 16) & 0xFF) / 255.0;
+        auto conv_b = ((agbr >> 8) & 0xFF) / 255.0;
+        auto conv_a = ((agbr >> 24) & 0xFF) / 255.0;
+        return new Color(conv_r, conv_g, conv_b, conv_a);
+    }
+
+    static Color*
+    from_float_list(const std::vector<double>& color) noexcept
+    {
+        if (color.size() == 3)
+            return new Color(color[0], color[1], color[2], 1.0);
+        else if (color.size() == 4)
+            return new Color(color[0], color[1], color[2], color[3]);
+
+        throw std::invalid_argument("List must have exactly 3 or 4 elements");
+    }
+
+    friend bool
+    operator==(Color lhs, Color rhs) noexcept
+    {
+        return lhs.to_hex() == rhs.to_hex() && lhs.to_agbr_integer() == rhs.to_agbr_integer();
+    }
+
+    std::string to_hex();
+    std::array<int, 4> to_rgba_int_list(int base);
+    unsigned int to_agbr_integer();
+    std::array<double, 4> to_rgba_float_list();
+
+    double r() const { return _r; }
+    double g() const { return _g; }
+    double b() const { return _b; }
+    double a() const { return _a; }
+
+    void set_r(double r) { _r = r; }
+    void set_g(double g) { _g = g; }
+    void set_b(double b) { _b = b; }
+    void set_a(double a) { _a = a; }
+
+protected:
+    virtual ~Color();
+
+    bool read_from(Reader&) override;
+    void write_to(Writer&) const override;
+
+private:
+    double _r;
+    double _g;
+    double _b;
+    double _a;
+};
+
+}} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/track.cpp
+++ b/src/opentimelineio/track.cpp
@@ -13,9 +13,11 @@ Track::Track(
     std::string const&              name,
     std::optional<TimeRange> const& source_range,
     std::string const&              kind,
-    AnyDictionary const&            metadata)
+    AnyDictionary const&            metadata,
+    Color*                          color)
     : Parent(name, source_range, metadata)
     , _kind(kind)
+    , _color(color)
 {}
 
 Track::~Track()
@@ -31,7 +33,9 @@ Track::composition_kind() const
 bool
 Track::read_from(Reader& reader)
 {
-    return reader.read("kind", &_kind) && Parent::read_from(reader);
+    return reader.read("kind", &_kind)
+           && reader.read_if_present("color", &_color)
+           && Parent::read_from(reader);
 }
 
 void
@@ -303,6 +307,18 @@ Track::available_image_bounds(ErrorStatus* error_status) const
         }
     }
     return box;
+}
+
+Color*
+Track::color() const noexcept
+{
+    return _color;
+}
+
+void
+Track::set_color(Color* color)
+{
+    _color = color ? color : new Color();
 }
 
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/track.h
+++ b/src/opentimelineio/track.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "opentimelineio/color.h"
 #include "opentimelineio/composition.h"
 #include "opentimelineio/version.h"
 
@@ -47,7 +48,8 @@ public:
         std::string const&              name         = std::string(),
         std::optional<TimeRange> const& source_range = std::nullopt,
         std::string const&              kind         = Kind::video,
-        AnyDictionary const&            metadata     = AnyDictionary());
+        AnyDictionary const&            metadata     = AnyDictionary(),
+        Color*                          color        = nullptr);
 
     /// @brief Return this kind of track.
     std::string kind() const noexcept { return _kind; }
@@ -92,6 +94,9 @@ public:
         std::optional<TimeRange> const& search_range   = std::nullopt,
         bool                            shallow_search = false) const;
 
+    Color* color() const noexcept;
+    void set_color(Color* color);
+
 protected:
     virtual ~Track();
 
@@ -101,7 +106,8 @@ protected:
     void write_to(Writer&) const override;
 
 private:
-    std::string _kind;
+    std::string      _kind;
+    Retainer<Color>  _color;
 };
 
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/typeRegistry.cpp
+++ b/src/opentimelineio/typeRegistry.cpp
@@ -5,6 +5,7 @@
 
 #include "anyDictionary.h"
 #include "opentimelineio/clip.h"
+#include "opentimelineio/color.h"
 #include "opentimelineio/composable.h"
 #include "opentimelineio/composition.h"
 #include "opentimelineio/effect.h"
@@ -55,6 +56,7 @@ TypeRegistry::TypeRegistry()
         "UnknownSchema");
 
     register_type<Clip>();
+    register_type<Color>();
     register_type<Composable>();
     register_type<Composition>();
     register_type<Effect>();

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -7,6 +7,7 @@
 #include "otio_errorStatusHandler.h"
 
 #include "opentimelineio/clip.h"
+#include "opentimelineio/color.h"
 #include "opentimelineio/composable.h"
 #include "opentimelineio/composition.h"
 #include "opentimelineio/effect.h"
@@ -203,6 +204,38 @@ static void define_bases1(py::module m) {
 static void define_bases2(py::module m) {
     MarkerVectorProxy::define_py_class(m, "MarkerVector");
     EffectVectorProxy::define_py_class(m, "EffectVector");
+
+    py::class_<Color, SOWithMetadata, managing_ptr<Color>>(m, "Color", py::dynamic_attr(), R"docstring(:class:`Color` is a definition of red, green, blue, and alpha double floating point values, allowing conversion between different formats. To be considered interoperable, the sRGB transfer function encoded values, ranging between zero and one, are expected to be accurate to within 1/255 of the intended value. Round-trip conversions may not be guaranteed outside that.)docstring")
+        .def(py::init([](double r, double g, double b, double a) {
+            return new Color(r, g, b, a);
+        }), "r"_a = 1.0, "g"_a = 1.0, "b"_a = 1.0, "a"_a = 1.0)
+        .def_property("r", &Color::r, &Color::set_r)
+        .def_property("g", &Color::g, &Color::set_g)
+        .def_property("b", &Color::b, &Color::set_b)
+        .def_property("a", &Color::a, &Color::set_a)
+
+        .def("to_hex", &Color::to_hex)
+        .def("to_rgba_int_list", &Color::to_rgba_int_list, py::arg("base") = 8)
+        .def("to_agbr_integer", &Color::to_agbr_integer)
+        .def("to_rgba_float_list", &Color::to_rgba_float_list)
+        
+        .def_static("from_hex",  Color::from_hex)
+        .def_static("from_float_list", &Color::from_float_list)
+        .def_static("from_int_list", &Color::from_int_list)
+        .def_static("from_agbr_int", &Color::from_agbr_int)
+
+        .def_property_readonly_static("PINK", [](py::object) { return new Color(Color::pink); }, py::return_value_policy::take_ownership)
+        .def_property_readonly_static("RED", [](py::object) { return new Color(Color::red); }, py::return_value_policy::take_ownership)
+        .def_property_readonly_static("ORANGE", [](py::object) { return new Color(Color::orange); }, py::return_value_policy::take_ownership)
+        .def_property_readonly_static("YELLOW", [](py::object) { return new Color(Color::yellow); }, py::return_value_policy::take_ownership)
+        .def_property_readonly_static("GREEN", [](py::object) { return new Color(Color::green); }, py::return_value_policy::take_ownership)
+        .def_property_readonly_static("CYAN", [](py::object) { return new Color(Color::cyan); }, py::return_value_policy::take_ownership)
+        .def_property_readonly_static("BLUE", [](py::object) { return new Color(Color::blue); }, py::return_value_policy::take_ownership)
+        .def_property_readonly_static("PURPLE", [](py::object) { return new Color(Color::purple); }, py::return_value_policy::take_ownership)
+        .def_property_readonly_static("MAGENTA", [](py::object) { return new Color(Color::magenta); }, py::return_value_policy::take_ownership)
+        .def_property_readonly_static("BLACK", [](py::object) { return new Color(Color::black); }, py::return_value_policy::take_ownership)
+        .def_property_readonly_static("WHITE", [](py::object) { return new Color(Color::white); }, py::return_value_policy::take_ownership)
+        .def_property_readonly_static("TRANSPARENT", [](py::object) { return new Color(Color::transparent); }, py::return_value_policy::take_ownership);
 
     auto marker_class =
         py::class_<Marker, SOWithMetadata, managing_ptr<Marker>>(m, "Marker", py::dynamic_attr(), R"docstring(
@@ -427,11 +460,13 @@ Contains a :class:`.MediaReference` and a trim on that media reference.
                          std::optional<TimeRange> source_range, py::object metadata,
                          std::optional<std::vector<Effect*>> effects,
                          std::optional<std::vector<Marker*>> markers,
-                         const std::string&  active_media_reference) {
+                         const std::string&  active_media_reference,
+                         Color* color) {
                           return new Clip(name, media_reference, source_range, py_to_any_dictionary(metadata),
                                           vector_or_default<Effect>(effects),
                                           vector_or_default<Marker>(markers),
-                                          active_media_reference);
+                                          active_media_reference,
+                                          color);
                       }),
              py::arg_v("name"_a = std::string()),
              "media_reference"_a = nullptr,
@@ -439,7 +474,8 @@ Contains a :class:`.MediaReference` and a trim on that media reference.
              py::arg_v("metadata"_a = py::none()),
              "effects"_a = py::none(),
              "markers"_a = py::none(),
-             "active_media_reference"_a = std::string(Clip::default_media_key))
+             "active_media_reference"_a = std::string(Clip::default_media_key),
+             "color"_a = nullptr)
         .def_property_readonly_static("DEFAULT_MEDIA_KEY",[](py::object /* self */) { 
             return Clip::default_media_key; 
            })
@@ -447,6 +483,7 @@ Contains a :class:`.MediaReference` and a trim on that media reference.
         .def_property("active_media_reference_key", &Clip::active_media_reference_key, [](Clip* clip, std::string const& new_active_key) { 
             clip->set_active_media_reference_key(new_active_key, ErrorStatusHandler()); 
             })
+        .def_property("color", &Clip::color, &Clip::set_color)
         .def("media_references", &Clip::media_references) 
         .def("set_media_references", [](Clip* clip, Clip::MediaReferences const& media_references, std::string const& new_active_key) {
             clip->set_media_references(media_references, new_active_key, ErrorStatusHandler());
@@ -565,13 +602,15 @@ Should be subclassed (for example by :class:`.Track` and :class:`.Stack`), not u
     track_class
         .def(py::init([](std::string name, std::optional<std::vector<Composable*>> children,
                          std::optional<TimeRange> const& source_range,
-                         std::string const& kind, py::object metadata) {
+                         std::string const& kind, py::object metadata,
+                         Color* color) {
                           auto composable_children = vector_or_default<Composable>(children);
                           Track* t = new Track(
                                   name,
                                   source_range,
                                   kind,
-                                  py_to_any_dictionary(metadata)
+                                  py_to_any_dictionary(metadata),
+                                  color
                           );
                           if (!composable_children.empty())
                               t->set_children(composable_children, ErrorStatusHandler());
@@ -581,8 +620,10 @@ Should be subclassed (for example by :class:`.Track` and :class:`.Stack`), not u
              "children"_a = py::none(),
              "source_range"_a = std::nullopt,
              "kind"_a = std::string(Track::Kind::video),
-             py::arg_v("metadata"_a = py::none()))
+             py::arg_v("metadata"_a = py::none()),
+             "color"_a = nullptr)
         .def_property("kind", &Track::kind, &Track::set_kind)
+        .def_property("color", &Track::color, &Track::set_color)
         .def("neighbors_of", [](Track* t, Composable* item, Track::NeighborGapPolicy policy) {
                 auto result =  t->neighbors_of(item, ErrorStatusHandler(), policy);
                 return py::make_tuple(py::cast(result.first.take_value()), py::cast(result.second.take_value()));

--- a/src/py-opentimelineio/opentimelineio/schema/__init__.py
+++ b/src/py-opentimelineio/opentimelineio/schema/__init__.py
@@ -7,6 +7,7 @@
 
 from .. _otio import (
     Box2d,
+    Color,
     Clip,
     Effect,
     TimeEffect,
@@ -37,6 +38,7 @@ from . schemadef import (
 
 from . import (
     box2d,
+    color,
     clip,
     effect,
     external_reference,
@@ -57,6 +59,7 @@ def timeline_from_clips(clips):
 
 __all__ = [
     'Box2d',
+    'Color',
     'Clip',
     'Effect',
     'TimeEffect',

--- a/src/py-opentimelineio/opentimelineio/schema/color.py
+++ b/src/py-opentimelineio/opentimelineio/schema/color.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the OpenTimelineIO project
+
+from .. core._core_utils import add_method
+from .. import _otio
+
+
+@add_method(_otio.Color)
+def __str__(self):
+    return 'Color({}, {}, {}, {})'.format(
+        self.r,
+        self.g,
+        self.b,
+        self.a,
+    )
+
+
+@add_method(_otio.Color)
+def __repr__(self):
+    return (
+        'otio.schema.Color('
+        'r={}, '
+        'g={}, '
+        'b={}, '
+        'a={})'.format(
+            repr(self.r),
+            repr(self.g),
+            repr(self.b),
+            repr(self.a),
+        )
+    )

--- a/tests/baselines/empty_clip.json
+++ b/tests/baselines/empty_clip.json
@@ -7,6 +7,7 @@
     "enabled" : true,
     "effects" : [],
     "active_media_reference_key": "DEFAULT_MEDIA",
+    "color": null,
     "media_references" : { 
         "DEFAULT_MEDIA" : {
             "FROM_TEST_FILE" : "empty_missingreference.json"

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the OpenTimelineIO project
+
+import unittest
+
+import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
+
+
+class ColorTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
+
+    def test_convert_to(self):
+        white = otio.schema.Color.WHITE
+        self.assertEqual(white.r, 1.0)
+        self.assertEqual(white.g, 1.0)
+        self.assertEqual(white.b, 1.0)
+        self.assertEqual(white.a, 1.0)
+        self.assertEqual(white.to_hex(), "#ffffffff")
+        self.assertEqual(white.to_rgba_int_list(8), [255, 255, 255, 255])
+        self.assertEqual(white.to_agbr_integer(), 4294967295)
+        self.assertEqual(white.to_rgba_float_list(), [1.0, 1.0, 1.0, 1.0])
+
+        black = otio.schema.Color.BLACK
+        self.assertEqual(black.r, 0.0)
+        self.assertEqual(black.g, 0.0)
+        self.assertEqual(black.b, 0.0)
+        self.assertEqual(black.a, 1.0)
+        self.assertEqual(black.to_hex(), "#000000ff")
+        self.assertEqual(black.to_rgba_int_list(8), [0, 0, 0, 255])
+        self.assertEqual(black.to_agbr_integer(), 4278190080)
+        self.assertEqual(black.to_rgba_float_list(), [0.0, 0.0, 0.0, 1.0])
+
+    def test_from_hex(self):
+        all_reds = [
+            "f00",  # 3 digits
+            "f00f",  # 4 digits
+            "ff0000",  # 6 digits
+            "ff0000ff",  # 8 digits
+            "0xff0000",  # prefix
+            "#ff0000",  # prefix
+        ]
+        for red_hex in all_reds + [s.upper() for s in all_reds]:
+            red = otio.schema.Color.from_hex(red_hex)
+            self.assertEqual(red.r, 1.0)
+            self.assertEqual(red.g, 0.0)
+            self.assertEqual(red.b, 0.0)
+            self.assertEqual(red.a, 1.0)
+
+    def test_from_int_list(self):
+        colors = (
+            [255, 255, 255],
+            [0, 0, 0],
+            [255, 0, 0, 0],
+        )
+
+        for c in colors:
+            actual = otio.schema.Color.from_int_list(c, 8).to_rgba_int_list(8)
+            if len(c) == 4:
+                self.assertEqual(c, actual)
+            elif len(c) == 3:
+                self.assertEqual(c[0], actual[0])
+                self.assertEqual(c[1], actual[1])
+                self.assertEqual(c[2], actual[2])
+                self.assertEqual(255, actual[3])
+
+    def test_from_float_list(self):
+        colors = (
+            [1.0, 1.0, 1.0],
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0, 0.0],
+        )
+
+        for c in colors:
+            actual = otio.schema.Color.from_float_list(c).to_rgba_float_list()
+            if len(c) == 4:
+                self.assertEqual(c, actual)
+            elif len(c) == 3:
+                self.assertEqual(c[0], actual[0])
+                self.assertEqual(c[1], actual[1])
+                self.assertEqual(c[2], actual[2])
+                self.assertEqual(1.0, actual[3])
+
+
+    def test_from_agbr_int(self):
+        self.assertEqual(otio.schema.Color.from_agbr_int(4281740498).to_hex(), '#d2362cff')
+
+    def test_str(self):
+        cl = otio.schema.Color.ORANGE
+
+        encoded = otio.adapters.otio_json.write_to_string(cl)
+        decoded = otio.adapters.otio_json.read_from_string(encoded)
+        # print('\n', encoded, otio.adapters.otio_json.write_to_string(decoded))
+        self.assertIsOTIOEquivalentTo(cl, decoded)
+
+        self.assertMultiLineEqual(
+            str(cl),
+            'Color({}, {}, {}, {})'.format(
+                cl.r,
+                cl.g,
+                cl.b,
+                cl.a,
+            )
+        )
+        self.assertMultiLineEqual(
+            repr(cl),
+            'otio.schema.Color('
+            'r={}, '
+            'g={}, '
+            'b={}, '
+            'a={})'.format(
+                repr(cl.r),
+                repr(cl.g),
+                repr(cl.b),
+                repr(cl.a),
+            )
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #1614 

**Summarize your change.**

Allow colors to be assigned per track and clip for organizational and tagging purposes. This change contains minimal API changes (colors are optional on both clip and track schemas). This work was part of ASWF Dev Days, thanks for the opportunity!

The new `Color` class with Python bindings also includes:
- Static premade colors for convenience (used list of colors specified in `Marker::Color` for reference)
- Utility functions to convert to different color formats: hex code, agbr integer (for Premiere), list of doubles, list of integers (given a base, e.g. 8-bit, 16-bit)

**Reference associated tests.**

- updated `tests/baselines/empty_clip.json` to compensate for new color entry
- new `test_color.py` test file
- I re-ran the clip and track tests, they ~~seem to be~~ are passing on my end :)

## To Discuss

- `Color` uses doubles to play nice with the serializer since it does not support reading/writing floats. While the extra precision won't hurt anything, some may find it more reasonable to be stored as floats (in which case, we'd need to find a reliable way to support converting to/from doubles for the serializer). As Nick mentioned on Slack, OTIO doesn't have a standard regarding float precision and roundtripping of values. I added a docstring for the pybind's docstring to only expect accuracy within 1/255 of the intended value. 
- I am aware of `Marker::Color` relying on string names instead of values (see #1873). Since integrating there would require a more drastic API change (not to mention more rigorous testing), I figured it was beyond scope. But future API changes and adapters should definitely take advantage of this class.
- I use named the utility functions `from_float_list()` and `to_float_list()` since Python does not differentiate between floats and doubles just for clarity. But let me know if you'd prefer to use `double` in the name, or have it be different between Python and C++.