### PR TITLE
Run tests on wheels

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -197,7 +197,7 @@ jobs:
           python -m pip install --break-system-packages --upgrade -r tests/requirements.txt
       - name: Build and Install OpenTimelineIO
         run: |
-          python -m pip install ./sdist/opentimelineio-*.tar.gz -v --break-system-packages
+          pkg=`ls -1 sdist/opentimelineio-*.tar.gz` python -m pip install $pkg -v --break-system-packages
       - name: Run tests w/ python coverage
         run: make ci-postbuild
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -121,9 +121,12 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel "flake8>=3.5" check-manifest
       - name: Run check-manifest and lint check
         run: make ci-prebuild
-      - name: Build and Install
+      - name: Install test dependencies
         run: |
-          python -m pip install -r tests/requirements.txt -v --break-system-packages
+          python -m pip install --upgrade -r tests/requirements.txt
+      - name: Build and Install OpenTimelineIO
+        run: |
+          python -m pip install . -v --break-system-packages
       - name: Run tests w/ python coverage
         run: make ci-postbuild
       # (only on GH_COV_OS and GH_COV_PY)

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -89,6 +89,7 @@ jobs:
           cmake ${{ github.workspace }}/tests/consumer -DCMAKE_PREFIX_PATH=${{ env.OTIO_INSTALL_DIR }}
 
   py_smoketest_build:
+    needs: package_sdist
     # Ideally this would be ${{ env.GH_COV_OS }} - but github doens't allow it
     runs-on: ubuntu-latest
     strategy:
@@ -104,9 +105,13 @@ jobs:
       OTIO_CXX_BUILD_TMP_DIR: ${{ github.workspace }}/build
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Get tests and requirements from source
+        uses: actions/checkout@v4
+      - name: Get sdist source
+        uses: actions/download-artifact@v5
         with:
-          submodules: "recursive"
+          name: sdist
+          path: 'sdist'
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5.4.0
         with:
@@ -126,7 +131,7 @@ jobs:
           python -m pip install --upgrade -r tests/requirements.txt
       - name: Build and Install OpenTimelineIO
         run: |
-          python -m pip install . -v --break-system-packages
+          python -m pip install sdist/opentimelineio-*.tar.gz -v --break-system-packages
       - name: Run tests w/ python coverage
         run: make ci-postbuild
       # (only on GH_COV_OS and GH_COV_PY)
@@ -145,6 +150,7 @@ jobs:
 
   # This is for platforms where we build and test, but don't make wheels
   py_testonly_build:
+    needs: package_sdist
     # Ideally this would be ${{ env.GH_COV_OS }} - but github doens't allow it
     runs-on: ${{ matrix.os }}
     strategy:
@@ -163,9 +169,11 @@ jobs:
       OTIO_CXX_BUILD_TMP_DIR: ${{ github.workspace }}/build
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Get sdist source
+        uses: actions/download-artifact@v5
         with:
-          submodules: "recursive"
+          name: sdist
+          path: 'sdist'
       - name: Set up MSYS2
         if: matrix.python-version == 'mingw64'
         uses: msys2/setup-msys2@v2
@@ -186,12 +194,14 @@ jobs:
       - name: Install python build dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel "flake8>=3.5" check-manifest
+      - name: Get source
+        uses: actions/checkout@v4
       - name: Install test dependencies
         run: |
           python -m pip install --break-system-packages --upgrade -r tests/requirements.txt
       - name: Build and Install OpenTimelineIO
         run: |
-          python -m pip install . -v --break-system-packages
+          python -m pip install sdist/opentimelineio-*.tar.gz -v --break-system-packages
       - name: Run tests w/ python coverage
         run: make ci-postbuild
 
@@ -275,7 +285,6 @@ jobs:
         run: make ci-postbuild
 
   package_sdist:
-    needs: py_smoketest_build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -227,7 +227,7 @@ jobs:
           path: 'wheelhouse'
           merge-multiple: true
       - name: Install wheel for environment
-        run: pip install  --no-index --find-links wheelhouse opentimelineio
+        run: pip install --no-cache-dir --break-system-packages --no-index --find-links wheelhouse opentimelineio
       - name: Run tests w/ python coverage
         run: make ci-postbuild
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -165,11 +165,6 @@ jobs:
       OTIO_CXX_BUILD_TMP_DIR: ${{ github.workspace }}/build
 
     steps:
-      - name: Get sdist source
-        uses: actions/download-artifact@v5
-        with:
-          name: sdist
-          path: ./sdist
       - name: Set up MSYS2
         if: matrix.python-version == 'mingw64'
         uses: msys2/setup-msys2@v2
@@ -187,7 +182,15 @@ jobs:
         uses: actions/setup-python@v5.4.0
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install python build dependencies
+      - name: Get sdist source
+        uses: actions/download-artifact@v5
+        with:
+          name: sdist
+          path: ./sdist
+      - name: Build and Install OpenTimelineIO
+        run: |
+          python -m pip install sdist/opentimelineio-*.tar.gz -v --break-system-packages
+      - name: Install python dev dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel "flake8>=3.5" check-manifest
       - name: Get source
@@ -195,10 +198,6 @@ jobs:
       - name: Install test dependencies
         run: |
           python -m pip install --break-system-packages --upgrade -r tests/requirements.txt
-      - name: Build and Install OpenTimelineIO
-        run: |
-          ls -1
-          pkg=`ls -1 sdist/opentimelineio-*.tar.gz` python -m pip install $pkg -v --break-system-packages
       - name: Run tests w/ python coverage
         run: make ci-postbuild
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -123,7 +123,7 @@ jobs:
         run: make ci-prebuild
       - name: Build and Install
         run: |
-          python -m pip install tests/requirements.txt -v --break-system-packages
+          python -m pip install -r tests/requirements.txt -v --break-system-packages
       - name: Run tests w/ python coverage
         run: make ci-postbuild
       # (only on GH_COV_OS and GH_COV_PY)

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -89,7 +89,6 @@ jobs:
           cmake ${{ github.workspace }}/tests/consumer -DCMAKE_PREFIX_PATH=${{ env.OTIO_INSTALL_DIR }}
 
   py_smoketest_build:
-    needs: package_sdist
     # Ideally this would be ${{ env.GH_COV_OS }} - but github doens't allow it
     runs-on: ubuntu-latest
     strategy:
@@ -107,11 +106,8 @@ jobs:
     steps:
       - name: Get tests and requirements from source
         uses: actions/checkout@v4
-      - name: Get sdist source
-        uses: actions/download-artifact@v5
         with:
-          name: sdist
-          path: 'sdist'
+          submodules: "recursive"
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5.4.0
         with:
@@ -131,7 +127,7 @@ jobs:
           python -m pip install --upgrade -r tests/requirements.txt
       - name: Build and Install OpenTimelineIO
         run: |
-          python -m pip install sdist/opentimelineio-*.tar.gz -v --break-system-packages
+          python -m pip install . -v --break-system-packages
       - name: Run tests w/ python coverage
         run: make ci-postbuild
       # (only on GH_COV_OS and GH_COV_PY)
@@ -201,12 +197,11 @@ jobs:
           python -m pip install --break-system-packages --upgrade -r tests/requirements.txt
       - name: Build and Install OpenTimelineIO
         run: |
-          python -m pip install sdist/opentimelineio-*.tar.gz -v --break-system-packages
+          python -m pip install --no-cache-dir --find-links sdist opentimelineio -v --break-system-packages
       - name: Run tests w/ python coverage
         run: make ci-postbuild
 
   package_wheels:
-    needs: py_smoketest_build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -89,7 +89,8 @@ jobs:
           cmake ${{ github.workspace }}/tests/consumer -DCMAKE_PREFIX_PATH=${{ env.OTIO_INSTALL_DIR }}
 
   py_smoketest_build:
-    runs-on: ${{ env.GH_COV_OS }}
+    # Ideally this would be ${{ env.GH_COV_OS }} - but github doens't allow it
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
@@ -99,7 +100,7 @@ jobs:
         shell: "bash {0}"
 
     env:
-      OTIO_CXX_COVERAGE_BUILD: ON
+      OTIO_CXX_COVERAGE_BUILD: 'ON'
       OTIO_CXX_BUILD_TMP_DIR: ${{ github.workspace }}/build
 
     steps:
@@ -155,6 +156,8 @@ jobs:
         python-build: ["cp39", "cp310", "cp311", "cp312", "cp313"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
 
       - name: Build wheels (Python 3)
         uses: pypa/cibuildwheel@v3.2.1
@@ -194,13 +197,11 @@ jobs:
         shell: "${{ matrix.shell }} {0}"
 
     env:
-      OTIO_CXX_COVERAGE_BUILD: ON
+      OTIO_CXX_COVERAGE_BUILD: 'ON'
       OTIO_CXX_BUILD_TMP_DIR: ${{ github.workspace }}/build
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
       - name: Set up MSYS2
         if: matrix.python-version == 'mingw64'
         uses: msys2/setup-msys2@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -228,10 +228,10 @@ jobs:
         if: matrix.python-version != 'mingw64'
         run: make ci-prebuild
       - uses: actions/download-artifact@v5
-          with:
-            pattern: 'wheel-.*'
-            path: 'wheelhouse'
-            merge-multiple: true
+        with:
+          pattern: 'wheel-.*'
+          path: 'wheelhouse'
+          merge-multiple: true
       - name: Install wheel for environment
         run: pip install  --no-index --find-links wheelhouse opentimelineio
       - name: Run tests w/ python coverage

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -197,7 +197,7 @@ jobs:
           python -m pip install --break-system-packages --upgrade -r tests/requirements.txt
       - name: Build and Install OpenTimelineIO
         run: |
-          ls -1 sdist/
+          ls -1
           pkg=`ls -1 sdist/opentimelineio-*.tar.gz` python -m pip install $pkg -v --break-system-packages
       - name: Run tests w/ python coverage
         run: make ci-postbuild

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -150,7 +150,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["mingw64"]
         include:
           - { os: windows-latest, shell: msys2, python-version: "mingw64" }
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -147,9 +147,9 @@ jobs:
   py_testonly_build:
     # Ideally this would be ${{ env.GH_COV_OS }} - but github doens't allow it
     runs-on: ${{ matrix.os }}
-    os: [windows-latest]
     strategy:
       matrix:
+        os: [windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           - { os: windows-latest, shell: msys2, python-version: "mingw64" }

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,7 +5,7 @@ name: OpenTimelineIO
 
 # for configuring which build will be a C++ coverage build / coverage report
 env:
-  GH_COV_PY: "3.10"
+  GH_COV_PY: "3.13"
   GH_COV_OS: ubuntu-latest
   GH_DEPENDABOT: dependabot
 
@@ -88,7 +88,93 @@ jobs:
           cd ${{ env.OTIO_CONSUMER_TEST_BUILD_DIR }}
           cmake ${{ github.workspace }}/tests/consumer -DCMAKE_PREFIX_PATH=${{ env.OTIO_INSTALL_DIR }}
 
-  py_build_test:
+  py_smoketest_build:
+    runs-on: ${{ env.GH_COV_OS }}
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+
+    defaults:
+      run:
+        shell: "bash {0}"
+
+    env:
+      OTIO_CXX_COVERAGE_BUILD: ON
+      OTIO_CXX_BUILD_TMP_DIR: ${{ github.workspace }}/build
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5.4.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install coverage dependency
+        if: matrix.python-version == env.GH_COV_PY && github.actor != env.GH_DEPENDABOT
+        run: |
+          echo 'OTIO_CXX_DEBUG_BUILD=1' >> $GITHUB_ENV
+          sudo apt-get install lcov
+      - name: Install python build dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel "flake8>=3.5" check-manifest
+      - name: Run check-manifest and lint check
+        run: make ci-prebuild
+      - name: Build and Install
+        run: |
+          python -m pip install tests/requirements.txt -v --break-system-packages
+      - name: Run tests w/ python coverage
+        run: make ci-postbuild
+      # (only on GH_COV_OS and GH_COV_PY)
+      - name: Generate C++ coverage report
+        if: matrix.python-version == env.GH_COV_PY && github.actor != env.GH_DEPENDABOT
+        run: make lcov
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == env.GH_COV_PY && github.actor != env.GH_DEPENDABOT
+        uses: codecov/codecov-action@v5
+        with:
+          flags: py-unittests
+          name: py-opentimelineio-codecov
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
+  package_wheels:
+    needs: py_smoketest_build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          [
+            ubuntu-latest,
+            ubuntu-24.04-arm,
+            windows-latest,
+            macos-14,
+            macos-latest,
+          ]
+        python-build: ["cp39", "cp310", "cp311", "cp312", "cp313"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels (Python 3)
+        uses: pypa/cibuildwheel@v3.2.1
+        with:
+          output-dir: wheelhouse
+        env:
+          CIBW_BUILD: ${{ matrix.python-build }}*
+          CIBW_SKIP: "*musllinux*"
+          CIBW_ARCHS_LINUX: native
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
+          MACOSX_DEPLOYMENT_TARGET: 10.15
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheel-${{ matrix.os }}-${{ matrix.python-build }}
+          path: ./wheelhouse/*.whl
+
+  test_wheels:
+    needs: package_wheels
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -132,76 +218,27 @@ jobs:
         uses: actions/setup-python@v5.4.0
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install coverage dependency
-        if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != env.GH_DEPENDABOT
-        run: |
-          echo 'OTIO_CXX_DEBUG_BUILD=1' >> $GITHUB_ENV
-          sudo apt-get install lcov
       - name: Install python build dependencies
         run: |
-          python -m pip install --upgrade pip setuptools wheel "flake8>=3.5" check-manifest
+          python -m pip install --upgrade pip setuptools wheel "flake8>=3.5" check-manifest && python -m pip install -r tests/requirements.txt
       # \todo Temporarily disable check-manifest on MinGW, it is failing
       # intermittently with this error:
       # ModuleNotFoundError: No module named 'pip._vendor.distlib'
       - name: Run check-manifest and lint check
         if: matrix.python-version != 'mingw64'
         run: make ci-prebuild
-      - name: Build and Install
-        run: |
-          pip install .[dev] -v --break-system-packages
+      - uses: actions/download-artifact@v5
+          with:
+            pattern: 'wheel-.*'
+            path: 'wheelhouse'
+            merge-multiple: true
+      - name: Install wheel for environment
+        run: pip install  --no-index --find-links wheelhouse opentimelineio
       - name: Run tests w/ python coverage
         run: make ci-postbuild
-      # (only on GH_COV_OS and GH_COV_PY)
-      - name: Generate C++ coverage report
-        if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != env.GH_DEPENDABOT
-        run: make lcov
-      - name: Upload coverage to Codecov
-        if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != env.GH_DEPENDABOT
-        uses: codecov/codecov-action@v4
-        with:
-          flags: py-unittests
-          name: py-opentimelineio-codecov
-          fail_ci_if_error: false
-        env:
-          # based on: https://github.com/codecov/codecov-action?tab=readme-ov-file#usage
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-  package_wheels:
-    needs: py_build_test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:
-          [
-            ubuntu-latest,
-            ubuntu-24.04-arm,
-            windows-latest,
-            macos-14,
-            macos-latest,
-          ]
-        python-build: ["cp39", "cp310", "cp311", "cp312", "cp313"]
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Build wheels (Python 3)
-        uses: pypa/cibuildwheel@v3.2.1
-        with:
-          output-dir: wheelhouse
-        env:
-          CIBW_BUILD: ${{ matrix.python-build }}*
-          CIBW_SKIP: "*musllinux*"
-          CIBW_ARCHS_LINUX: native
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
-          MACOSX_DEPLOYMENT_TARGET: 10.15
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: wheel-${{ matrix.os }}-${{ matrix.python-build }}
-          path: ./wheelhouse/*.whl
 
   package_sdist:
-    needs: py_build_test
+    needs: py_smoketest_build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -225,12 +225,6 @@ jobs:
       - name: Install python build dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel "flake8>=3.5" check-manifest && python -m pip install -r tests/requirements.txt
-      # \todo Temporarily disable check-manifest on MinGW, it is failing
-      # intermittently with this error:
-      # ModuleNotFoundError: No module named 'pip._vendor.distlib'
-      - name: Run check-manifest and lint check
-        if: matrix.python-version != 'mingw64'
-        run: make ci-prebuild
       - uses: actions/download-artifact@v5
         with:
           pattern: 'wheel-.*'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -143,6 +143,58 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 
+  # This is for platforms where we build and test, but don't make wheels
+  py_testonly_build:
+    # Ideally this would be ${{ env.GH_COV_OS }} - but github doens't allow it
+    runs-on: ${{ matrix.os }}
+    os: [windows-latest]
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        include:
+          - { os: windows-latest, shell: msys2, python-version: "mingw64" }
+
+    defaults:
+      run:
+        shell: "${{ matrix.shell }} {0}"
+
+    env:
+      OTIO_CXX_COVERAGE_BUILD: 'ON'
+      OTIO_CXX_BUILD_TMP_DIR: ${{ github.workspace }}/build
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - name: Set up MSYS2
+        if: matrix.python-version == 'mingw64'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: mingw64
+          install: >-
+            mingw-w64-x86_64-python
+            mingw-w64-x86_64-python-pip
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-cmake
+            make
+            git
+      - name: Set up Python ${{ matrix.python-version }}
+        if: matrix.python-version != 'mingw64'
+        uses: actions/setup-python@v5.4.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install python build dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel "flake8>=3.5" check-manifest
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade -r tests/requirements.txt
+      - name: Build and Install OpenTimelineIO
+        run: |
+          python -m pip install . -v --break-system-packages
+      - name: Run tests w/ python coverage
+        run: make ci-postbuild
+
   package_wheels:
     needs: py_smoketest_build
     runs-on: ${{ matrix.os }}
@@ -191,7 +243,6 @@ jobs:
           - { os: macos-latest, shell: bash }
           - { os: macos-14, shell: bash }
           - { os: windows-latest, shell: pwsh }
-          - { os: windows-latest, shell: msys2, python-version: "mingw64" }
         exclude:
           - { os: macos-latest, python-version: 3.9 }
 
@@ -205,14 +256,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up MSYS2
-        if: matrix.python-version == 'mingw64'
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: mingw64
-          install: >-
-            mingw-w64-x86_64-python
-            mingw-w64-x86_64-python-pip
       - name: Set up Python ${{ matrix.python-version }}
         if: matrix.python-version != 'mingw64'
         uses: actions/setup-python@v5.4.0
@@ -220,14 +263,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install python build dependencies
         run: |
-          python -m pip install --upgrade pip setuptools wheel "flake8>=3.5" check-manifest && python -m pip install --upgrade --break-system-packages -r tests/requirements.txt
+          python -m pip install --upgrade pip setuptools wheel "flake8>=3.5" check-manifest && python -m pip install --upgrade -r tests/requirements.txt
       - uses: actions/download-artifact@v5
         with:
           pattern: wheel-${{ matrix.os }}-*
           path: 'wheelhouse'
           merge-multiple: true
       - name: Install wheel for environment
-        run: pip install --no-cache-dir --break-system-packages --no-index --find-links wheelhouse opentimelineio
+        run: pip install --no-cache-dir --no-index --find-links wheelhouse opentimelineio
       - name: Run tests w/ python coverage
         run: make ci-postbuild
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -188,7 +188,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel "flake8>=3.5" check-manifest
       - name: Install test dependencies
         run: |
-          python -m pip install --upgrade -r tests/requirements.txt
+          python -m pip install --break-system-packages --upgrade -r tests/requirements.txt
       - name: Build and Install OpenTimelineIO
         run: |
           python -m pip install . -v --break-system-packages

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -213,10 +213,6 @@ jobs:
           install: >-
             mingw-w64-x86_64-python
             mingw-w64-x86_64-python-pip
-            mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-cmake
-            make
-            git
       - name: Set up Python ${{ matrix.python-version }}
         if: matrix.python-version != 'mingw64'
         uses: actions/setup-python@v5.4.0
@@ -224,7 +220,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install python build dependencies
         run: |
-          python -m pip install --upgrade pip setuptools wheel "flake8>=3.5" check-manifest && python -m pip install -r tests/requirements.txt
+          python -m pip install --upgrade pip setuptools wheel "flake8>=3.5" check-manifest && python -m pip install --upgrade --break-system-packages -r tests/requirements.txt
       - uses: actions/download-artifact@v5
         with:
           pattern: wheel-${{ matrix.os }}-*

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -227,7 +227,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel "flake8>=3.5" check-manifest && python -m pip install -r tests/requirements.txt
       - uses: actions/download-artifact@v5
         with:
-          pattern: 'wheel-.*'
+          pattern: 'wheel-*'
           path: 'wheelhouse'
           merge-multiple: true
       - name: Install wheel for environment

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -227,7 +227,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel "flake8>=3.5" check-manifest && python -m pip install -r tests/requirements.txt
       - uses: actions/download-artifact@v5
         with:
-          pattern: 'wheel-*'
+          pattern: wheel-${{ matrix.os }}-*
           path: 'wheelhouse'
           merge-multiple: true
       - name: Install wheel for environment

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -169,7 +169,7 @@ jobs:
         uses: actions/download-artifact@v5
         with:
           name: sdist
-          path: 'sdist'
+          path: ./sdist
       - name: Set up MSYS2
         if: matrix.python-version == 'mingw64'
         uses: msys2/setup-msys2@v2
@@ -197,7 +197,7 @@ jobs:
           python -m pip install --break-system-packages --upgrade -r tests/requirements.txt
       - name: Build and Install OpenTimelineIO
         run: |
-          python -m pip install --no-cache-dir --find-links sdist opentimelineio -v --break-system-packages
+          python -m pip install ./sdist/opentimelineio-*.tar.gz -v --break-system-packages
       - name: Run tests w/ python coverage
         run: make ci-postbuild
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -197,6 +197,7 @@ jobs:
           python -m pip install --break-system-packages --upgrade -r tests/requirements.txt
       - name: Build and Install OpenTimelineIO
         run: |
+          ls -1 sdist/
           pkg=`ls -1 sdist/opentimelineio-*.tar.gz` python -m pip install $pkg -v --break-system-packages
       - name: Run tests w/ python coverage
         run: make ci-postbuild

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ccend = $(shell echo "\033[0m")
 # Helpful link to install development dependencies declared in setup.py
 define dev_deps_message
 $(ccred)You can install this and other development dependencies with$(newline)$(ccend)\
-$(ccblue)	pip install -e .[dev]$(newline)$(ccend)
+$(ccblue)	pip install -e . && pip install -r tests/requirements.txt$(newline)$(ccend)
 endef
 
 # variables

--- a/setup.py
+++ b/setup.py
@@ -371,14 +371,6 @@ setup(
             ),
         ],
     },
-    extras_require={
-        'dev': [
-            'check-manifest',
-            'flake8>=3.5',
-            'coverage>=4.5',
-            'urllib3>=1.24.3'
-        ],
-    },
 
     # because we need to open() the adapters manifest, we aren't zip-safe
     zip_safe=False,

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,4 @@
+check-manifest
+flake8>=3.5
+coverage>=4.5
+urllib3>=1.24.3


### PR DESCRIPTION
This change re-shuffles the CI so that:

- A "smoke test" set of builds are run on one OS and generate coverage
- A separate "build and test only" set of platforms/python version run off the sdist (currently mingw)
- All wheels are built after smoke tests pass
- The test suite is run for each OS/python combo against the wheels

~Ideally this would take the suggestion from @JeanChristopheMorinPerso and run against `sdist` - that change hasn't been made.~
Update: after investigation, cibuildwheel isn't really meant to happen from sdist sources. I did a pass to make our build and test only phase run off it though - since those platforms would be running off sdist in the wild.

Additionally, if we could capture coverage from one of the cibuildwheel runs, we could probably eliminate  the smoke test phase.

- [x] ~Consider dropping the smoke test and just harvest coverage from testing the wheels~
    - Update: we decided against this because you need particular build options to generate needed coverage artifacts
- [x] Investigate having the wheel build to happen off the sdist
- [x] Currently the build and test only phase is hitting a test error - getting it to find the sdist tar.gz when the name is indeterminate (includes the version) is proving tricky
- [ ] Re-shuffle the order of repo checkout and wheel install in the wheel test action to match the test only step
- [ ] Reduce the matrix on the smoketest build so that it only does the one it needs for coverage - consider renaming explicitly as "generate_coverage" or similar

Fixes #1027 
This supersedes #1961 - the changes have been added to this PR