### PR TITLE
moved find_clips function to superclass and added test case

### DIFF
--- a/src/opentimelineio/composition.cpp
+++ b/src/opentimelineio/composition.cpp
@@ -709,4 +709,13 @@ Composition::has_clips() const
     return false;
 }
 
+std::vector<SerializableObject::Retainer<Clip>>
+Composition::find_clips(
+    ErrorStatus*                    error_status,
+    std::optional<TimeRange> const& search_range,
+    bool                            shallow_search) const
+{
+    return find_children<Clip>(error_status, search_range, shallow_search);
+}
+
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/composition.h
+++ b/src/opentimelineio/composition.h
@@ -9,6 +9,8 @@
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
+class Clip;
+
 /// @brief Base class for an Item that contains Composables.
 ///
 /// Should be subclassed (for example by Track Stack), not used directly.
@@ -157,6 +159,17 @@ public:
         ErrorStatus*             error_status   = nullptr,
         std::optional<TimeRange> search_range   = std::nullopt,
         bool                     shallow_search = false) const;
+   
+    /// @brief Find child clips.
+    ///
+    /// @param error_status The return status.
+    /// @param search_range An optional range to limit the search.
+    /// @param shallow_search The search is recursive unless shallow_search is
+    /// set to true.
+    std::vector<Retainer<Clip>> find_clips(
+        ErrorStatus*                    error_status   = nullptr,
+        std::optional<TimeRange> const& search_range   = std::nullopt,
+        bool                            shallow_search = false) const;
 
 protected:
     virtual ~Composition();

--- a/src/opentimelineio/stack.cpp
+++ b/src/opentimelineio/stack.cpp
@@ -133,15 +133,6 @@ Stack::available_range(ErrorStatus* error_status) const
     return TimeRange(RationalTime(0, duration.rate()), duration);
 }
 
-std::vector<SerializableObject::Retainer<Clip>>
-Stack::find_clips(
-    ErrorStatus*                    error_status,
-    std::optional<TimeRange> const& search_range,
-    bool                            shallow_search) const
-{
-    return find_children<Clip>(error_status, search_range, shallow_search);
-}
-
 std::optional<IMATH_NAMESPACE::Box2d>
 Stack::available_image_bounds(ErrorStatus* error_status) const
 {

--- a/src/opentimelineio/stack.h
+++ b/src/opentimelineio/stack.h
@@ -58,17 +58,6 @@ public:
     std::optional<IMATH_NAMESPACE::Box2d>
     available_image_bounds(ErrorStatus* error_status) const override;
 
-    /// @brief Find child clips.
-    ///
-    /// @param error_status The return status.
-    /// @param search_range An optional range to limit the search.
-    /// @param shallow_search The search is recursive unless shallow_search is
-    /// set to true.
-    std::vector<Retainer<Clip>> find_clips(
-        ErrorStatus*                    error_status   = nullptr,
-        std::optional<TimeRange> const& search_range   = std::nullopt,
-        bool                            shallow_search = false) const;
-
 protected:
     virtual ~Stack();
 

--- a/src/opentimelineio/track.cpp
+++ b/src/opentimelineio/track.cpp
@@ -263,15 +263,6 @@ Track::range_of_all_children(ErrorStatus* error_status) const
     return result;
 }
 
-std::vector<SerializableObject::Retainer<Clip>>
-Track::find_clips(
-    ErrorStatus*                    error_status,
-    std::optional<TimeRange> const& search_range,
-    bool                            shallow_search) const
-{
-    return find_children<Clip>(error_status, search_range, shallow_search);
-}
-
 std::optional<IMATH_NAMESPACE::Box2d>
 Track::available_image_bounds(ErrorStatus* error_status) const
 {

--- a/src/opentimelineio/track.h
+++ b/src/opentimelineio/track.h
@@ -81,17 +81,6 @@ public:
     std::optional<IMATH_NAMESPACE::Box2d>
     available_image_bounds(ErrorStatus* error_status) const override;
 
-    /// @brief Find child clips.
-    ///
-    /// @param error_status The return status.
-    /// @param search_range An optional range to limit the search.
-    /// @param shallow_search The search is recursive unless shallow_search is
-    /// set to true.
-    std::vector<Retainer<Clip>> find_clips(
-        ErrorStatus*                    error_status   = nullptr,
-        std::optional<TimeRange> const& search_range   = std::nullopt,
-        bool                            shallow_search = false) const;
-
 protected:
     virtual ~Track();
 

--- a/tests/test_stack_algo.cpp
+++ b/tests/test_stack_algo.cpp
@@ -213,6 +213,22 @@ main(int argc, char** argv)
         assertEqual(result->duration().value(), 300);
     });
 
+    // test stack correctly calls find_clips from superclass
+    tests.add_test(
+        "test_find_clips", [] {
+        using namespace otio;
+        SerializableObject::Retainer<Stack> stack = new Stack();
+        SerializableObject::Retainer<Track> track = new Track;
+        SerializableObject::Retainer<Clip>  clip  = new Clip;
+        stack->append_child(track);
+        track->append_child(clip);
+
+        opentimelineio::v1_0::ErrorStatus err;
+        auto items = stack->find_clips(&err);
+        assertFalse(is_error(err));
+        assertEqual(items.size(), 1);
+    });
+
     tests.run(argc, argv);
     return 0;
 }

--- a/tests/test_track.cpp
+++ b/tests/test_track.cpp
@@ -51,7 +51,7 @@ main(int argc, char** argv)
         opentimelineio::v1_0::ErrorStatus err;
         auto result = tr->find_children<otio::Clip>(
             &err,
-            TimeRange(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0)));
+            TimeRange(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0)));       
         assertEqual(result.size(), 1);
         assertEqual(result[0].value, cl0.value);
         result = tr->find_children<otio::Clip>(
@@ -164,6 +164,20 @@ main(int argc, char** argv)
             std::find(items.begin(), items.end(), track.value) != items.end());
         assertTrue(
             std::find(items.begin(), items.end(), clip.value) != items.end());
+    });
+
+    // test track correctly calls find_clips from superclass
+    tests.add_test(
+        "test_find_clips", [] {
+        using namespace otio;
+        SerializableObject::Retainer<Track> track = new Track;
+        SerializableObject::Retainer<Clip>  clip  = new Clip;
+        track->append_child(clip);
+
+        opentimelineio::v1_0::ErrorStatus err;
+        auto items = track->find_clips(&err);
+        assertFalse(is_error(err));
+        assertEqual(items.size(), 1);
     });
 
     tests.run(argc, argv);


### PR DESCRIPTION
**Summarize your change:**
Moving `find_clips` to the Composition superclass so it only needs to be defined once. It was previously defined in both Track and Stack subclasses.

**Reference associated tests:**
Added a new test called "test_find_clips" to both `test_stack_algo.cpp` and `test_track.cpp`.
