### PR TITLE
Fix various warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 # FindPython's Development.Module component was added in 3.18.
 # Require 3.18.2+ because pybind11 recommends it.
 cmake_minimum_required(VERSION 3.18.2)
+# This policy CMP0177 can be removed when we upgrade to CMake >= 3.31.
+cmake_policy(SET CMP0177 NEW)
 
 #------------------------------------------------------------------------------
 # Project Metadata

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,32 @@
-include README.md README_contrib.md LICENSE.txt NOTICE.txt SECURITY.md CMakeLists.txt
+include README.md README_contrib.md CHANGELOG.md LICENSE.txt NOTICE.txt SECURITY.md CMakeLists.txt
 recursive-include examples *
 recursive-include src *
 recursive-include tests *
+prune .github
+prune docs
+prune doxygen
+exclude .gitmodules
+recursive-exclude src *.git
+exclude .readthedocs.yml
+exclude readthedocs-conda.yml
+exclude .codecov.yml
+exclude .gitlab-ci.yml
+exclude *.pdf
+exclude ADOPTERS.md
+exclude CODE_OF_CONDUCT.md
+exclude CONTRIBUTING.md
+exclude CONTRIBUTORS.md
+exclude GOVERNANCE.md
+exclude VERSIONS.md
+exclude Makefile
 exclude */.DS_Store
+exclude .clang-format
+exclude OTIO_VERSION.json
 global-exclude *.pyc
+global-exclude *.so
 global-exclude *.pyd
+
+prune maintainers
+prune tsc
+prune src/deps/pybind11/tools/clang
 prune src/deps/rapidjson/thirdparty

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,32 +1,8 @@
-include README.md README_contrib.md CHANGELOG.md LICENSE.txt NOTICE.txt SECURITY.md CMakeLists.txt
+include README.md README_contrib.md LICENSE.txt NOTICE.txt SECURITY.md CMakeLists.txt
 recursive-include examples *
 recursive-include src *
 recursive-include tests *
-prune .github
-prune docs
-prune doxygen
-exclude .gitmodules
-recursive-exclude src *.git
-exclude .readthedocs.yml
-exclude readthedocs-conda.yml
-exclude .codecov.yml
-exclude .gitlab-ci.yml
-exclude *.pdf
-exclude ADOPTERS.md
-exclude CODE_OF_CONDUCT.md
-exclude CONTRIBUTING.md
-exclude CONTRIBUTORS.md
-exclude GOVERNANCE.md
-exclude VERSIONS.md
-exclude Makefile
 exclude */.DS_Store
-exclude .clang-format
-exclude OTIO_VERSION.json
 global-exclude *.pyc
-global-exclude *.so
 global-exclude *.pyd
-
-prune maintainers
-prune tsc
-prune src/deps/pybind11/tools/clang
 prune src/deps/rapidjson/thirdparty

--- a/src/opentimelineio/serializableObject.h
+++ b/src/opentimelineio/serializableObject.h
@@ -162,7 +162,7 @@ public:
         template <typename T>
         bool read(std::string const& key, Retainer<T>* dest)
         {
-            SerializableObject* so;
+            SerializableObject* so = nullptr;
             if (!read(key, &so))
             {
                 return false;


### PR DESCRIPTION
Fixes #1408

This PR fixes various warnings in the OTIO build:
* C++ warnings
* CMake warnings
* ~~setuptools warnings~~ (these were actually necessary for `check-manifest`)

We still have a couple of C++ warnings about functions that have been deprecated, these should probably stay on to remind us to remove them at some point.

The setuptools warnings:
```
warning: no previously-included files found matching 'CHANGELOG.md'
```
Seem to be coming from excluding files in the manifest that were not included in the first place, but it would be good for someone with more Python knowledge to double check this. There are still a couple of warnings about temporary files (*.pyc, .DS_Store, etc.) that seem OK to leave in.
