### PR TITLE
Export C++ symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,8 @@ endif()
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+include(GenerateExportHeader)
+
 #------------------------------------------------------------------------------
 # Fetch or refresh submodules if requested
 #

--- a/src/opentime/CMakeLists.txt
+++ b/src/opentime/CMakeLists.txt
@@ -25,8 +25,7 @@ target_include_directories(
 set_target_properties(opentime PROPERTIES 
     DEBUG_POSTFIX "${OTIO_DEBUG_POSTFIX}"
     LIBRARY_OUTPUT_NAME "opentime"
-    POSITION_INDEPENDENT_CODE TRUE
-    WINDOWS_EXPORT_ALL_SYMBOLS true)
+    POSITION_INDEPENDENT_CODE TRUE)
 
 if(BUILD_SHARED_LIBS)
     set_target_properties(opentime PROPERTIES
@@ -51,6 +50,10 @@ configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/version.h.in
     ${CMAKE_CURRENT_BINARY_DIR}/version.h
 )
+
+generate_export_header(
+    opentime
+    EXPORT_FILE_NAME export.h)
 
 if(OTIO_CXX_INSTALL)
     install(FILES ${OPENTIME_HEADER_FILES} 
@@ -86,6 +89,7 @@ if(OTIO_CXX_INSTALL)
 
     install(
         FILES
+            ${CMAKE_CURRENT_BINARY_DIR}/export.h
             ${CMAKE_CURRENT_BINARY_DIR}/version.h
         DESTINATION
             "${OTIO_RESOLVED_CXX_INSTALL_DIR}/include/opentime"

--- a/src/opentime/errorStatus.h
+++ b/src/opentime/errorStatus.h
@@ -3,13 +3,14 @@
 
 #pragma once
 
+#include "opentime/export.h"
 #include "opentime/version.h"
 #include <string>
 
 namespace opentime { namespace OPENTIME_VERSION {
 
 /// @brief This struct represents the return status of a function.
-struct ErrorStatus
+struct OPENTIME_EXPORT ErrorStatus
 {
     /// @brief This enumeration represents the possible outcomes.
     enum Outcome
@@ -51,14 +52,14 @@ struct ErrorStatus
 };
 
 ///! @brief Check whether the given ErrorStatus is an error.
-constexpr bool
+OPENTIME_EXPORT constexpr bool
 is_error(const ErrorStatus& es) noexcept
 {
     return ErrorStatus::Outcome::OK != es.outcome;
 }
 
 ///! @brief Check whether the given ErrorStatus is non-null and an error.
-constexpr bool
+OPENTIME_EXPORT constexpr bool
 is_error(const ErrorStatus* es) noexcept
 {
     return es && ErrorStatus::Outcome::OK != es->outcome;

--- a/src/opentime/rationalTime.h
+++ b/src/opentime/rationalTime.h
@@ -13,7 +13,7 @@
 namespace opentime { namespace OPENTIME_VERSION {
 
 /// @brief This enumeration provides options for drop frame timecode.
-enum IsDropFrameRate : int
+enum OPENTIME_EXPORT IsDropFrameRate : int
 {
     InferFromRate = -1,
     ForceNo       = 0,
@@ -23,7 +23,7 @@ enum IsDropFrameRate : int
 /// @brief Returns the absolute value.
 ///
 /// \todo Document why this function is used instead of "std::fabs()".
-constexpr double
+OPENTIME_EXPORT constexpr double
 fabs(double val) noexcept
 {
     union
@@ -36,7 +36,7 @@ fabs(double val) noexcept
 }
 
 /// @brief This class represents a measure of time defined by a value and rate.
-class RationalTime
+class OPENTIME_EXPORT RationalTime
 {
 public:
     /// @brief Construct a new time with an optional value and rate.

--- a/src/opentime/timeRange.h
+++ b/src/opentime/timeRange.h
@@ -16,7 +16,7 @@ namespace opentime { namespace OPENTIME_VERSION {
 /// a resolution of half a frame at 192kHz. The value can be changed in the future if
 /// necessary, due to higher sampling rates or some other kind of numeric tolerance
 /// detected in the library.
-constexpr double DEFAULT_EPSILON_s = 1.0 / (2 * 192000.0);
+OPENTIME_EXPORT constexpr double DEFAULT_EPSILON_s = 1.0 / (2 * 192000.0);
 
 /// @brief This class represents a time range defined by a start time and duration.
 ///
@@ -27,7 +27,7 @@ constexpr double DEFAULT_EPSILON_s = 1.0 / (2 * 192000.0);
 /// The duration on a TimeRange indicates a time range that is inclusive of the
 /// start time, and exclusive of the end time. All of the predicates are
 /// computed accordingly.
-class TimeRange
+class OPENTIME_EXPORT TimeRange
 {
 public:
     /// @brief Construct a new time range with a zero start time and duration.

--- a/src/opentime/timeTransform.h
+++ b/src/opentime/timeTransform.h
@@ -11,7 +11,7 @@
 namespace opentime { namespace OPENTIME_VERSION {
 
 /// @brief One-dimensional time transform.
-class TimeTransform
+class OPENTIME_EXPORT TimeTransform
 {
 public:
     /// @brief Construct a new transform with an optional offset, scale, and rate.

--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -100,8 +100,7 @@ target_link_libraries(opentimelineio
 set_target_properties(opentimelineio PROPERTIES
     DEBUG_POSTFIX "${OTIO_DEBUG_POSTFIX}"
     LIBRARY_OUTPUT_NAME "opentimelineio"
-    POSITION_INDEPENDENT_CODE TRUE
-    WINDOWS_EXPORT_ALL_SYMBOLS true)
+    POSITION_INDEPENDENT_CODE TRUE)
 
 if(BUILD_SHARED_LIBS)
     set_target_properties(opentimelineio PROPERTIES
@@ -127,6 +126,10 @@ configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/version.h.in
     ${CMAKE_CURRENT_BINARY_DIR}/version.h
 )
+
+generate_export_header(
+    opentimelineio
+    EXPORT_FILE_NAME export.h)
 
 if(OTIO_CXX_INSTALL)
     install(FILES ${OPENTIMELINEIO_HEADER_FILES} 
@@ -164,6 +167,7 @@ if(OTIO_CXX_INSTALL)
 
     install(
         FILES
+            ${CMAKE_CURRENT_BINARY_DIR}/export.h
             ${CMAKE_CURRENT_BINARY_DIR}/version.h
         DESTINATION
             "${OTIO_RESOLVED_CXX_INSTALL_DIR}/include/opentimelineio"

--- a/src/opentimelineio/algo/editAlgorithm.h
+++ b/src/opentimelineio/algo/editAlgorithm.h
@@ -8,7 +8,7 @@
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION { namespace algo {
 
 //! Enum used by 3/4 Point Edit (aka. as fill)
-enum class ReferencePoint
+enum class OPENTIMELINEIO_EXPORT ReferencePoint
 {
     Source,
     Sequence,
@@ -38,7 +38,7 @@ enum class ReferencePoint
 //            
 // If overwrite range starts and ends before A, a gap hole is filled with
 // fill_template.
-void overwrite(
+OPENTIMELINEIO_EXPORT void overwrite(
     Item*            item,
     Composition*     composition,
     TimeRange const& range,
@@ -62,7 +62,7 @@ void overwrite(
 // If A and B's length is L1 and C's length is L2, the end result is L1 + L2.
 // A is split.
 //
-void insert(
+OPENTIMELINEIO_EXPORT void insert(
     Item* const         item,
     Composition*        composition,
     RationalTime const& time,
@@ -88,7 +88,7 @@ void insert(
 // Fill now-"empty" time with gap or template
 // Unless item is meeting a Gap, then, existing Gap's duration will be augmented
 //    
-void trim(
+OPENTIMELINEIO_EXPORT void trim(
     Item*               item,
     RationalTime const& delta_in,
     RationalTime const& delta_out,
@@ -101,7 +101,7 @@ void trim(
 //   ^
 // composition = usually a track item.
 //        time = time to slice at.
-void slice(
+OPENTIMELINEIO_EXPORT void slice(
     Composition*        composition,
     RationalTime const& time,
     bool const          remove_transitions = true,
@@ -119,7 +119,7 @@ void slice(
 // Do not affect item duration.
 // Do not affect surrounding items.
 // Clamp to available_range of media (if available)
-void slip(Item* item, RationalTime const& delta);
+OPENTIMELINEIO_EXPORT void slip(Item* item, RationalTime const& delta);
 
 //
 // Slide an item start_time by + or -, adjusting the previous item's duration.
@@ -133,7 +133,7 @@ void slip(Item* item, RationalTime const& delta);
 //
 // If item is the first clip, it does nothing.
 //
-void slide(Item* item, RationalTime const& delta);
+OPENTIMELINEIO_EXPORT void slide(Item* item, RationalTime const& delta);
 
 //
 // Adjust a source_range without affecting any other items.
@@ -146,7 +146,7 @@ void slide(Item* item, RationalTime const& delta);
 //             will be adjusted by
 // delta_out = RationalTime that the item's
 //             source_range().end_time_exclusive() will be adjusted by
-void ripple(
+OPENTIMELINEIO_EXPORT void ripple(
     Item*               item,
     RationalTime const& delta_in,
     RationalTime const& delta_out,
@@ -168,7 +168,7 @@ void ripple(
 //             will be adjusted by
 // delta_out = RationalTime that the item's
 //             source_range().end_time_exclusive() will be adjusted by
-void roll(
+OPENTIMELINEIO_EXPORT void roll(
     Item*               item,
     RationalTime const& delta_in,
     RationalTime const& delta_out,
@@ -186,7 +186,7 @@ void roll(
 // reference_point = For 4 point editing, the reference point dictates what
 //                   transform to use when running the fill.
 //
-void fill(
+OPENTIMELINEIO_EXPORT void fill(
     Item*                item,
     Composition*         track,
     RationalTime const&  track_time,
@@ -207,7 +207,7 @@ void fill(
 //
 // if fill is not set, A and B become concatenated, with no fill.
 //
-void remove(
+OPENTIMELINEIO_EXPORT void remove(
     Composition*        composition,
     RationalTime const& time,
     bool         const  fill = true,

--- a/src/opentimelineio/anyDictionary.h
+++ b/src/opentimelineio/anyDictionary.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "opentimelineio/export.h"
 #include "opentimelineio/version.h"
 
 #include <any>
@@ -24,7 +25,7 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 /// This allows us to hand out iterators that can be aware of mutation and moves
 /// and take steps to safe-guard themselves from causing a crash.  (Yes, I'm
 /// talking to you, Python...)
-class AnyDictionary : private std::map<std::string, std::any>
+class OPENTIMELINEIO_EXPORT AnyDictionary : private std::map<std::string, std::any>
 {
 public:
     using map::map;

--- a/src/opentimelineio/anyVector.h
+++ b/src/opentimelineio/anyVector.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "opentimelineio/export.h"
 #include "opentimelineio/version.h"
 
 #include <any>
@@ -20,7 +21,7 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 ///
 /// This allows us to hand out iterators that can be aware of moves
 /// and take steps to safe-guard themselves from causing a crash.
-class AnyVector : private std::vector<std::any>
+class OPENTIMELINEIO_EXPORT AnyVector : private std::vector<std::any>
 {
 public:
     using vector::vector;

--- a/src/opentimelineio/clip.h
+++ b/src/opentimelineio/clip.h
@@ -12,7 +12,7 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 /// @brief A clip is a segment of editable media (usually audio or video).
 ///
 /// Contains a MediaReference and a trim on that media reference.
-class Clip : public Item
+class OPENTIMELINEIO_EXPORT Clip : public Item
 {
 public:
     /// @brief The default media within a clip.

--- a/src/opentimelineio/color.h
+++ b/src/opentimelineio/color.h
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <vector>
 
+#include "opentimelineio/export.h"
 #include "opentimelineio/version.h"
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
@@ -21,7 +22,7 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 /// Round-trip conversions may not be guaranteed outside that.
 /// This class is meant for use in user interface elements,
 // like marker or clip coloring, NOT for image pixel content.
-class Color
+class OPENTIMELINEIO_EXPORT Color
 {
 public:
     struct Schema

--- a/src/opentimelineio/composable.h
+++ b/src/opentimelineio/composable.h
@@ -13,7 +13,7 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 class Composition;
 
 /// @brief An object that can be composed within a Composition (such as a Track or Stack).
-class Composable : public SerializableObjectWithMetadata
+class OPENTIMELINEIO_EXPORT Composable : public SerializableObjectWithMetadata
 {
 public:
     /// @brief This struct provides the Composable schema.

--- a/src/opentimelineio/composition.h
+++ b/src/opentimelineio/composition.h
@@ -14,7 +14,7 @@ class Clip;
 /// @brief Base class for an Item that contains Composables.
 ///
 /// Should be subclassed (for example by Track Stack), not used directly.
-class Composition : public Item
+class OPENTIMELINEIO_EXPORT Composition : public Item
 {
 public:
     /// @brief This struct provides the Composition schema.

--- a/src/opentimelineio/deserialization.h
+++ b/src/opentimelineio/deserialization.h
@@ -12,13 +12,13 @@
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
 /// @brief Deserialize JSON data from a string.
-bool deserialize_json_from_string(
+OPENTIMELINEIO_EXPORT bool deserialize_json_from_string(
     std::string const& input,
     std::any*          destination,
     ErrorStatus*       error_status = nullptr);
 
 /// @brief Deserialize JSON data from a file.
-bool deserialize_json_from_file(
+OPENTIMELINEIO_EXPORT bool deserialize_json_from_file(
     std::string const& file_name,
     std::any*          destination,
     ErrorStatus*       error_status = nullptr);

--- a/src/opentimelineio/effect.h
+++ b/src/opentimelineio/effect.h
@@ -9,7 +9,7 @@
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
 /// @brief An effect that can be applied to an item, such as an image or audio filter.
-class Effect : public SerializableObjectWithMetadata
+class OPENTIMELINEIO_EXPORT Effect : public SerializableObjectWithMetadata
 {
 public:
     /// @brief This struct provides the Effect schema.

--- a/src/opentimelineio/errorStatus.h
+++ b/src/opentimelineio/errorStatus.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "opentimelineio/export.h"
 #include "opentimelineio/version.h"
 #include <string>
 
@@ -11,7 +12,7 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 class SerializableObject;
 
 /// @brief This struct represents the return status of a function.
-struct ErrorStatus
+struct OPENTIMELINEIO_EXPORT ErrorStatus
 {
     /// @brief This enumeration represents the possible outcomes.
     enum Outcome
@@ -96,14 +97,14 @@ struct ErrorStatus
 };
 
 /// @brief Check whether the given ErrorStatus is an error.
-constexpr bool
+OPENTIMELINEIO_EXPORT constexpr bool
 is_error(const ErrorStatus& es) noexcept
 {
     return ErrorStatus::Outcome::OK != es.outcome;
 }
 
 /// @brief Check whether the given ErrorStatus* is non-null and an error.
-constexpr bool
+OPENTIMELINEIO_EXPORT constexpr bool
 is_error(const ErrorStatus* es) noexcept
 {
     return es && ErrorStatus::Outcome::OK != es->outcome;

--- a/src/opentimelineio/externalReference.h
+++ b/src/opentimelineio/externalReference.h
@@ -9,7 +9,7 @@
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
 /// @brief A reference to a media file.
-class ExternalReference final : public MediaReference
+class OPENTIMELINEIO_EXPORT ExternalReference final : public MediaReference
 {
 public:
     /// @brief This struct provides the ExternalReference schema.

--- a/src/opentimelineio/freezeFrame.h
+++ b/src/opentimelineio/freezeFrame.h
@@ -9,7 +9,7 @@
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
 /// @brief Hold the first frame of the clip for the duration of the clip.
-class FreezeFrame : public LinearTimeWarp
+class OPENTIMELINEIO_EXPORT FreezeFrame : public LinearTimeWarp
 {
 public:
     /// @brief This struct provides the FreezeFrame schema.

--- a/src/opentimelineio/gap.h
+++ b/src/opentimelineio/gap.h
@@ -10,7 +10,7 @@
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
 /// @brief An empty item within a timeline.
-class Gap : public Item
+class OPENTIMELINEIO_EXPORT Gap : public Item
 {
 public:
     /// @brief This struct provides the Gap schema.

--- a/src/opentimelineio/generatorReference.h
+++ b/src/opentimelineio/generatorReference.h
@@ -9,7 +9,7 @@
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
 /// @brief A reference to dynamically generated media.
-class GeneratorReference final : public MediaReference
+class OPENTIMELINEIO_EXPORT GeneratorReference final : public MediaReference
 {
 public:
     /// @brief This struct provides the GeneratorReference schema.

--- a/src/opentimelineio/imageSequenceReference.h
+++ b/src/opentimelineio/imageSequenceReference.h
@@ -17,7 +17,7 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 /// * Name prefix: "image."
 /// * Name suffix: ".exr"
 /// * Frame number padded to six zeroes: "000100"
-class ImageSequenceReference final : public MediaReference
+class OPENTIMELINEIO_EXPORT ImageSequenceReference final : public MediaReference
 {
 public:
     /// @brief How to handle missing frames.

--- a/src/opentimelineio/item.h
+++ b/src/opentimelineio/item.h
@@ -15,7 +15,7 @@ class Effect;
 class Marker;
 
 /// @brief An item in the timeline.
-class Item : public Composable
+class OPENTIMELINEIO_EXPORT Item : public Composable
 {
 public:
     /// @brief This struct provides the Item schema.

--- a/src/opentimelineio/linearTimeWarp.h
+++ b/src/opentimelineio/linearTimeWarp.h
@@ -9,7 +9,7 @@
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
 /// @brief A time warp that applies a linear speed up or slow down across the entire clip.
-class LinearTimeWarp : public TimeEffect
+class OPENTIMELINEIO_EXPORT LinearTimeWarp : public TimeEffect
 {
 public:
     /// @brief This struct provides the LinearTimeWarp schema.

--- a/src/opentimelineio/marker.h
+++ b/src/opentimelineio/marker.h
@@ -13,7 +13,7 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 ///
 /// The marked range may have a zero duration. The marked range is in the
 /// owning item's time coordinate system.
-class Marker : public SerializableObjectWithMetadata
+class OPENTIMELINEIO_EXPORT Marker : public SerializableObjectWithMetadata
 {
 public:
     /// @brief This struct provides the base set of colors.

--- a/src/opentimelineio/mediaReference.h
+++ b/src/opentimelineio/mediaReference.h
@@ -13,7 +13,7 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 using namespace opentime;
 
 /// @brief A reference to a piece of media, for example a movie on a clip.
-class MediaReference : public SerializableObjectWithMetadata
+class OPENTIMELINEIO_EXPORT MediaReference : public SerializableObjectWithMetadata
 {
 public:
     /// @brief This struct provides the MediaReference schema.

--- a/src/opentimelineio/missingReference.h
+++ b/src/opentimelineio/missingReference.h
@@ -12,7 +12,7 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 ///
 /// Note that a missing reference may have useful metadata, even if the
 /// location of the media is not known.
-class MissingReference final : public MediaReference
+class OPENTIMELINEIO_EXPORT MissingReference final : public MediaReference
 {
 public:
     /// @brief This struct provides the MissingReference schema.

--- a/src/opentimelineio/safely_typed_any.h
+++ b/src/opentimelineio/safely_typed_any.h
@@ -31,48 +31,48 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 /// @name Any Create
 ///@{
 
-std::any create_safely_typed_any(bool&&);
-std::any create_safely_typed_any(int&&);
-std::any create_safely_typed_any(int64_t&&);
-std::any create_safely_typed_any(uint64_t&&);
-std::any create_safely_typed_any(double&&);
-std::any create_safely_typed_any(std::string&&);
-std::any create_safely_typed_any(RationalTime&&);
-std::any create_safely_typed_any(TimeRange&&);
-std::any create_safely_typed_any(Color&&);
-std::any create_safely_typed_any(TimeTransform&&);
-std::any create_safely_typed_any(IMATH_NAMESPACE::V2d&&);
-std::any create_safely_typed_any(IMATH_NAMESPACE::Box2d&&);
-std::any create_safely_typed_any(AnyVector&&);
-std::any create_safely_typed_any(AnyDictionary&&);
-std::any create_safely_typed_any(SerializableObject*);
+OPENTIMELINEIO_EXPORT std::any create_safely_typed_any(bool&&);
+OPENTIMELINEIO_EXPORT std::any create_safely_typed_any(int&&);
+OPENTIMELINEIO_EXPORT std::any create_safely_typed_any(int64_t&&);
+OPENTIMELINEIO_EXPORT std::any create_safely_typed_any(uint64_t&&);
+OPENTIMELINEIO_EXPORT std::any create_safely_typed_any(double&&);
+OPENTIMELINEIO_EXPORT std::any create_safely_typed_any(std::string&&);
+OPENTIMELINEIO_EXPORT std::any create_safely_typed_any(RationalTime&&);
+OPENTIMELINEIO_EXPORT std::any create_safely_typed_any(TimeRange&&);
+OPENTIMELINEIO_EXPORT std::any create_safely_typed_any(Color&&);
+OPENTIMELINEIO_EXPORT std::any create_safely_typed_any(TimeTransform&&);
+OPENTIMELINEIO_EXPORT std::any create_safely_typed_any(IMATH_NAMESPACE::V2d&&);
+OPENTIMELINEIO_EXPORT std::any create_safely_typed_any(IMATH_NAMESPACE::Box2d&&);
+OPENTIMELINEIO_EXPORT std::any create_safely_typed_any(AnyVector&&);
+OPENTIMELINEIO_EXPORT std::any create_safely_typed_any(AnyDictionary&&);
+OPENTIMELINEIO_EXPORT std::any create_safely_typed_any(SerializableObject*);
 
 ///@}
 
 /// @name Any Casting
 ///@{
 
-bool                   safely_cast_bool_any(std::any const& a);
-int                    safely_cast_int_any(std::any const& a);
-int64_t                safely_cast_int64_any(std::any const& a);
-uint64_t               safely_cast_uint64_any(std::any const& a);
-double                 safely_cast_double_any(std::any const& a);
-std::string            safely_cast_string_any(std::any const& a);
-RationalTime           safely_cast_rational_time_any(std::any const& a);
-TimeRange              safely_cast_time_range_any(std::any const& a);
-TimeTransform          safely_cast_time_transform_any(std::any const& a);
-Color                  safely_cast_color_any(std::any const& a);
-IMATH_NAMESPACE::V2d   safely_cast_point_any(std::any const& a);
-IMATH_NAMESPACE::Box2d safely_cast_box_any(std::any const& a);
+OPENTIMELINEIO_EXPORT bool                   safely_cast_bool_any(std::any const& a);
+OPENTIMELINEIO_EXPORT int                    safely_cast_int_any(std::any const& a);
+OPENTIMELINEIO_EXPORT int64_t                safely_cast_int64_any(std::any const& a);
+OPENTIMELINEIO_EXPORT uint64_t               safely_cast_uint64_any(std::any const& a);
+OPENTIMELINEIO_EXPORT double                 safely_cast_double_any(std::any const& a);
+OPENTIMELINEIO_EXPORT std::string            safely_cast_string_any(std::any const& a);
+OPENTIMELINEIO_EXPORT RationalTime           safely_cast_rational_time_any(std::any const& a);
+OPENTIMELINEIO_EXPORT TimeRange              safely_cast_time_range_any(std::any const& a);
+OPENTIMELINEIO_EXPORT TimeTransform          safely_cast_time_transform_any(std::any const& a);
+OPENTIMELINEIO_EXPORT Color                  safely_cast_color_any(std::any const& a);
+OPENTIMELINEIO_EXPORT IMATH_NAMESPACE::V2d   safely_cast_point_any(std::any const& a);
+OPENTIMELINEIO_EXPORT IMATH_NAMESPACE::Box2d safely_cast_box_any(std::any const& a);
 
-SerializableObject* safely_cast_retainer_any(std::any const& a);
+OPENTIMELINEIO_EXPORT SerializableObject* safely_cast_retainer_any(std::any const& a);
 
-AnyDictionary safely_cast_any_dictionary_any(std::any const& a);
-AnyVector     safely_cast_any_vector_any(std::any const& a);
+OPENTIMELINEIO_EXPORT AnyDictionary safely_cast_any_dictionary_any(std::any const& a);
+OPENTIMELINEIO_EXPORT AnyVector     safely_cast_any_vector_any(std::any const& a);
 
 /// @bug Don't use these unless you know what you're doing...
-AnyDictionary& temp_safely_cast_any_dictionary_any(std::any const& a);
-AnyVector&     temp_safely_cast_any_vector_any(std::any const& a);
+OPENTIMELINEIO_EXPORT AnyDictionary& temp_safely_cast_any_dictionary_any(std::any const& a);
+OPENTIMELINEIO_EXPORT AnyVector&     temp_safely_cast_any_vector_any(std::any const& a);
 
 ///@}
 

--- a/src/opentimelineio/serializableCollection.h
+++ b/src/opentimelineio/serializableCollection.h
@@ -22,7 +22,7 @@ class Clip;
 ///
 /// A SerializableCollection is useful for serializing multiple timelines,
 /// clips, or media references to a single file.
-class SerializableCollection : public SerializableObjectWithMetadata
+class OPENTIMELINEIO_EXPORT SerializableCollection : public SerializableObjectWithMetadata
 {
 public:
     /// @brief This struct provides the SerializableCollection schema.

--- a/src/opentimelineio/serializableObject.h
+++ b/src/opentimelineio/serializableObject.h
@@ -25,7 +25,7 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 class CloningEncoder;
 
 /// @brief A serializable object.
-class SerializableObject
+class OPENTIMELINEIO_EXPORT SerializableObject
 {
 public:
     /// @brief This struct provides the SerializableObject schema.

--- a/src/opentimelineio/serializableObjectWithMetadata.h
+++ b/src/opentimelineio/serializableObjectWithMetadata.h
@@ -9,7 +9,7 @@
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
 /// @brief A serializable object with metadata.
-class SerializableObjectWithMetadata : public SerializableObject
+class OPENTIMELINEIO_EXPORT SerializableObjectWithMetadata : public SerializableObject
 {
 public:
     /// @brief This struct provides the SerializableObjectWithMetadata schema.

--- a/src/opentimelineio/serialization.h
+++ b/src/opentimelineio/serialization.h
@@ -14,14 +14,14 @@
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
 /// @brief Serialize JSON data to a string.
-std::string serialize_json_to_string(
+OPENTIMELINEIO_EXPORT std::string serialize_json_to_string(
     const std::any&           value,
     const schema_version_map* schema_version_targets = nullptr,
     ErrorStatus*              error_status           = nullptr,
     int                       indent                 = 4);
 
 /// @brief Serialize JSON data to a file.
-bool serialize_json_to_file(
+OPENTIMELINEIO_EXPORT bool serialize_json_to_file(
     const std::any&           value,
     std::string const&        file_name,
     const schema_version_map* schema_version_targets = nullptr,

--- a/src/opentimelineio/stack.h
+++ b/src/opentimelineio/stack.h
@@ -11,7 +11,7 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 class Clip;
 
 /// @brief A stack of items in a timeline, for example a stack of tracks in a timelime.
-class Stack : public Composition
+class OPENTIMELINEIO_EXPORT Stack : public Composition
 {
 public:
     /// @brief This struct provides the Stack schema.

--- a/src/opentimelineio/stackAlgorithm.h
+++ b/src/opentimelineio/stackAlgorithm.h
@@ -10,10 +10,11 @@
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
 /// @brief Flatten a stack down to a single track.
+OPENTIMELINEIO_EXPORT
 Track* flatten_stack(Stack* in_stack, ErrorStatus* error_status = nullptr);
 
 /// @brief Flatten a list of tracks down to a single track.
-Track* flatten_stack(
+OPENTIMELINEIO_EXPORT Track* flatten_stack(
     std::vector<Track*> const& tracks,
     ErrorStatus*               error_status = nullptr);
 

--- a/src/opentimelineio/stringUtils.h
+++ b/src/opentimelineio/stringUtils.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "opentime/stringPrintf.h"
+#include "opentimelineio/export.h"
 #include "opentimelineio/version.h"
 using opentime::string_printf;
 
@@ -15,11 +16,11 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 /// @name String Utilities
 ///@{
 
-void fatal_error(std::string const& errMsg);
+OPENTIMELINEIO_EXPORT void fatal_error(std::string const& errMsg);
 
-std::string type_name_for_error_message(std::type_info const&);
-std::string type_name_for_error_message(std::any const& a);
-std::string type_name_for_error_message(class SerializableObject*);
+OPENTIMELINEIO_EXPORT std::string type_name_for_error_message(std::type_info const&);
+OPENTIMELINEIO_EXPORT std::string type_name_for_error_message(std::any const& a);
+OPENTIMELINEIO_EXPORT std::string type_name_for_error_message(class SerializableObject*);
 
 template <typename T>
 std::string
@@ -28,7 +29,7 @@ type_name_for_error_message()
     return type_name_for_error_message(typeid(T));
 }
 
-bool split_schema_string(
+OPENTIMELINEIO_EXPORT bool split_schema_string(
     std::string const& schema_and_version,
     std::string*       schema_name,
     int*               schema_version);

--- a/src/opentimelineio/timeEffect.h
+++ b/src/opentimelineio/timeEffect.h
@@ -9,7 +9,7 @@
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
 /// @brief Base class for all effects that alter the timing of an item.
-class TimeEffect : public Effect
+class OPENTIMELINEIO_EXPORT TimeEffect : public Effect
 {
 public:
     /// @brief This struct provides the TimeEffect schema.

--- a/src/opentimelineio/timeline.h
+++ b/src/opentimelineio/timeline.h
@@ -13,7 +13,7 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 class Clip;
 
 /// @brief A timeline contains a stack of tracks.
-class Timeline : public SerializableObjectWithMetadata
+class OPENTIMELINEIO_EXPORT Timeline : public SerializableObjectWithMetadata
 {
 public:
     /// @brief This struct provides the Timeline schema.

--- a/src/opentimelineio/track.h
+++ b/src/opentimelineio/track.h
@@ -11,7 +11,7 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 class Clip;
 
 /// @brief A track is a composition of a certain kind, like video or audio.
-class Track : public Composition
+class OPENTIMELINEIO_EXPORT Track : public Composition
 {
 public:
     /// @brief This struct provides the base set of kinds of tracks.

--- a/src/opentimelineio/trackAlgorithm.h
+++ b/src/opentimelineio/trackAlgorithm.h
@@ -9,7 +9,7 @@
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
 /// @brief Trim the track to the given range.
-Track* track_trimmed_to_range(
+OPENTIMELINEIO_EXPORT Track* track_trimmed_to_range(
     Track*       in_track,
     TimeRange    trim_range,
     ErrorStatus* error_status = nullptr);

--- a/src/opentimelineio/transition.h
+++ b/src/opentimelineio/transition.h
@@ -10,7 +10,7 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 /// @brief Represents a transition between the two adjacent items in a Track.
 ///
 /// For example, a cross dissolve or wipe.
-class Transition : public Composable
+class OPENTIMELINEIO_EXPORT Transition : public Composable
 {
 public:
     /// @brief This struct provides base set of transitions.

--- a/src/opentimelineio/typeRegistry.h
+++ b/src/opentimelineio/typeRegistry.h
@@ -33,10 +33,10 @@ using label_to_schema_version_map =
 
 ///@}
 
-extern const label_to_schema_version_map CORE_VERSION_MAP;
+OPENTIMELINEIO_EXPORT extern const label_to_schema_version_map CORE_VERSION_MAP;
 
 /// @brief Type registry.
-class TypeRegistry
+class OPENTIMELINEIO_EXPORT TypeRegistry
 {
 public:
     /// @brief Get the type registry singleton.

--- a/src/opentimelineio/unknownSchema.h
+++ b/src/opentimelineio/unknownSchema.h
@@ -9,7 +9,7 @@
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
 /// @brief An unknown schema.
-class UnknownSchema : public SerializableObject
+class OPENTIMELINEIO_EXPORT UnknownSchema : public SerializableObject
 {
 public:
     /// @brief This struct provides the UnknownSchema schema.


### PR DESCRIPTION
Fixes #1919

This change uses the CMake GenerateExportHeader functionality to explicitly export C++ symbols. In addition to fixing #1919, this can also potentially make the use of OTIO shared libraries more efficient.
