### PR TITLE
Remove MinGW CI job

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -99,7 +99,6 @@ jobs:
           - { os: macos-latest, shell: bash }
           - { os: macos-13, shell: bash }
           - { os: windows-latest, shell: pwsh }
-          - { os: windows-latest, shell: msys2, python-version: 'mingw64' }
         exclude:
           - { os: macos-latest, python-version: 3.9 }
 
@@ -115,20 +114,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
-    - name: Set up MSYS2
-      if: matrix.python-version == 'mingw64'
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: mingw64
-        install: >-
-          mingw-w64-x86_64-python
-          mingw-w64-x86_64-python-pip
-          mingw-w64-x86_64-gcc
-          mingw-w64-x86_64-cmake
-          make
-          git
     - name: Set up Python ${{ matrix.python-version }}
-      if: matrix.python-version != 'mingw64'
       uses: actions/setup-python@v5.4.0
       with:
         python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
This PR removes the MinGW CI job. It seems to have intermittent failures and I don't think we have the resources to troubleshoot it each time:
https://github.com/darbyjohnston/OpenTimelineIO/actions/runs/17500902789/job/49713367017
