### PR TITLE
Workflow fix, exclude cannot be empty

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -169,9 +169,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-latest]
         python-build: ['cp39', 'cp310', 'cp311', 'cp312']
-        exclude:
-          # none currently
-          # - { os: macos-latest, python-build: 'cp37' }
+        #exclude:
+        #   none currently
+        #   - { os: macos-latest, python-build: 'cp37' }
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The CI jobs have been failing with this error:
```
 Invalid workflow file

The workflow is not valid. .github/workflows/python-package.yml (Line: 172, Col: 17): Unexpected value ''
```

Which I think is coming from the `exclude:` line being empty.