### PR TITLE
Replace GitHub action version tags with commit SHAs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,11 +10,11 @@ jobs:
   check-links:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: 'recursive'
 
-    - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+    - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: '3.10'
 
@@ -58,11 +58,11 @@ jobs:
   check-warnings:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: 'recursive'
 
-    - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+    - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: '3.10'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,11 +10,11 @@ jobs:
   check-links:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       with:
         submodules: 'recursive'
 
-    - uses: actions/setup-python@v5.4.0
+    - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
       with:
         python-version: '3.10'
 
@@ -58,11 +58,11 @@ jobs:
   check-warnings:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       with:
         submodules: 'recursive'
 
-    - uses: actions/setup-python@v5.4.0
+    - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
       with:
         python-version: '3.10'
 

--- a/.github/workflows/pr-tools.yml
+++ b/.github/workflows/pr-tools.yml
@@ -28,10 +28,10 @@
 #       pull-requests: write
 #     steps:
 #       - name: Checkout Repo
-#         uses: actions/checkout@v4 # https://github.com/actions/checkout/tree/main#usage
+#         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # https://github.com/actions/checkout/tree/main#usage
 
 #       # https://github.com/actions/labeler#usage
-#       - uses: actions/labeler@v4
+#       - uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594
 #         with:
 #           # https://github.com/actions/labeler#inputs
 #           configuration-path: .github/labeler.yml

--- a/.github/workflows/pr-tools.yml
+++ b/.github/workflows/pr-tools.yml
@@ -28,10 +28,10 @@
 #       pull-requests: write
 #     steps:
 #       - name: Checkout Repo
-#         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # https://github.com/actions/checkout/tree/main#usage
+#         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 https://github.com/actions/checkout/tree/main#usage
 
 #       # https://github.com/actions/labeler#usage
-#       - uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594
+#       - uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # v4
 #         with:
 #           # https://github.com/actions/labeler#inputs
 #           configuration-path: .github/labeler.yml

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -17,7 +17,7 @@ jobs:
     # happen for this actual commit (the commit that the tag points to).
     # It also restores the files timestamps.
     - name: Download wheels from commit ${{ github.sha }}
-      uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5
+      uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5 # v11
       with:
         workflow: python-package.yml
         workflow_conclusion: success
@@ -28,7 +28,7 @@ jobs:
         merge_multiple: true
 
     - name: Download sdist from commit ${{ github.sha }}
-      uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5
+      uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5 # v11
       with:
         workflow: python-package.yml
         workflow_conclusion: success
@@ -37,7 +37,7 @@ jobs:
         path: dist
 
     - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -17,7 +17,7 @@ jobs:
     # happen for this actual commit (the commit that the tag points to).
     # It also restores the files timestamps.
     - name: Download wheels from commit ${{ github.sha }}
-      uses: dawidd6/action-download-artifact@v11
+      uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5
       with:
         workflow: python-package.yml
         workflow_conclusion: success
@@ -28,7 +28,7 @@ jobs:
         merge_multiple: true
 
     - name: Download sdist from commit ${{ github.sha }}
-      uses: dawidd6/action-download-artifact@v11
+      uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5
       with:
         workflow: python-package.yml
         workflow_conclusion: success
@@ -37,7 +37,7 @@ jobs:
         path: dist
 
     - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,7 +44,7 @@ jobs:
       OTIO_CONSUMER_TEST_BUILD_DIR: ${{ github.workspace }}/consumertest
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: "recursive"
       - name: Install coverage dependency
@@ -72,7 +72,7 @@ jobs:
       # \todo Should the Codecov web pages show the results of the C++ or Python tests?
       #    - name: Upload coverage to Codecov
       #      if: matrix.os == env.GH_COV_OS && github.actor != env.GH_DEPENDABOT
-      #      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
+      #      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
       #      with:
       #        files: ${{ env.OTIO_BUILD_DIR }}/coverage.filtered.info
       #        flags: unittests
@@ -112,12 +112,12 @@ jobs:
       OTIO_CXX_BUILD_TMP_DIR: ${{ github.workspace }}/build
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: "recursive"
       - name: Set up MSYS2
         if: matrix.python-version == 'mingw64'
-        uses: msys2/setup-msys2@4f806de0a5a7294ffabaff804b38a9b435a73bda
+        uses: msys2/setup-msys2@4f806de0a5a7294ffabaff804b38a9b435a73bda # v2
         with:
           msystem: mingw64
           install: >-
@@ -129,7 +129,7 @@ jobs:
             git
       - name: Set up Python ${{ matrix.python-version }}
         if: matrix.python-version != 'mingw64'
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install coverage dependency
@@ -157,7 +157,7 @@ jobs:
         run: make lcov
       - name: Upload coverage to Codecov
         if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != env.GH_DEPENDABOT
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           flags: py-unittests
           name: py-opentimelineio-codecov
@@ -181,10 +181,10 @@ jobs:
           ]
         python-build: ["cp39", "cp310", "cp311", "cp312", "cp313"]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build wheels (Python 3)
-        uses: pypa/cibuildwheel@9c00cb4f6b517705a3794b22395aedc36257242c
+        uses: pypa/cibuildwheel@9c00cb4f6b517705a3794b22395aedc36257242c # v3.2.1
         with:
           output-dir: wheelhouse
         env:
@@ -195,7 +195,7 @@ jobs:
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
           MACOSX_DEPLOYMENT_TARGET: 10.15
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: wheel-${{ matrix.os }}-${{ matrix.python-build }}
           path: ./wheelhouse/*.whl
@@ -204,11 +204,11 @@ jobs:
     needs: py_build_test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: "recursive"
 
-      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
 
       - name: Install pypa/build
         run: python -m pip install build --user
@@ -216,7 +216,7 @@ jobs:
       - name: Generate sdist
         run: python -m build -s .
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: sdist
           path: dist

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,7 +44,7 @@ jobs:
       OTIO_CONSUMER_TEST_BUILD_DIR: ${{ github.workspace }}/consumertest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           submodules: "recursive"
       - name: Install coverage dependency
@@ -72,7 +72,7 @@ jobs:
       # \todo Should the Codecov web pages show the results of the C++ or Python tests?
       #    - name: Upload coverage to Codecov
       #      if: matrix.os == env.GH_COV_OS && github.actor != env.GH_DEPENDABOT
-      #      uses: codecov/codecov-action@v3.1.4
+      #      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
       #      with:
       #        files: ${{ env.OTIO_BUILD_DIR }}/coverage.filtered.info
       #        flags: unittests
@@ -112,12 +112,12 @@ jobs:
       OTIO_CXX_BUILD_TMP_DIR: ${{ github.workspace }}/build
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           submodules: "recursive"
       - name: Set up MSYS2
         if: matrix.python-version == 'mingw64'
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@4f806de0a5a7294ffabaff804b38a9b435a73bda
         with:
           msystem: mingw64
           install: >-
@@ -129,7 +129,7 @@ jobs:
             git
       - name: Set up Python ${{ matrix.python-version }}
         if: matrix.python-version != 'mingw64'
-        uses: actions/setup-python@v5.4.0
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install coverage dependency
@@ -157,7 +157,7 @@ jobs:
         run: make lcov
       - name: Upload coverage to Codecov
         if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != env.GH_DEPENDABOT
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
         with:
           flags: py-unittests
           name: py-opentimelineio-codecov
@@ -181,10 +181,10 @@ jobs:
           ]
         python-build: ["cp39", "cp310", "cp311", "cp312", "cp313"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Build wheels (Python 3)
-        uses: pypa/cibuildwheel@v3.2.1
+        uses: pypa/cibuildwheel@9c00cb4f6b517705a3794b22395aedc36257242c
         with:
           output-dir: wheelhouse
         env:
@@ -195,7 +195,7 @@ jobs:
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
           MACOSX_DEPLOYMENT_TARGET: 10.15
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: wheel-${{ matrix.os }}-${{ matrix.python-build }}
           path: ./wheelhouse/*.whl
@@ -204,11 +204,11 @@ jobs:
     needs: py_build_test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           submodules: "recursive"
 
-      - uses: actions/setup-python@v5.4.0
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
 
       - name: Install pypa/build
         run: python -m pip install build --user
@@ -216,7 +216,7 @@ jobs:
       - name: Generate sdist
         run: python -m build -s .
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: sdist
           path: dist

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -28,7 +28,7 @@ jobs:
     outputs:
       branch-name: ${{ steps.get-branch-name.outputs.branch-name }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Create Branch
         shell: bash
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: Draft or Update a Release
         # https://github.com/release-drafter/release-drafter
-        uses: release-drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7
+        uses: release-drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7 # v5
         id: draft-release
         with:
           publish: false
@@ -59,7 +59,7 @@ jobs:
 
       - name: Convert Github markdown to Slack markdown syntax
         # https://github.com/LoveToKnow/slackify-markdown-action
-        uses: LoveToKnow/slackify-markdown-action@444d1c5cb9c46a046c29bb88cc032e9c27d31f38
+        uses: LoveToKnow/slackify-markdown-action@444d1c5cb9c46a046c29bb88cc032e9c27d31f38 # v1.0.0
         if: ${{ github.event.inputs.notify == 'true' }}
         id: slack-markdown
         with:
@@ -70,7 +70,7 @@ jobs:
 
       - name: 'Slack Notification to ##opentimelineio'
         # https://github.com/rtCamp/action-slack-notify
-        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2
         if: ${{ github.event.inputs.notify == 'true' }}
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_RELEASES_URL }}

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -28,7 +28,7 @@ jobs:
     outputs:
       branch-name: ${{ steps.get-branch-name.outputs.branch-name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Create Branch
         shell: bash
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: Draft or Update a Release
         # https://github.com/release-drafter/release-drafter
-        uses: release-drafter/release-drafter@v5
+        uses: release-drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7
         id: draft-release
         with:
           publish: false
@@ -59,7 +59,7 @@ jobs:
 
       - name: Convert Github markdown to Slack markdown syntax
         # https://github.com/LoveToKnow/slackify-markdown-action
-        uses: LoveToKnow/slackify-markdown-action@v1.0.0
+        uses: LoveToKnow/slackify-markdown-action@444d1c5cb9c46a046c29bb88cc032e9c27d31f38
         if: ${{ github.event.inputs.notify == 'true' }}
         id: slack-markdown
         with:
@@ -70,7 +70,7 @@ jobs:
 
       - name: 'Slack Notification to ##opentimelineio'
         # https://github.com/rtCamp/action-slack-notify
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
         if: ${{ github.event.inputs.notify == 'true' }}
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_RELEASES_URL }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       
   announce-release:
     runs-on: ubuntu-latest
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Convert markdown to slack markdown
         # https://github.com/LoveToKnow/slackify-markdown-action
-        uses: LoveToKnow/slackify-markdown-action@444d1c5cb9c46a046c29bb88cc032e9c27d31f38
+        uses: LoveToKnow/slackify-markdown-action@444d1c5cb9c46a046c29bb88cc032e9c27d31f38 # v1.0.0
         id: slack-markdown
         with:
           text: |
@@ -35,7 +35,7 @@ jobs:
 
       - name: 'Slack Notification to #opentimelineio'
         # https://github.com/rtCamp/action-slack-notify
-        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_RELEASES_URL }}
           SLACK_ICON: https://avatars.githubusercontent.com/u/40807682?s=512&v=4

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       
   announce-release:
     runs-on: ubuntu-latest
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Convert markdown to slack markdown
         # https://github.com/LoveToKnow/slackify-markdown-action
-        uses: LoveToKnow/slackify-markdown-action@v1.0.0
+        uses: LoveToKnow/slackify-markdown-action@444d1c5cb9c46a046c29bb88cc032e9c27d31f38
         id: slack-markdown
         with:
           text: |
@@ -35,7 +35,7 @@ jobs:
 
       - name: 'Slack Notification to #opentimelineio'
         # https://github.com/rtCamp/action-slack-notify
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_RELEASES_URL }}
           SLACK_ICON: https://avatars.githubusercontent.com/u/40807682?s=512&v=4


### PR DESCRIPTION
This PR replaces the version tags used in the GitHub actions with their corresponding commit SHAs. This is intended to improve security since the SHAs are immutable while the tags can potentially change.

Note that it looked like `pypa/gh-action-pypi-publish` was pointing to a branch name, so I used the latest version of v1 (v1.13.0).