### PR TITLE
Added --remove-effects feature to otiotool.

### DIFF
--- a/src/py-opentimelineio/opentimelineio/console/otiotool.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiotool.py
@@ -65,6 +65,9 @@ def main():
     if args.remove_transitions:
         timelines = filter_transitions(timelines)
 
+    if args.remove_effects:
+        timelines = filter_effects(timelines)
+
     if args.only_tracks_with_name or args.only_tracks_with_index:
         timelines = filter_tracks(
             args.only_tracks_with_name,
@@ -184,10 +187,10 @@ This tool works in phases, as follows:
 
 2. Filtering
     Options such as --video-only, --audio-only, --only-tracks-with-name,
-    -only-tracks-with-index, --only-clips-with-name,
-    --only-clips-with-name-regex, --remove-transitions, and --trim will remove
-    content. Only the tracks, clips, etc. that pass all of the filtering options
-    provided are passed to the next phase.
+    --only-tracks-with-index, --only-clips-with-name,
+    --only-clips-with-name-regex, --remove-transitions, --remove-effects and
+    --trim will remove content. Only the tracks, clips, etc. that pass all of
+    the filtering options provided are passed to the next phase.
 
 3. Combine
     If specified, the --stack, --concat, and --flatten operations are
@@ -294,6 +297,11 @@ otiotool -i playlist.otio --only-audio --list-tracks --inspect "Interview"
         "--remove-transitions",
         action='store_true',
         help="Remove all transitions"
+    )
+    parser.add_argument(
+        "--remove-effects",
+        action='store_true',
+        help="Remove all effects"
     )
     parser.add_argument(
         "--trim",
@@ -499,6 +507,16 @@ def filter_transitions(timelines):
             return None
         return item
     return [otio.algorithms.filtered_composition(t, _f) for t in timelines]
+
+
+def filter_effects(timelines):
+    """Return a copy of the input timelines with all effects removed.
+    The overall duration of the timelines should not be affected, with
+    the possible exception of time warp effects, which are also removed."""
+    for timeline in timelines:
+        for item in timeline.find_children():
+            item.effects[:] = []
+    return timelines
 
 
 def _filter(item, names, patterns):

--- a/src/py-opentimelineio/opentimelineio/console/otiotool.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiotool.py
@@ -510,11 +510,13 @@ def filter_transitions(timelines):
 
 
 def filter_effects(timelines):
-    """Return a copy of the input timelines with all effects removed.
-    The overall duration of the timelines should not be affected, with
-    the possible exception of time warp effects, which are also removed."""
+    """Remove all effects from the input timelines. The inputs are modified
+    in place, and also returned."""
     for timeline in timelines:
-        for item in timeline.find_children():
+        # Items have an effects attribute, but other Composables do not.
+        # (e.g. Transitions) so we need to find only Items.
+        for item in timeline.find_children(descended_from_type=otio.core.Item):
+            # Clear the effects list contents
             item.effects[:] = []
     return timelines
 

--- a/tests/sample_data/effects.otio
+++ b/tests/sample_data/effects.otio
@@ -1,0 +1,6795 @@
+{
+    "OTIO_SCHEMA": "Timeline.1",
+    "metadata": {
+        "Resolve_OTIO": {
+            "Resolve OTIO Meta Version": "1.0"
+        }
+    },
+    "name": "",
+    "global_start_time": {
+        "OTIO_SCHEMA": "RationalTime.1",
+        "rate": 24.0,
+        "value": 86400.0
+    },
+    "tracks": {
+        "OTIO_SCHEMA": "Stack.1",
+        "metadata": {},
+        "name": "",
+        "source_range": null,
+        "effects": [],
+        "markers": [],
+        "enabled": true,
+        "children": [
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "Resolve_OTIO": {
+                        "Locked": false
+                    }
+                },
+                "name": "Video 1",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {}
+                        },
+                        "name": "Picchu_V7_310821_0003.png",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 444.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Transform",
+                                        "Enabled": true,
+                                        "Name": "Transform",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 1.0,
+                                                "Key Frames": {
+                                                    "3": {
+                                                        "Value": 2.110382080078125,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "424": {
+                                                        "InBez": {
+                                                            "InBez": [
+                                                                -49.75,
+                                                                0.0
+                                                            ],
+                                                            "Variant Type": "POINTF"
+                                                        },
+                                                        "Value": 1.5003825426101685,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "transformationZoomX",
+                                                "Parameter Value": 1.1899998188018799,
+                                                "Variant Type": "Double",
+                                                "maxValue": 100.0,
+                                                "minValue": 0.0
+                                            },
+                                            {
+                                                "Default Parameter Value": 1.0,
+                                                "Key Frames": {
+                                                    "3": {
+                                                        "Value": 2.110382080078125,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "424": {
+                                                        "InBez": {
+                                                            "InBez": [
+                                                                -49.75,
+                                                                0.0
+                                                            ],
+                                                            "Variant Type": "POINTF"
+                                                        },
+                                                        "Value": 1.5003825426101685,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "transformationZoomY",
+                                                "Parameter Value": 1.1899998188018799,
+                                                "Variant Type": "Double",
+                                                "maxValue": 100.0,
+                                                "minValue": 0.0
+                                            },
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Key Frames": {
+                                                    "203": {
+                                                        "InBez": {
+                                                            "InBez": [
+                                                                -50.0,
+                                                                -0.009602577785650889
+                                                            ],
+                                                            "Variant Type": "POINTF"
+                                                        },
+                                                        "OutBez": {
+                                                            "OutBez": [
+                                                                50.0,
+                                                                0.009602577785653164
+                                                            ],
+                                                            "Variant Type": "POINTF"
+                                                        },
+                                                        "Value": -0.2515834867954254,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "3": {
+                                                        "Value": -0.2515834867954254,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "424": {
+                                                        "InBez": {
+                                                            "InBez": [
+                                                                -55.25,
+                                                                -0.12587182223796845
+                                                            ],
+                                                            "Variant Type": "POINTF"
+                                                        },
+                                                        "Value": 0.25190380215644839,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "transformationPan",
+                                                "Parameter Value": 0.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 4.0,
+                                                "minValue": -4.0
+                                            },
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Key Frames": {
+                                                    "203": {
+                                                        "InBez": {
+                                                            "InBez": [
+                                                                -50.0,
+                                                                -0.03884801547974348
+                                                            ],
+                                                            "Variant Type": "POINTF"
+                                                        },
+                                                        "OutBez": {
+                                                            "OutBez": [
+                                                                50.0,
+                                                                0.03884801547974348
+                                                            ],
+                                                            "Variant Type": "POINTF"
+                                                        },
+                                                        "Value": 0.17423609438984523,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "3": {
+                                                        "Value": 0.02886868268251419,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "424": {
+                                                        "InBez": {
+                                                            "InBez": [
+                                                                -55.25,
+                                                                -0.041354178032654179
+                                                            ],
+                                                            "Variant Type": "POINTF"
+                                                        },
+                                                        "Value": 0.33965280652046206,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "transformationTilt",
+                                                "Parameter Value": 0.11501597613096237,
+                                                "Variant Type": "Double",
+                                                "maxValue": 4.0,
+                                                "minValue": -4.0
+                                            }
+                                        ],
+                                        "Type": 2
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Cropping",
+                                        "Enabled": true,
+                                        "Name": "Cropping",
+                                        "Parameters": [],
+                                        "Type": 3
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Dynamic Zoom",
+                                        "Enabled": false,
+                                        "Name": "Dynamic Zoom",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": [
+                                                    0.0,
+                                                    0.0
+                                                ],
+                                                "Key Frames": {
+                                                    "-85200": {
+                                                        "Value": [
+                                                            0.0,
+                                                            0.0
+                                                        ],
+                                                        "Variant Type": "POINTF"
+                                                    },
+                                                    "-86200": {
+                                                        "Value": [
+                                                            0.0,
+                                                            0.0
+                                                        ],
+                                                        "Variant Type": "POINTF"
+                                                    }
+                                                },
+                                                "Parameter ID": "dynamicZoomCenter",
+                                                "Parameter Value": [
+                                                    0.0,
+                                                    0.0
+                                                ],
+                                                "Variant Type": "POINTF"
+                                            },
+                                            {
+                                                "Default Parameter Value": 1.0,
+                                                "Key Frames": {
+                                                    "-85200": {
+                                                        "Value": 1.0,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "-86200": {
+                                                        "Value": 0.8,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "dynamicZoomScale",
+                                                "Parameter Value": 1.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 100.0,
+                                                "minValue": 0.01
+                                            }
+                                        ],
+                                        "Type": 59
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Composite",
+                                        "Enabled": true,
+                                        "Name": "Composite",
+                                        "Parameters": [],
+                                        "Type": 1
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Lens Correction",
+                                        "Enabled": true,
+                                        "Name": "Lens Correction",
+                                        "Parameters": [],
+                                        "Type": 43
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Retime and Scaling",
+                                        "Enabled": true,
+                                        "Name": "Retime and Scaling",
+                                        "Parameters": [],
+                                        "Type": 22
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Video Faders",
+                                        "Enabled": true,
+                                        "Name": "Video Faders",
+                                        "Parameters": [],
+                                        "Type": 36
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            }
+                        ],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "metadata": {},
+                                "name": "Picchu_V7_310821_0003.png",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 1.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null,
+                                "target_url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/frames/Picchu_V7_310821_0003.png"
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {}
+                        },
+                        "name": "Picchu_V7_310821_0005.png",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 56.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "metadata": {},
+                                "name": "Picchu_V7_310821_0005.png",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 1.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null,
+                                "target_url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/frames/Picchu_V7_310821_0005.png"
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {}
+                        },
+                        "name": "Picchu_V7_310821_0006.png",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 13.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "metadata": {},
+                                "name": "Picchu_V7_310821_0006.png",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 1.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null,
+                                "target_url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/frames/Picchu_V7_310821_0006.png"
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {}
+                        },
+                        "name": "Picchu_V7_310821_0007.png",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 18.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "metadata": {},
+                                "name": "Picchu_V7_310821_0007.png",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 1.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null,
+                                "target_url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/frames/Picchu_V7_310821_0007.png"
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {}
+                        },
+                        "name": "Picchu_V7_310821_0009.png",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 30.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "metadata": {},
+                                "name": "Picchu_V7_310821_0009.png",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 1.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null,
+                                "target_url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/frames/Picchu_V7_310821_0009.png"
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {}
+                        },
+                        "name": "Picchu_V7_310821_0010.png",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 34.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "metadata": {},
+                                "name": "Picchu_V7_310821_0010.png",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 1.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null,
+                                "target_url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/frames/Picchu_V7_310821_0010.png"
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {}
+                        },
+                        "name": "Picchu_V7_310821_0011.png",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 18.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "metadata": {},
+                                "name": "Picchu_V7_310821_0011.png",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 1.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null,
+                                "target_url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/frames/Picchu_V7_310821_0011.png"
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {}
+                        },
+                        "name": "Picchu_V7_310821_0012.png",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 16.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "metadata": {},
+                                "name": "Picchu_V7_310821_0012.png",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 1.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null,
+                                "target_url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/frames/Picchu_V7_310821_0012.png"
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {}
+                        },
+                        "name": "Picchu_V7_310821_0013.png",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 42.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "metadata": {},
+                                "name": "Picchu_V7_310821_0013.png",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 1.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null,
+                                "target_url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/frames/Picchu_V7_310821_0013.png"
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {}
+                        },
+                        "name": "Panel 3.3.5.png",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 145.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "metadata": {},
+                                "name": "Panel 3.3.5.png",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 1.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null,
+                                "target_url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/frames_v2/Panel 3.3.5.png"
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {}
+                        },
+                        "name": "Panel 3.3.5.png",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 202.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "metadata": {},
+                                "name": "Panel 3.3.5.png",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 1.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null,
+                                "target_url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/frames_v2/Panel 3.3.5.png"
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {}
+                        },
+                        "name": "Picchu_V7_310821_0014.png",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 37.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "metadata": {},
+                                "name": "Picchu_V7_310821_0014.png",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 1.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null,
+                                "target_url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/frames/Picchu_V7_310821_0014.png"
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {}
+                        },
+                        "name": "Picchu_V7_310821_0015.png",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 70.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Transform",
+                                        "Enabled": true,
+                                        "Name": "Transform",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 1.0,
+                                                "Key Frames": {
+                                                    "0": {
+                                                        "Value": 1.0,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "67": {
+                                                        "Value": 1.179999828338623,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "transformationZoomX",
+                                                "Parameter Value": 1.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 100.0,
+                                                "minValue": 0.0
+                                            },
+                                            {
+                                                "Default Parameter Value": 1.0,
+                                                "Key Frames": {
+                                                    "0": {
+                                                        "Value": 1.0,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "67": {
+                                                        "Value": 1.179999828338623,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "transformationZoomY",
+                                                "Parameter Value": 1.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 100.0,
+                                                "minValue": 0.0
+                                            },
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Key Frames": {
+                                                    "0": {
+                                                        "Value": 0.0,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "67": {
+                                                        "Value": -0.0234375,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "transformationPan",
+                                                "Parameter Value": 0.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 4.0,
+                                                "minValue": -4.0
+                                            },
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Key Frames": {
+                                                    "0": {
+                                                        "Value": 0.0,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "67": {
+                                                        "Value": -0.043130990117788318,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "transformationTilt",
+                                                "Parameter Value": 0.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 4.0,
+                                                "minValue": -4.0
+                                            }
+                                        ],
+                                        "Type": 2
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Cropping",
+                                        "Enabled": true,
+                                        "Name": "Cropping",
+                                        "Parameters": [],
+                                        "Type": 3
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Dynamic Zoom",
+                                        "Enabled": false,
+                                        "Name": "Dynamic Zoom",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": [
+                                                    0.0,
+                                                    0.0
+                                                ],
+                                                "Key Frames": {
+                                                    "-85384": {
+                                                        "Value": [
+                                                            0.0,
+                                                            0.0
+                                                        ],
+                                                        "Variant Type": "POINTF"
+                                                    },
+                                                    "-86384": {
+                                                        "Value": [
+                                                            0.0,
+                                                            0.0
+                                                        ],
+                                                        "Variant Type": "POINTF"
+                                                    }
+                                                },
+                                                "Parameter ID": "dynamicZoomCenter",
+                                                "Parameter Value": [
+                                                    0.0,
+                                                    0.0
+                                                ],
+                                                "Variant Type": "POINTF"
+                                            },
+                                            {
+                                                "Default Parameter Value": 1.0,
+                                                "Key Frames": {
+                                                    "-85384": {
+                                                        "Value": 1.0,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "-86384": {
+                                                        "Value": 0.8,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "dynamicZoomScale",
+                                                "Parameter Value": 1.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 100.0,
+                                                "minValue": 0.01
+                                            }
+                                        ],
+                                        "Type": 59
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Composite",
+                                        "Enabled": true,
+                                        "Name": "Composite",
+                                        "Parameters": [],
+                                        "Type": 1
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Lens Correction",
+                                        "Enabled": true,
+                                        "Name": "Lens Correction",
+                                        "Parameters": [],
+                                        "Type": 43
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Retime and Scaling",
+                                        "Enabled": true,
+                                        "Name": "Retime and Scaling",
+                                        "Parameters": [],
+                                        "Type": 22
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Video Faders",
+                                        "Enabled": true,
+                                        "Name": "Video Faders",
+                                        "Parameters": [],
+                                        "Type": 36
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            }
+                        ],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "metadata": {},
+                                "name": "Picchu_V7_310821_0015.png",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 1.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null,
+                                "target_url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/frames/Picchu_V7_310821_0015.png"
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    }
+                ],
+                "kind": "Video"
+            },
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "Resolve_OTIO": {
+                        "Locked": false
+                    }
+                },
+                "name": "Video 2",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {}
+                        },
+                        "name": "A_title.png",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 444.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Transform",
+                                        "Enabled": true,
+                                        "Name": "Transform",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 1.0,
+                                                "Key Frames": {
+                                                    "3": {
+                                                        "Value": 2.110382080078125,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "424": {
+                                                        "InBez": {
+                                                            "InBez": [
+                                                                -49.75,
+                                                                0.0
+                                                            ],
+                                                            "Variant Type": "POINTF"
+                                                        },
+                                                        "Value": 1.5003825426101685,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "transformationZoomX",
+                                                "Parameter Value": 1.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 100.0,
+                                                "minValue": 0.0
+                                            },
+                                            {
+                                                "Default Parameter Value": 1.0,
+                                                "Key Frames": {
+                                                    "3": {
+                                                        "Value": 2.110382080078125,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "424": {
+                                                        "InBez": {
+                                                            "InBez": [
+                                                                -49.75,
+                                                                0.0
+                                                            ],
+                                                            "Variant Type": "POINTF"
+                                                        },
+                                                        "Value": 1.5003825426101685,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "transformationZoomY",
+                                                "Parameter Value": 1.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 100.0,
+                                                "minValue": 0.0
+                                            },
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Key Frames": {
+                                                    "203": {
+                                                        "InBez": {
+                                                            "InBez": [
+                                                                -50.0,
+                                                                -0.009602577785650889
+                                                            ],
+                                                            "Variant Type": "POINTF"
+                                                        },
+                                                        "OutBez": {
+                                                            "OutBez": [
+                                                                50.0,
+                                                                0.009602577785653164
+                                                            ],
+                                                            "Variant Type": "POINTF"
+                                                        },
+                                                        "Value": -0.2515834867954254,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "3": {
+                                                        "Value": -0.2515834867954254,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "424": {
+                                                        "InBez": {
+                                                            "InBez": [
+                                                                -55.25,
+                                                                -0.12587182223796845
+                                                            ],
+                                                            "Variant Type": "POINTF"
+                                                        },
+                                                        "Value": 0.25190380215644839,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "transformationPan",
+                                                "Parameter Value": 0.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 4.0,
+                                                "minValue": -4.0
+                                            },
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Key Frames": {
+                                                    "203": {
+                                                        "InBez": {
+                                                            "InBez": [
+                                                                -50.0,
+                                                                -0.03884801547974348
+                                                            ],
+                                                            "Variant Type": "POINTF"
+                                                        },
+                                                        "OutBez": {
+                                                            "OutBez": [
+                                                                50.0,
+                                                                0.03884801547974348
+                                                            ],
+                                                            "Variant Type": "POINTF"
+                                                        },
+                                                        "Value": 0.17423609438984523,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "3": {
+                                                        "Value": 0.02886868268251419,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "424": {
+                                                        "InBez": {
+                                                            "InBez": [
+                                                                -55.25,
+                                                                -0.041354178032654179
+                                                            ],
+                                                            "Variant Type": "POINTF"
+                                                        },
+                                                        "Value": 0.33965280652046206,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "transformationTilt",
+                                                "Parameter Value": 0.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 4.0,
+                                                "minValue": -4.0
+                                            }
+                                        ],
+                                        "Type": 2
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Cropping",
+                                        "Enabled": true,
+                                        "Name": "Cropping",
+                                        "Parameters": [],
+                                        "Type": 3
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Dynamic Zoom",
+                                        "Enabled": false,
+                                        "Name": "Dynamic Zoom",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": [
+                                                    0.0,
+                                                    0.0
+                                                ],
+                                                "Key Frames": {
+                                                    "-85212": {
+                                                        "Value": [
+                                                            0.0,
+                                                            0.0
+                                                        ],
+                                                        "Variant Type": "POINTF"
+                                                    },
+                                                    "-86212": {
+                                                        "Value": [
+                                                            0.0,
+                                                            0.0
+                                                        ],
+                                                        "Variant Type": "POINTF"
+                                                    }
+                                                },
+                                                "Parameter ID": "dynamicZoomCenter",
+                                                "Parameter Value": [
+                                                    0.0,
+                                                    0.0
+                                                ],
+                                                "Variant Type": "POINTF"
+                                            },
+                                            {
+                                                "Default Parameter Value": 1.0,
+                                                "Key Frames": {
+                                                    "-85212": {
+                                                        "Value": 1.0,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "-86212": {
+                                                        "Value": 0.8,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "dynamicZoomScale",
+                                                "Parameter Value": 1.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 100.0,
+                                                "minValue": 0.01
+                                            }
+                                        ],
+                                        "Type": 59
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Composite",
+                                        "Enabled": true,
+                                        "Name": "Composite",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 100.0,
+                                                "Key Frames": {
+                                                    "316": {
+                                                        "Value": 100.0,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "370": {
+                                                        "Value": 0.0,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "73": {
+                                                        "Value": 0.0,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "98": {
+                                                        "Value": 100.0,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "opacity",
+                                                "Parameter Value": 0.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 100.0,
+                                                "minValue": 0.0
+                                            }
+                                        ],
+                                        "Type": 1
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Lens Correction",
+                                        "Enabled": true,
+                                        "Name": "Lens Correction",
+                                        "Parameters": [],
+                                        "Type": 43
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Retime and Scaling",
+                                        "Enabled": true,
+                                        "Name": "Retime and Scaling",
+                                        "Parameters": [],
+                                        "Type": 22
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Video Faders",
+                                        "Enabled": true,
+                                        "Name": "Video Faders",
+                                        "Parameters": [],
+                                        "Type": 36
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            }
+                        ],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "metadata": {},
+                                "name": "A_title.png",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 1.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null,
+                                "target_url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/frames/A_title.png"
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "metadata": {},
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 681.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true
+                    }
+                ],
+                "kind": "Video"
+            },
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "Resolve_OTIO": {
+                        "Locked": false
+                    }
+                },
+                "name": "Video 3",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {}
+                        },
+                        "name": "_bar.png",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 444.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Transform",
+                                        "Enabled": true,
+                                        "Name": "Transform",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 1.0,
+                                                "Key Frames": {
+                                                    "265": {
+                                                        "Value": 1.0,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "transformationZoomX",
+                                                "Parameter Value": 1.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 100.0,
+                                                "minValue": 0.0
+                                            },
+                                            {
+                                                "Default Parameter Value": 1.0,
+                                                "Key Frames": {
+                                                    "265": {
+                                                        "Value": 1.0,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "transformationZoomY",
+                                                "Parameter Value": 1.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 100.0,
+                                                "minValue": 0.0
+                                            },
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Key Frames": {
+                                                    "265": {
+                                                        "Value": 0.0,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "transformationPan",
+                                                "Parameter Value": 0.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 4.0,
+                                                "minValue": -4.0
+                                            },
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Key Frames": {
+                                                    "265": {
+                                                        "Value": -1.6506849527359009,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "transformationTilt",
+                                                "Parameter Value": -1.6506849527359009,
+                                                "Variant Type": "Double",
+                                                "maxValue": 4.0,
+                                                "minValue": -4.0
+                                            }
+                                        ],
+                                        "Type": 2
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Cropping",
+                                        "Enabled": true,
+                                        "Name": "Cropping",
+                                        "Parameters": [],
+                                        "Type": 3
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Dynamic Zoom",
+                                        "Enabled": false,
+                                        "Name": "Dynamic Zoom",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": [
+                                                    0.0,
+                                                    0.0
+                                                ],
+                                                "Key Frames": {
+                                                    "-85341": {
+                                                        "Value": [
+                                                            0.0,
+                                                            0.0
+                                                        ],
+                                                        "Variant Type": "POINTF"
+                                                    },
+                                                    "-86341": {
+                                                        "Value": [
+                                                            0.0,
+                                                            0.0
+                                                        ],
+                                                        "Variant Type": "POINTF"
+                                                    }
+                                                },
+                                                "Parameter ID": "dynamicZoomCenter",
+                                                "Parameter Value": [
+                                                    0.0,
+                                                    0.0
+                                                ],
+                                                "Variant Type": "POINTF"
+                                            },
+                                            {
+                                                "Default Parameter Value": 1.0,
+                                                "Key Frames": {
+                                                    "-85341": {
+                                                        "Value": 1.0,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "-86341": {
+                                                        "Value": 0.8,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "dynamicZoomScale",
+                                                "Parameter Value": 1.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 100.0,
+                                                "minValue": 0.01
+                                            }
+                                        ],
+                                        "Type": 59
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Composite",
+                                        "Enabled": true,
+                                        "Name": "Composite",
+                                        "Parameters": [],
+                                        "Type": 1
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Lens Correction",
+                                        "Enabled": true,
+                                        "Name": "Lens Correction",
+                                        "Parameters": [],
+                                        "Type": 43
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Retime and Scaling",
+                                        "Enabled": true,
+                                        "Name": "Retime and Scaling",
+                                        "Parameters": [],
+                                        "Type": 22
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Video Faders",
+                                        "Enabled": true,
+                                        "Name": "Video Faders",
+                                        "Parameters": [],
+                                        "Type": 36
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            }
+                        ],
+                        "markers": [],
+                        "enabled": false,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "metadata": {},
+                                "name": "_bar.png",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 1.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null,
+                                "target_url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/frames/_bar.png"
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "metadata": {},
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 681.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true
+                    }
+                ],
+                "kind": "Video"
+            },
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "Resolve_OTIO": {
+                        "Locked": false
+                    }
+                },
+                "name": "Video 4",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {}
+                        },
+                        "name": "A_title.png",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 444.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Transform",
+                                        "Enabled": true,
+                                        "Name": "Transform",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 1.0,
+                                                "Key Frames": {
+                                                    "252": {
+                                                        "InBez": {
+                                                            "InBez": [
+                                                                -104.21834821101271,
+                                                                -0.02666666666666667
+                                                            ],
+                                                            "Variant Type": "POINTF"
+                                                        },
+                                                        "Value": 1.8203825426101688,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "65": {
+                                                        "Value": 2.110382080078125,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "transformationZoomX",
+                                                "Parameter Value": 1.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 100.0,
+                                                "minValue": 0.0
+                                            },
+                                            {
+                                                "Default Parameter Value": 1.0,
+                                                "Key Frames": {
+                                                    "252": {
+                                                        "InBez": {
+                                                            "InBez": [
+                                                                -104.21834821101271,
+                                                                -0.02666666666666667
+                                                            ],
+                                                            "Variant Type": "POINTF"
+                                                        },
+                                                        "Value": 1.8203825426101688,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "65": {
+                                                        "Value": 2.110382080078125,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "transformationZoomY",
+                                                "Parameter Value": 1.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 100.0,
+                                                "minValue": 0.0
+                                            },
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Key Frames": {
+                                                    "265": {
+                                                        "InBez": {
+                                                            "InBez": [
+                                                                -50.0,
+                                                                -0.009602577785650889
+                                                            ],
+                                                            "Variant Type": "POINTF"
+                                                        },
+                                                        "OutBez": {
+                                                            "OutBez": [
+                                                                50.0,
+                                                                0.009602577785653164
+                                                            ],
+                                                            "Variant Type": "POINTF"
+                                                        },
+                                                        "Value": -0.2515834867954254,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "486": {
+                                                        "InBez": {
+                                                            "InBez": [
+                                                                -55.25,
+                                                                -0.12587182223796845
+                                                            ],
+                                                            "Variant Type": "POINTF"
+                                                        },
+                                                        "Value": 0.25190380215644839,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "65": {
+                                                        "Value": -0.2515834867954254,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "transformationPan",
+                                                "Parameter Value": 0.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 4.0,
+                                                "minValue": -4.0
+                                            },
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Key Frames": {
+                                                    "265": {
+                                                        "InBez": {
+                                                            "InBez": [
+                                                                -50.0,
+                                                                -0.03884801547974348
+                                                            ],
+                                                            "Variant Type": "POINTF"
+                                                        },
+                                                        "OutBez": {
+                                                            "OutBez": [
+                                                                50.0,
+                                                                0.03884801547974348
+                                                            ],
+                                                            "Variant Type": "POINTF"
+                                                        },
+                                                        "Value": 0.17423609438984523,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "486": {
+                                                        "InBez": {
+                                                            "InBez": [
+                                                                -55.25,
+                                                                -0.041354178032654179
+                                                            ],
+                                                            "Variant Type": "POINTF"
+                                                        },
+                                                        "Value": 0.33965280652046206,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "65": {
+                                                        "Value": 0.02886868268251419,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "transformationTilt",
+                                                "Parameter Value": 0.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 4.0,
+                                                "minValue": -4.0
+                                            }
+                                        ],
+                                        "Type": 2
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Cropping",
+                                        "Enabled": true,
+                                        "Name": "Cropping",
+                                        "Parameters": [],
+                                        "Type": 3
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Dynamic Zoom",
+                                        "Enabled": false,
+                                        "Name": "Dynamic Zoom",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": [
+                                                    0.0,
+                                                    0.0
+                                                ],
+                                                "Key Frames": {
+                                                    "-85150": {
+                                                        "Value": [
+                                                            0.0,
+                                                            0.0
+                                                        ],
+                                                        "Variant Type": "POINTF"
+                                                    },
+                                                    "-86150": {
+                                                        "Value": [
+                                                            0.0,
+                                                            0.0
+                                                        ],
+                                                        "Variant Type": "POINTF"
+                                                    }
+                                                },
+                                                "Parameter ID": "dynamicZoomCenter",
+                                                "Parameter Value": [
+                                                    0.0,
+                                                    0.0
+                                                ],
+                                                "Variant Type": "POINTF"
+                                            },
+                                            {
+                                                "Default Parameter Value": 1.0,
+                                                "Key Frames": {
+                                                    "-85150": {
+                                                        "Value": 1.0,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "-86150": {
+                                                        "Value": 0.8,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "dynamicZoomScale",
+                                                "Parameter Value": 1.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 100.0,
+                                                "minValue": 0.01
+                                            }
+                                        ],
+                                        "Type": 59
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Composite",
+                                        "Enabled": true,
+                                        "Name": "Composite",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 100.0,
+                                                "Key Frames": {
+                                                    "132": {
+                                                        "Value": 0.0,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "183": {
+                                                        "Value": 98.66666666666667,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "378": {
+                                                        "Value": 100.0,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "432": {
+                                                        "Value": 0.0,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "opacity",
+                                                "Parameter Value": 0.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 100.0,
+                                                "minValue": 0.0
+                                            }
+                                        ],
+                                        "Type": 1
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Lens Correction",
+                                        "Enabled": true,
+                                        "Name": "Lens Correction",
+                                        "Parameters": [],
+                                        "Type": 43
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Retime and Scaling",
+                                        "Enabled": true,
+                                        "Name": "Retime and Scaling",
+                                        "Parameters": [],
+                                        "Type": 22
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Video Faders",
+                                        "Enabled": true,
+                                        "Name": "Video Faders",
+                                        "Parameters": [],
+                                        "Type": 36
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            }
+                        ],
+                        "markers": [],
+                        "enabled": false,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "metadata": {},
+                                "name": "A_title.png",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 1.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null,
+                                "target_url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/frames/A_title.png"
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "metadata": {},
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 681.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true
+                    }
+                ],
+                "kind": "Video"
+            },
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "Resolve_OTIO": {
+                        "Locked": false
+                    }
+                },
+                "name": "Video 5",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {}
+                        },
+                        "name": "sq0100_sh0010_layout_v004.mp4",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 500.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Transform",
+                                        "Enabled": true,
+                                        "Name": "Transform",
+                                        "Parameters": [],
+                                        "Type": 2
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Cropping",
+                                        "Enabled": true,
+                                        "Name": "Cropping",
+                                        "Parameters": [],
+                                        "Type": 3
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Dynamic Zoom",
+                                        "Enabled": false,
+                                        "Name": "Dynamic Zoom",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": [
+                                                    0.0,
+                                                    0.0
+                                                ],
+                                                "Key Frames": {
+                                                    "0": {
+                                                        "Value": [
+                                                            0.0,
+                                                            0.0
+                                                        ],
+                                                        "Variant Type": "POINTF"
+                                                    },
+                                                    "1000": {
+                                                        "Value": [
+                                                            0.0,
+                                                            0.0
+                                                        ],
+                                                        "Variant Type": "POINTF"
+                                                    }
+                                                },
+                                                "Parameter ID": "dynamicZoomCenter",
+                                                "Parameter Value": [
+                                                    0.0,
+                                                    0.0
+                                                ],
+                                                "Variant Type": "POINTF"
+                                            },
+                                            {
+                                                "Default Parameter Value": 1.0,
+                                                "Key Frames": {
+                                                    "0": {
+                                                        "Value": 0.8,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "1000": {
+                                                        "Value": 1.0,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "dynamicZoomScale",
+                                                "Parameter Value": 1.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 100.0,
+                                                "minValue": 0.01
+                                            }
+                                        ],
+                                        "Type": 59
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Composite",
+                                        "Enabled": true,
+                                        "Name": "Composite",
+                                        "Parameters": [],
+                                        "Type": 1
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Lens Correction",
+                                        "Enabled": true,
+                                        "Name": "Lens Correction",
+                                        "Parameters": [],
+                                        "Type": 43
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Retime and Scaling",
+                                        "Enabled": true,
+                                        "Name": "Retime and Scaling",
+                                        "Parameters": [],
+                                        "Type": 22
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Video Faders",
+                                        "Enabled": true,
+                                        "Name": "Video Faders",
+                                        "Parameters": [],
+                                        "Type": 36
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            }
+                        ],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "MissingReference.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Media Url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/Layout/delivery_001/sq0100_sh0010_layout_v004.mp4"
+                                    }
+                                },
+                                "name": "sq0100_sh0010_layout_v004.mp4",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 500.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {}
+                        },
+                        "name": "sq0100_sh0020_layout_v005.mp4",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 316.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "MissingReference.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Media Url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/Layout/delivery_002/sq0100_sh0020_layout_v005.mp4"
+                                    }
+                                },
+                                "name": "sq0100_sh0020_layout_v005.mp4",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 316.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {}
+                        },
+                        "name": "sq0100_sh0030_layout_v004.mp4",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 211.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "MissingReference.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Media Url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/Layout/delivery_001/sq0100_sh0030_layout_v004.mp4"
+                                    }
+                                },
+                                "name": "sq0100_sh0030_layout_v004.mp4",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 211.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {}
+                        },
+                        "name": "sq0100_sh0050_layout_v004.mp4",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 98.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "MissingReference.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Media Url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/Layout/delivery_001/sq0100_sh0050_layout_v004.mp4"
+                                    }
+                                },
+                                "name": "sq0100_sh0050_layout_v004.mp4",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 98.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    }
+                ],
+                "kind": "Video"
+            },
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "Resolve_OTIO": {
+                        "Locked": false
+                    }
+                },
+                "name": "Video 6",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "metadata": {},
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 1125.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true
+                    }
+                ],
+                "kind": "Video"
+            },
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "Resolve_OTIO": {
+                        "Locked": false
+                    }
+                },
+                "name": "Video 7",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "metadata": {},
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 1125.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true
+                    }
+                ],
+                "kind": "Video"
+            },
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "Resolve_OTIO": {
+                        "Locked": false
+                    }
+                },
+                "name": "Video 8",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "metadata": {},
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 1125.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true
+                    }
+                ],
+                "kind": "Video"
+            },
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "Resolve_OTIO": {
+                        "Audio Type": "Stereo",
+                        "Locked": false,
+                        "SoloOn": false
+                    }
+                },
+                "name": "Audio 1",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "metadata": {},
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 1125.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true
+                    }
+                ],
+                "kind": "Audio"
+            },
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "Resolve_OTIO": {
+                        "Audio Type": "Stereo",
+                        "Locked": false,
+                        "SoloOn": false
+                    }
+                },
+                "name": "Audio 2",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "metadata": {},
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 347.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {
+                                "Channels": [
+                                    {
+                                        "Source Channel ID": 0,
+                                        "Source Track ID": 0
+                                    },
+                                    {
+                                        "Source Channel ID": 1,
+                                        "Source Track ID": 0
+                                    }
+                                ]
+                            }
+                        },
+                        "name": "06_Mayu_Sfx_ladderStruggleAhhagg.wav",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 85.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 40.0
+                            }
+                        },
+                        "effects": [
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Volume and Fades",
+                                        "Enabled": true,
+                                        "Name": "Volume",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Key Frames": {},
+                                                "Parameter ID": "volume",
+                                                "Parameter Value": -16.999998092651368,
+                                                "Variant Type": "Double",
+                                                "maxValue": 30.0,
+                                                "minValue": -100.0
+                                            }
+                                        ],
+                                        "Type": 62
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pan",
+                                        "Enabled": true,
+                                        "Name": "Pan",
+                                        "Parameters": [],
+                                        "Type": 72
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pitch",
+                                        "Enabled": true,
+                                        "Name": "Pitch",
+                                        "Parameters": [],
+                                        "Type": 67
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Equaliser",
+                                        "Enabled": false,
+                                        "Name": "Equalizer",
+                                        "Parameters": [],
+                                        "Type": 64
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 0,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 1,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 1,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 2,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 2,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 3,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 3,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            }
+                        ],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "metadata": {},
+                                "name": "06_Mayu_Sfx_ladderStruggleAhhagg.wav",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 1139.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null,
+                                "target_url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/Mayu_Saywa_Kathy/wav/06_Mayu_Sfx_ladderStruggleAhhagg.wav"
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "metadata": {},
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 40.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {
+                                "Channels": [
+                                    {
+                                        "Source Channel ID": 0,
+                                        "Source Track ID": 0
+                                    },
+                                    {
+                                        "Source Channel ID": 1,
+                                        "Source Track ID": 0
+                                    }
+                                ]
+                            }
+                        },
+                        "name": "06_Mayu_Sfx_ladderStruggleAhhagg.wav",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 28.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 354.0
+                            }
+                        },
+                        "effects": [
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Volume and Fades",
+                                        "Enabled": true,
+                                        "Name": "Volume",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Key Frames": {},
+                                                "Parameter ID": "volume",
+                                                "Parameter Value": -8.600000083446503,
+                                                "Variant Type": "Double",
+                                                "maxValue": 30.0,
+                                                "minValue": -100.0
+                                            }
+                                        ],
+                                        "Type": 62
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pan",
+                                        "Enabled": true,
+                                        "Name": "Pan",
+                                        "Parameters": [],
+                                        "Type": 72
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pitch",
+                                        "Enabled": true,
+                                        "Name": "Pitch",
+                                        "Parameters": [],
+                                        "Type": 67
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Equaliser",
+                                        "Enabled": false,
+                                        "Name": "Equalizer",
+                                        "Parameters": [],
+                                        "Type": 64
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 0,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 1,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 1,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 2,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 2,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 3,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 3,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            }
+                        ],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "metadata": {},
+                                "name": "06_Mayu_Sfx_ladderStruggleAhhagg.wav",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 1139.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null,
+                                "target_url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/Mayu_Saywa_Kathy/wav/06_Mayu_Sfx_ladderStruggleAhhagg.wav"
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "metadata": {},
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 625.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true
+                    }
+                ],
+                "kind": "Audio"
+            },
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "Resolve_OTIO": {
+                        "Audio Type": "Stereo",
+                        "Locked": false,
+                        "SoloOn": false
+                    }
+                },
+                "name": "Audio 3",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "metadata": {},
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 220.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {
+                                "Channels": [
+                                    {
+                                        "Source Channel ID": 0,
+                                        "Source Track ID": 0
+                                    },
+                                    {
+                                        "Source Channel ID": 1,
+                                        "Source Track ID": 0
+                                    }
+                                ]
+                            }
+                        },
+                        "name": "MayuYize_-01.wav",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 53.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Volume and Fades",
+                                        "Enabled": true,
+                                        "Name": "Volume",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Key Frames": {},
+                                                "Parameter ID": "volume",
+                                                "Parameter Value": 13.85869565217391,
+                                                "Variant Type": "Double",
+                                                "maxValue": 30.0,
+                                                "minValue": -100.0
+                                            }
+                                        ],
+                                        "Type": 62
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pan",
+                                        "Enabled": true,
+                                        "Name": "Pan",
+                                        "Parameters": [],
+                                        "Type": 72
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pitch",
+                                        "Enabled": true,
+                                        "Name": "Pitch",
+                                        "Parameters": [],
+                                        "Type": 67
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Equaliser",
+                                        "Enabled": false,
+                                        "Name": "Equalizer",
+                                        "Parameters": [],
+                                        "Type": 64
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 0,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 1,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 1,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 2,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 2,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 3,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 3,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            }
+                        ],
+                        "markers": [],
+                        "enabled": false,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "metadata": {},
+                                "name": "MayuYize_-01.wav",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 168.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null,
+                                "target_url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/Mayu_Yize/MayuYize_-01.wav"
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "metadata": {},
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 717.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {
+                                "Channels": [
+                                    {
+                                        "Source Channel ID": 0,
+                                        "Source Track ID": 0
+                                    },
+                                    {
+                                        "Source Channel ID": 1,
+                                        "Source Track ID": 0
+                                    }
+                                ]
+                            }
+                        },
+                        "name": "MayuYize_-03.wav",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 37.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Volume and Fades",
+                                        "Enabled": true,
+                                        "Name": "Volume",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Key Frames": {},
+                                                "Parameter ID": "volume",
+                                                "Parameter Value": 11.413043478260864,
+                                                "Variant Type": "Double",
+                                                "maxValue": 30.0,
+                                                "minValue": -100.0
+                                            }
+                                        ],
+                                        "Type": 62
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pan",
+                                        "Enabled": true,
+                                        "Name": "Pan",
+                                        "Parameters": [],
+                                        "Type": 72
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pitch",
+                                        "Enabled": true,
+                                        "Name": "Pitch",
+                                        "Parameters": [],
+                                        "Type": 67
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Equaliser",
+                                        "Enabled": false,
+                                        "Name": "Equalizer",
+                                        "Parameters": [],
+                                        "Type": 64
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 0,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 1,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 1,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 2,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 2,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 3,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 3,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            }
+                        ],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "metadata": {},
+                                "name": "MayuYize_-03.wav",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 107.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null,
+                                "target_url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/Mayu_Yize/MayuYize_-03.wav"
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "metadata": {},
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 98.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true
+                    }
+                ],
+                "kind": "Audio"
+            },
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "Resolve_OTIO": {
+                        "Audio Type": "Stereo",
+                        "Locked": false,
+                        "SoloOn": false
+                    }
+                },
+                "name": "Audio 4",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "metadata": {},
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 1125.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true
+                    }
+                ],
+                "kind": "Audio"
+            },
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "Resolve_OTIO": {
+                        "Audio Type": "Stereo",
+                        "Locked": false,
+                        "SoloOn": false
+                    }
+                },
+                "name": "Audio 5",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "metadata": {},
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 444.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {
+                                "Channels": [
+                                    {
+                                        "Source Channel ID": 0,
+                                        "Source Track ID": 0
+                                    },
+                                    {
+                                        "Source Channel ID": 1,
+                                        "Source Track ID": 0
+                                    }
+                                ]
+                            }
+                        },
+                        "name": "Slide On Concrete Sound Effect (128 kbps).mp3",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 12.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 11.0
+                            }
+                        },
+                        "effects": [
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Volume and Fades",
+                                        "Enabled": true,
+                                        "Name": "Volume",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Key Frames": {},
+                                                "Parameter ID": "volume",
+                                                "Parameter Value": -4.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 30.0,
+                                                "minValue": -100.0
+                                            }
+                                        ],
+                                        "Type": 62
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pan",
+                                        "Enabled": true,
+                                        "Name": "Pan",
+                                        "Parameters": [],
+                                        "Type": 72
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pitch",
+                                        "Enabled": true,
+                                        "Name": "Pitch",
+                                        "Parameters": [],
+                                        "Type": 67
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Equaliser",
+                                        "Enabled": false,
+                                        "Name": "Equalizer",
+                                        "Parameters": [],
+                                        "Type": 64
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 0,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 1,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 1,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 2,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 2,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 3,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 3,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            }
+                        ],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "MissingReference.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Media Url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/_deliveriesTO_EDIT/amaru/delivery_001/davinci/Picchu_Animatic_016.dra/MediaFiles/Sdisk/Picchu/davinci/sq200/Slide On Concrete Sound Effect (128 kbps).mp3"
+                                    }
+                                },
+                                "name": "Slide On Concrete Sound Effect (128 kbps).mp3",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 2588.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {
+                                "Channels": [
+                                    {
+                                        "Source Channel ID": 0,
+                                        "Source Track ID": 0
+                                    },
+                                    {
+                                        "Source Channel ID": 1,
+                                        "Source Track ID": 0
+                                    }
+                                ]
+                            }
+                        },
+                        "name": "Slide On Concrete Sound Effect (128 kbps).mp3",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 11.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 68.0
+                            }
+                        },
+                        "effects": [
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Volume and Fades",
+                                        "Enabled": true,
+                                        "Name": "Volume",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Key Frames": {},
+                                                "Parameter ID": "volume",
+                                                "Parameter Value": -4.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 30.0,
+                                                "minValue": -100.0
+                                            }
+                                        ],
+                                        "Type": 62
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pan",
+                                        "Enabled": true,
+                                        "Name": "Pan",
+                                        "Parameters": [],
+                                        "Type": 72
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pitch",
+                                        "Enabled": true,
+                                        "Name": "Pitch",
+                                        "Parameters": [],
+                                        "Type": 67
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Equaliser",
+                                        "Enabled": false,
+                                        "Name": "Equalizer",
+                                        "Parameters": [],
+                                        "Type": 64
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 0,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 1,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 1,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 2,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 2,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 3,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 3,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            }
+                        ],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "MissingReference.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Media Url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/_deliveriesTO_EDIT/amaru/delivery_001/davinci/Picchu_Animatic_016.dra/MediaFiles/Sdisk/Picchu/davinci/sq200/Slide On Concrete Sound Effect (128 kbps).mp3"
+                                    }
+                                },
+                                "name": "Slide On Concrete Sound Effect (128 kbps).mp3",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 2588.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {
+                                "Channels": [
+                                    {
+                                        "Source Channel ID": 0,
+                                        "Source Track ID": 0
+                                    },
+                                    {
+                                        "Source Channel ID": 1,
+                                        "Source Track ID": 0
+                                    }
+                                ]
+                            }
+                        },
+                        "name": "Slide On Concrete Sound Effect (128 kbps).mp3",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 7.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 135.0
+                            }
+                        },
+                        "effects": [
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Volume and Fades",
+                                        "Enabled": true,
+                                        "Name": "Volume",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Key Frames": {},
+                                                "Parameter ID": "volume",
+                                                "Parameter Value": -4.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 30.0,
+                                                "minValue": -100.0
+                                            }
+                                        ],
+                                        "Type": 62
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pan",
+                                        "Enabled": true,
+                                        "Name": "Pan",
+                                        "Parameters": [],
+                                        "Type": 72
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pitch",
+                                        "Enabled": true,
+                                        "Name": "Pitch",
+                                        "Parameters": [],
+                                        "Type": 67
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Equaliser",
+                                        "Enabled": false,
+                                        "Name": "Equalizer",
+                                        "Parameters": [],
+                                        "Type": 64
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 0,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 1,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 1,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 2,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 2,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 3,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 3,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            }
+                        ],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "MissingReference.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Media Url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/_deliveriesTO_EDIT/amaru/delivery_001/davinci/Picchu_Animatic_016.dra/MediaFiles/Sdisk/Picchu/davinci/sq200/Slide On Concrete Sound Effect (128 kbps).mp3"
+                                    }
+                                },
+                                "name": "Slide On Concrete Sound Effect (128 kbps).mp3",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 2588.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {
+                                "Channels": [
+                                    {
+                                        "Source Channel ID": 0,
+                                        "Source Track ID": 0
+                                    },
+                                    {
+                                        "Source Channel ID": 1,
+                                        "Source Track ID": 0
+                                    }
+                                ]
+                            }
+                        },
+                        "name": "Slide On Concrete Sound Effect (128 kbps).mp3",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 9.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 202.0
+                            }
+                        },
+                        "effects": [
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Volume and Fades",
+                                        "Enabled": true,
+                                        "Name": "Volume",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Key Frames": {},
+                                                "Parameter ID": "volume",
+                                                "Parameter Value": -4.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 30.0,
+                                                "minValue": -100.0
+                                            }
+                                        ],
+                                        "Type": 62
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pan",
+                                        "Enabled": true,
+                                        "Name": "Pan",
+                                        "Parameters": [],
+                                        "Type": 72
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pitch",
+                                        "Enabled": true,
+                                        "Name": "Pitch",
+                                        "Parameters": [],
+                                        "Type": 67
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Equaliser",
+                                        "Enabled": false,
+                                        "Name": "Equalizer",
+                                        "Parameters": [],
+                                        "Type": 64
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 0,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 1,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 1,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 2,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 2,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 3,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 3,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            }
+                        ],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "MissingReference.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Media Url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/_deliveriesTO_EDIT/amaru/delivery_001/davinci/Picchu_Animatic_016.dra/MediaFiles/Sdisk/Picchu/davinci/sq200/Slide On Concrete Sound Effect (128 kbps).mp3"
+                                    }
+                                },
+                                "name": "Slide On Concrete Sound Effect (128 kbps).mp3",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 2588.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {
+                                "Channels": [
+                                    {
+                                        "Source Channel ID": 0,
+                                        "Source Track ID": 0
+                                    },
+                                    {
+                                        "Source Channel ID": 1,
+                                        "Source Track ID": 0
+                                    }
+                                ]
+                            }
+                        },
+                        "name": "Slide On Concrete Sound Effect (128 kbps).mp3",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 13.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 262.0
+                            }
+                        },
+                        "effects": [
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Volume and Fades",
+                                        "Enabled": true,
+                                        "Name": "Volume",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Key Frames": {},
+                                                "Parameter ID": "volume",
+                                                "Parameter Value": -4.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 30.0,
+                                                "minValue": -100.0
+                                            }
+                                        ],
+                                        "Type": 62
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pan",
+                                        "Enabled": true,
+                                        "Name": "Pan",
+                                        "Parameters": [],
+                                        "Type": 72
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pitch",
+                                        "Enabled": true,
+                                        "Name": "Pitch",
+                                        "Parameters": [],
+                                        "Type": 67
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Equaliser",
+                                        "Enabled": false,
+                                        "Name": "Equalizer",
+                                        "Parameters": [],
+                                        "Type": 64
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 0,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 1,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 1,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 2,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 2,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 3,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 3,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            }
+                        ],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "MissingReference.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Media Url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/_deliveriesTO_EDIT/amaru/delivery_001/davinci/Picchu_Animatic_016.dra/MediaFiles/Sdisk/Picchu/davinci/sq200/Slide On Concrete Sound Effect (128 kbps).mp3"
+                                    }
+                                },
+                                "name": "Slide On Concrete Sound Effect (128 kbps).mp3",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 2588.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "metadata": {},
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 580.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {
+                                "Channels": [
+                                    {
+                                        "Source Channel ID": 0,
+                                        "Source Track ID": 0
+                                    },
+                                    {
+                                        "Source Channel ID": 1,
+                                        "Source Track ID": 0
+                                    }
+                                ]
+                            }
+                        },
+                        "name": "Snake Hissing sound effect no copyright _ snake sounds _ snake noises _ HQ (128 kbps).mp3",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 47.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 199.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "MissingReference.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Media Url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/SFX/Snake Hissing sound effect no copyright _ snake sounds _ snake noises _ HQ (128 kbps).mp3"
+                                    }
+                                },
+                                "name": "Snake Hissing sound effect no copyright _ snake sounds _ snake noises _ HQ (128 kbps).mp3",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 690.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    }
+                ],
+                "kind": "Audio"
+            },
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "Resolve_OTIO": {
+                        "Audio Type": "Stereo",
+                        "Locked": false,
+                        "SoloOn": false
+                    }
+                },
+                "name": "Audio 6",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {
+                                "Channels": [
+                                    {
+                                        "Source Channel ID": 0,
+                                        "Source Track ID": 0
+                                    },
+                                    {
+                                        "Source Channel ID": 1,
+                                        "Source Track ID": 0
+                                    }
+                                ]
+                            }
+                        },
+                        "name": "Cold wind sound effect (128 kbps).mp3",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 500.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Volume and Fades",
+                                        "Enabled": true,
+                                        "Name": "Volume",
+                                        "Parameters": [],
+                                        "Type": 62
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pan",
+                                        "Enabled": true,
+                                        "Name": "Pan",
+                                        "Parameters": [],
+                                        "Type": 72
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pitch",
+                                        "Enabled": true,
+                                        "Name": "Pitch",
+                                        "Parameters": [],
+                                        "Type": 67
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Equaliser",
+                                        "Enabled": false,
+                                        "Name": "Equalizer",
+                                        "Parameters": [],
+                                        "Type": 64
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 0,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 1,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 1,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 2,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 2,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 3,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 3,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            }
+                        ],
+                        "markers": [],
+                        "enabled": false,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "MissingReference.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Media Url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/SFX/Cold wind sound effect (128 kbps).mp3"
+                                    }
+                                },
+                                "name": "Cold wind sound effect (128 kbps).mp3",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 1290.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {
+                                "Channels": [
+                                    {
+                                        "Source Channel ID": 0,
+                                        "Source Track ID": 0
+                                    },
+                                    {
+                                        "Source Channel ID": 1,
+                                        "Source Track ID": 0
+                                    }
+                                ]
+                            }
+                        },
+                        "name": "Cold wind sound effect (128 kbps).mp3",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 192.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 616.0
+                            }
+                        },
+                        "effects": [
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Volume and Fades",
+                                        "Enabled": true,
+                                        "Name": "Volume",
+                                        "Parameters": [],
+                                        "Type": 62
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pan",
+                                        "Enabled": true,
+                                        "Name": "Pan",
+                                        "Parameters": [],
+                                        "Type": 72
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pitch",
+                                        "Enabled": true,
+                                        "Name": "Pitch",
+                                        "Parameters": [],
+                                        "Type": 67
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Equaliser",
+                                        "Enabled": false,
+                                        "Name": "Equalizer",
+                                        "Parameters": [],
+                                        "Type": 64
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 0,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 1,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 1,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 2,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 2,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 3,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 3,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            }
+                        ],
+                        "markers": [],
+                        "enabled": false,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "MissingReference.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Media Url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/SFX/Cold wind sound effect (128 kbps).mp3"
+                                    }
+                                },
+                                "name": "Cold wind sound effect (128 kbps).mp3",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 1290.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "metadata": {},
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 433.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true
+                    }
+                ],
+                "kind": "Audio"
+            },
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "Resolve_OTIO": {
+                        "Audio Type": "Stereo",
+                        "Locked": false,
+                        "SoloOn": false
+                    }
+                },
+                "name": "Audio 7",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "metadata": {},
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 676.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {
+                                "Channels": [
+                                    {
+                                        "Source Channel ID": 0,
+                                        "Source Track ID": 0
+                                    },
+                                    {
+                                        "Source Channel ID": 1,
+                                        "Source Track ID": 0
+                                    }
+                                ]
+                            }
+                        },
+                        "name": "Andean_SFX-02.wav",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 191.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Volume and Fades",
+                                        "Enabled": true,
+                                        "Name": "Volume",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Key Frames": {},
+                                                "Parameter ID": "volume",
+                                                "Parameter Value": -4.306451612903228,
+                                                "Variant Type": "Double",
+                                                "maxValue": 30.0,
+                                                "minValue": -100.0
+                                            }
+                                        ],
+                                        "Type": 62
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pan",
+                                        "Enabled": true,
+                                        "Name": "Pan",
+                                        "Parameters": [],
+                                        "Type": 72
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pitch",
+                                        "Enabled": true,
+                                        "Name": "Pitch",
+                                        "Parameters": [],
+                                        "Type": 67
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Equaliser",
+                                        "Enabled": false,
+                                        "Name": "Equalizer",
+                                        "Parameters": [],
+                                        "Type": 64
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 0,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 1,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 1,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 2,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 2,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 3,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 3,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            }
+                        ],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "MissingReference.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Media Url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/SFX/Andean_SFX-02.wav"
+                                    }
+                                },
+                                "name": "Andean_SFX-02.wav",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 191.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "metadata": {},
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 258.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true
+                    }
+                ],
+                "kind": "Audio"
+            },
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "Resolve_OTIO": {
+                        "Audio Type": "Stereo",
+                        "Locked": false,
+                        "SoloOn": false
+                    }
+                },
+                "name": "Audio 8",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {
+                                "Channels": [
+                                    {
+                                        "Source Channel ID": 0,
+                                        "Source Track ID": 0
+                                    },
+                                    {
+                                        "Source Channel ID": 1,
+                                        "Source Track ID": 0
+                                    }
+                                ]
+                            }
+                        },
+                        "name": "PICCHU MAQUETA .wav",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 759.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Volume and Fades",
+                                        "Enabled": true,
+                                        "Name": "Volume",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Key Frames": {},
+                                                "Parameter ID": "volume",
+                                                "Parameter Value": -11.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 30.0,
+                                                "minValue": -100.0
+                                            }
+                                        ],
+                                        "Type": 62
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pan",
+                                        "Enabled": true,
+                                        "Name": "Pan",
+                                        "Parameters": [],
+                                        "Type": 72
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pitch",
+                                        "Enabled": true,
+                                        "Name": "Pitch",
+                                        "Parameters": [],
+                                        "Type": 67
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Equaliser",
+                                        "Enabled": false,
+                                        "Name": "Equalizer",
+                                        "Parameters": [],
+                                        "Type": 64
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 0,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 1,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 1,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 2,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 2,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 3,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 3,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            }
+                        ],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "MissingReference.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Media Url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/_deliveriesTO_EDIT/amaru/delivery_001/davinci/Picchu_Animatic_016.dra/MediaFiles/Sdisk/Picchu/davinci/sq200/PICCHU MAQUETA .wav"
+                                    }
+                                },
+                                "name": "PICCHU MAQUETA .wav",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 1491.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "metadata": {},
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 366.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true
+                    }
+                ],
+                "kind": "Audio"
+            },
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "Resolve_OTIO": {
+                        "Audio Type": "Stereo",
+                        "Locked": false,
+                        "SoloOn": false
+                    }
+                },
+                "name": "Audio 9",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {
+                                "Channels": [
+                                    {
+                                        "Source Channel ID": 0,
+                                        "Source Track ID": 0
+                                    },
+                                    {
+                                        "Source Channel ID": 1,
+                                        "Source Track ID": 0
+                                    }
+                                ]
+                            }
+                        },
+                        "name": "Pachamama Opening Theme-(1080p).wav",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 1034.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Volume and Fades",
+                                        "Enabled": true,
+                                        "Name": "Volume",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Key Frames": {},
+                                                "Parameter ID": "volume",
+                                                "Parameter Value": -5.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 30.0,
+                                                "minValue": -100.0
+                                            }
+                                        ],
+                                        "Type": 62
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pan",
+                                        "Enabled": true,
+                                        "Name": "Pan",
+                                        "Parameters": [],
+                                        "Type": 72
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pitch",
+                                        "Enabled": true,
+                                        "Name": "Pitch",
+                                        "Parameters": [],
+                                        "Type": 67
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Equaliser",
+                                        "Enabled": false,
+                                        "Name": "Equalizer",
+                                        "Parameters": [],
+                                        "Type": 64
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 0,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 1,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 1,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 2,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 2,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 3,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 3,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            }
+                        ],
+                        "markers": [],
+                        "enabled": false,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "MissingReference.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Media Url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/music/Pachamama Opening Theme-(1080p).wav"
+                                    }
+                                },
+                                "name": "Pachamama Opening Theme-(1080p).wav",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 2835.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    },
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "metadata": {},
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 91.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true
+                    }
+                ],
+                "kind": "Audio"
+            },
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "Resolve_OTIO": {
+                        "Audio Type": "Stereo",
+                        "Locked": false,
+                        "SoloOn": false
+                    }
+                },
+                "name": "Audio 10",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "metadata": {},
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 751.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {
+                                "Channels": [
+                                    {
+                                        "Source Channel ID": 0,
+                                        "Source Track ID": 0
+                                    },
+                                    {
+                                        "Source Channel ID": 1,
+                                        "Source Track ID": 0
+                                    }
+                                ]
+                            }
+                        },
+                        "name": "Sea of Clouds-(1080p).mp3",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 374.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 448.0
+                            }
+                        },
+                        "effects": [
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Volume and Fades",
+                                        "Enabled": true,
+                                        "Name": "Volume",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Key Frames": {
+                                                    "194": {
+                                                        "Value": -2.0,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "241": {
+                                                        "Value": -29.540000000000008,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "96": {
+                                                        "Value": 0.0,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "volume",
+                                                "Parameter Value": -2.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 30.0,
+                                                "minValue": -100.0
+                                            }
+                                        ],
+                                        "Type": 62
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pan",
+                                        "Enabled": true,
+                                        "Name": "Pan",
+                                        "Parameters": [],
+                                        "Type": 72
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pitch",
+                                        "Enabled": true,
+                                        "Name": "Pitch",
+                                        "Parameters": [],
+                                        "Type": 67
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Equaliser",
+                                        "Enabled": false,
+                                        "Name": "Equalizer",
+                                        "Parameters": [],
+                                        "Type": 64
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 0,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 1,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 1,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 2,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 2,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 3,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 3,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            }
+                        ],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "MissingReference.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Media Url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/music/Sea of Clouds-(1080p).mp3"
+                                    }
+                                },
+                                "name": "Sea of Clouds-(1080p).mp3",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 3329.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    }
+                ],
+                "kind": "Audio"
+            },
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "metadata": {
+                    "Resolve_OTIO": {
+                        "Audio Type": "Stereo",
+                        "Locked": false,
+                        "SoloOn": false
+                    }
+                },
+                "name": "Audio 11",
+                "source_range": null,
+                "effects": [],
+                "markers": [],
+                "enabled": true,
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Gap.1",
+                        "metadata": {},
+                        "name": "",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 872.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0.0
+                            }
+                        },
+                        "effects": [],
+                        "markers": [],
+                        "enabled": true
+                    },
+                    {
+                        "OTIO_SCHEMA": "Clip.2",
+                        "metadata": {
+                            "Resolve_OTIO": {
+                                "Channels": [
+                                    {
+                                        "Source Channel ID": 0,
+                                        "Source Track ID": 0
+                                    },
+                                    {
+                                        "Source Channel ID": 1,
+                                        "Source Track ID": 0
+                                    }
+                                ]
+                            }
+                        },
+                        "name": "Sea of Clouds-(1080p).mp3",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 253.0
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 448.0
+                            }
+                        },
+                        "effects": [
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Volume and Fades",
+                                        "Enabled": true,
+                                        "Name": "Volume",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0.0,
+                                                "Key Frames": {
+                                                    "194": {
+                                                        "Value": -2.0,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "241": {
+                                                        "Value": -29.540000000000008,
+                                                        "Variant Type": "Double"
+                                                    },
+                                                    "96": {
+                                                        "Value": 0.0,
+                                                        "Variant Type": "Double"
+                                                    }
+                                                },
+                                                "Parameter ID": "volume",
+                                                "Parameter Value": -2.0,
+                                                "Variant Type": "Double",
+                                                "maxValue": 30.0,
+                                                "minValue": -100.0
+                                            }
+                                        ],
+                                        "Type": 62
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pan",
+                                        "Enabled": true,
+                                        "Name": "Pan",
+                                        "Parameters": [],
+                                        "Type": 72
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Pitch",
+                                        "Enabled": true,
+                                        "Name": "Pitch",
+                                        "Parameters": [],
+                                        "Type": 67
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Clip Equaliser",
+                                        "Enabled": false,
+                                        "Name": "Equalizer",
+                                        "Parameters": [],
+                                        "Type": 64
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 0,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 0,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 1,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 1,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": true,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 2,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 2,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            },
+                            {
+                                "OTIO_SCHEMA": "Effect.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Effect Name": "Fairlight Equaliser Band",
+                                        "Enabled": false,
+                                        "Name": "Equalizer Band",
+                                        "Parameters": [
+                                            {
+                                                "Default Parameter Value": 3,
+                                                "Parameter ID": "eq band index",
+                                                "Parameter Value": 3,
+                                                "Variant Type": "Int",
+                                                "maxValue": 3.0,
+                                                "minValue": -1.0
+                                            }
+                                        ],
+                                        "Type": 63
+                                    }
+                                },
+                                "name": "",
+                                "effect_name": "Resolve Effect"
+                            }
+                        ],
+                        "markers": [],
+                        "enabled": true,
+                        "media_references": {
+                            "DEFAULT_MEDIA": {
+                                "OTIO_SCHEMA": "MissingReference.1",
+                                "metadata": {
+                                    "Resolve_OTIO": {
+                                        "Media Url": "/Users/joshm/Downloads/picchu_edit/Picchu_v10_AZ.dra/MediaFiles/Xdisk/picchu/editorial/animatic/Picchu_Animatic_014.dra/MediaFiles/music/Sea of Clouds-(1080p).mp3"
+                                    }
+                                },
+                                "name": "Sea of Clouds-(1080p).mp3",
+                                "available_range": {
+                                    "OTIO_SCHEMA": "TimeRange.1",
+                                    "duration": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 3329.0
+                                    },
+                                    "start_time": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24.0,
+                                        "value": 0.0
+                                    }
+                                },
+                                "available_image_bounds": null
+                            }
+                        },
+                        "active_media_reference_key": "DEFAULT_MEDIA"
+                    }
+                ],
+                "kind": "Audio"
+            }
+        ]
+    }
+}

--- a/tests/sample_data/effects.otio
+++ b/tests/sample_data/effects.otio
@@ -363,6 +363,33 @@
                         "active_media_reference_key": "DEFAULT_MEDIA"
                     },
                     {
+                        "OTIO_SCHEMA": "Transition.1",
+                        "metadata": {
+                            "Resolve_OTIO": {
+                                "Effects": {
+                                    "Effect Name": "Cross Fade 0 dB",
+                                    "Enabled": true,
+                                    "Name": "Cross Fade",
+                                    "Parameters": [],
+                                    "Type": 40
+                                },
+                                "Transition Type": "Cross Fade 0DB"
+                            }
+                        },
+                        "name": "Cross Fade 0 dB",
+                        "in_offset": {
+                            "OTIO_SCHEMA": "RationalTime.1",
+                            "rate": 24.0,
+                            "value": 30.0
+                        },
+                        "out_offset": {
+                            "OTIO_SCHEMA": "RationalTime.1",
+                            "rate": 24.0,
+                            "value": 30.0
+                        },
+                        "transition_type": "SMPTE_Dissolve"
+                    },
+                    {
                         "OTIO_SCHEMA": "Clip.2",
                         "metadata": {
                             "Resolve_OTIO": {}

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -26,6 +26,7 @@ PREMIERE_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "premiere_example.otio")
 SCREENING_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "screening_example.otio")
 SIMPLE_CUT_PATH = os.path.join(SAMPLE_DATA_DIR, "simple_cut.otio")
 TRANSITION_PATH = os.path.join(SAMPLE_DATA_DIR, "transition.otio")
+EFFECTS_PATH = os.path.join(SAMPLE_DATA_DIR, "effects.otio")
 
 
 def CreateShelloutTest(cl):
@@ -642,6 +643,26 @@ TRACK:  (Audio)
         ]
         out, err = self.run_test()
         self.assertNotIn('"OTIO_SCHEMA": "Transition.', out)
+
+        # make sure the timeline has the same clips in it
+        in_timeline = otio.adapters.read_from_file(TRANSITION_PATH, "otio_json")
+        out_timeline = otio.adapters.read_from_string(out, "otio_json")
+        self.assertEqual(len(in_timeline.find_clips()), len(out_timeline.find_clips()))
+
+    def test_remote_effects(self):
+        sys.argv = [
+            'otiotool',
+            '-i', EFFECTS_PATH,
+            '-o', '-',
+            '--remove-effects'
+        ]
+        out, err = self.run_test()
+        self.assertNotIn('"OTIO_SCHEMA": "Effect.', out)
+
+        # make sure the timeline has the same clips in it
+        in_timeline = otio.adapters.read_from_file(EFFECTS_PATH, "otio_json")
+        out_timeline = otio.adapters.read_from_string(out, "otio_json")
+        self.assertEqual(len(in_timeline.find_clips()), len(out_timeline.find_clips()))
 
     def test_trim(self):
         sys.argv = [

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -634,7 +634,7 @@ TRACK:  (Audio)
   CLIP: sc01_sh010_anim.mov
 """, out)
 
-    def test_remote_transition(self):
+    def test_remove_transition(self):
         sys.argv = [
             'otiotool',
             '-i', TRANSITION_PATH,
@@ -649,7 +649,7 @@ TRACK:  (Audio)
         out_timeline = otio.adapters.read_from_string(out, "otio_json")
         self.assertEqual(len(in_timeline.find_clips()), len(out_timeline.find_clips()))
 
-    def test_remote_effects(self):
+    def test_remove_effects(self):
         sys.argv = [
             'otiotool',
             '-i', EFFECTS_PATH,

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -171,7 +171,6 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
                 'otioconvert',
                 '-i', SCREENING_EXAMPLE_PATH,
                 '-o', temp_file,
-                '-O', 'otio_json',
                 '--tracks', '0'
             ]
             self.run_test()
@@ -189,7 +188,6 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
                 'otioconvert',
                 '-i', SCREENING_EXAMPLE_PATH,
                 '-o', temp_file,
-                '-O', 'otio_json',
                 "--begin", "foobar"
             ]
             with self.assertRaises(SystemExit):
@@ -200,7 +198,6 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
                 'otioconvert',
                 '-i', SCREENING_EXAMPLE_PATH,
                 '-o', temp_file,
-                '-O', 'otio_json',
                 "--end", "foobar"
             ]
             with self.assertRaises(SystemExit):
@@ -211,7 +208,6 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
                 'otioconvert',
                 '-i', SCREENING_EXAMPLE_PATH,
                 '-o', temp_file,
-                '-O', 'otio_json',
                 "--begin", "0,24",
                 "--end", "0,24",
             ]
@@ -222,7 +218,6 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
                 'otioconvert',
                 '-i', SCREENING_EXAMPLE_PATH,
                 '-o', temp_file,
-                '-O', 'otio_json',
                 "--begin", "0",
                 "--end", "0,24",
             ]
@@ -233,14 +228,13 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
                 'otioconvert',
                 '-i', SCREENING_EXAMPLE_PATH,
                 '-o', temp_file,
-                '-O', 'otio_json',
                 "--begin", "0,24",
                 "--end", "0",
             ]
             with self.assertRaises(SystemExit):
                 self.run_test()
 
-            result = otio.adapters.read_from_file(temp_file, "otio_json")
+            result = otio.adapters.read_from_file(temp_file)
             self.assertEqual(len(result.tracks[0]), 0)
             self.assertEqual(result.name, "Example_Screening.01")
 
@@ -269,7 +263,6 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
                 'otioconvert',
                 '-i', SCREENING_EXAMPLE_PATH,
                 '-o', temp_file,
-                '-O', 'otio_json',
                 "-A", "foobar",
             ]
 
@@ -287,7 +280,6 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
                 'otioconvert',
                 '-i', SCREENING_EXAMPLE_PATH,
                 '-o', temp_file,
-                '-O', 'otio_json',
                 "-m", "fake_linker",
                 "-M", "somestring=foobar",
                 "-M", "foobar",
@@ -645,7 +637,7 @@ TRACK:  (Audio)
         self.assertNotIn('"OTIO_SCHEMA": "Transition.', out)
 
         # make sure the timeline has the same clips in it
-        in_timeline = otio.adapters.read_from_file(TRANSITION_PATH, "otio_json")
+        in_timeline = otio.adapters.read_from_file(TRANSITION_PATH)
         out_timeline = otio.adapters.read_from_string(out, "otio_json")
         self.assertEqual(len(in_timeline.find_clips()), len(out_timeline.find_clips()))
 
@@ -660,7 +652,7 @@ TRACK:  (Audio)
         self.assertNotIn('"OTIO_SCHEMA": "Effect.', out)
 
         # make sure the timeline has the same clips in it
-        in_timeline = otio.adapters.read_from_file(EFFECTS_PATH, "otio_json")
+        in_timeline = otio.adapters.read_from_file(EFFECTS_PATH)
         out_timeline = otio.adapters.read_from_string(out, "otio_json")
         self.assertEqual(len(in_timeline.find_clips()), len(out_timeline.find_clips()))
 


### PR DESCRIPTION
Sometimes you have effects in your timeline that you want to remove. This PR adds a `--remove-effects` option to otiotool to make that easy and convenient.

Example:
```
otiotool -i effects.otio --remove-effects -o no-effects.otio
```