### PR TITLE
Commented out empty exclude

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -169,7 +169,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-latest]
         python-build: ['cp39', 'cp310', 'cp311', 'cp312']
-        exclude:
+        # exclude:
           # none currently
           # - { os: macos-latest, python-build: 'cp37' }
     steps:


### PR DESCRIPTION
We encountered this error on the GitHub Actions workflow for another PR:

https://github.com/AcademySoftwareFoundation/OpenTimelineIO/actions/runs/15502006126
```
[Invalid workflow file: .github/workflows/python-package.yml#L172](https://github.com/AcademySoftwareFoundation/OpenTimelineIO/actions/runs/15502006126/workflow)
The workflow is not valid. .github/workflows/python-package.yml (Line: 172, Col: 17): Unexpected value ''
```

This PR is a test to see if the culprit is this empty "exclude" statement in the workflow yaml.
