### PR TITLE
Consistent namespace use in C++ tests

### DIFF
--- a/tests/test_clip.cpp
+++ b/tests/test_clip.cpp
@@ -15,8 +15,7 @@
 
 #include <iostream>
 
-namespace otime = opentime::OPENTIME_VERSION_NS;
-namespace otio  = opentimelineio::OPENTIMELINEIO_VERSION_NS;
+using namespace OTIO_NS;
 
 int
 main(int argc, char** argv)
@@ -24,17 +23,16 @@ main(int argc, char** argv)
     Tests tests;
 
     tests.add_test("test_cons", [] {
-        std::string         name = "test";
-        otime::RationalTime rt(5, 24);
-        otime::TimeRange    tr(rt, rt);
+        std::string  name = "test";
+        RationalTime rt(5, 24);
+        TimeRange    tr(rt, rt);
 
-        otio::SerializableObject::Retainer<otio::ExternalReference> mr(
-            new otio::ExternalReference);
-        mr->set_available_range(
-            otime::TimeRange(rt, otime::RationalTime(10, 24)));
+        SerializableObject::Retainer<ExternalReference> mr(
+            new ExternalReference);
+        mr->set_available_range(TimeRange(rt, RationalTime(10, 24)));
         mr->set_target_url("/var/tmp/test.mov");
 
-        otio::SerializableObject::Retainer<otio::Clip> cl(new otio::Clip);
+        SerializableObject::Retainer<Clip> cl(new Clip);
         cl->set_name(name);
         cl->set_media_reference(mr);
         cl->set_source_range(tr);
@@ -42,21 +40,20 @@ main(int argc, char** argv)
         assertEqual(cl->source_range().value(), tr);
 
         std::string encoded = cl->to_json_string();
-        otio::SerializableObject::Retainer<otio::SerializableObject> decoded(
-            otio::SerializableObject::from_json_string(encoded));
+        SerializableObject::Retainer<SerializableObject> decoded(
+            SerializableObject::from_json_string(encoded));
         assertTrue(cl->is_equivalent_to(*decoded));
     });
 
     tests.add_test("test_ranges", [] {
-        otime::TimeRange tr(
+        TimeRange tr(
             // 1 hour in at 24 fps
-            otime::RationalTime(86400, 24),
-            otime::RationalTime(200, 24));
+            RationalTime(86400, 24),
+            RationalTime(200, 24));
 
-        otio::SerializableObject::Retainer<otio::Clip> cl(
-            new otio::Clip("test_clip"));
-        otio::SerializableObject::Retainer<otio::ExternalReference> mr(
-            new otio::ExternalReference);
+        SerializableObject::Retainer<Clip> cl(new Clip("test_clip"));
+        SerializableObject::Retainer<ExternalReference> mr(
+            new ExternalReference);
         mr->set_target_url("/var/tmp/test.mov");
         mr->set_available_range(tr);
         cl->set_media_reference(mr);
@@ -65,10 +62,10 @@ main(int argc, char** argv)
         assertEqual(cl->trimmed_range(), tr);
         assertEqual(cl->available_range(), tr);
 
-        cl->set_source_range(otime::TimeRange(
+        cl->set_source_range(TimeRange(
             // 1 hour + 100 frames
-            otime::RationalTime(86500, 24),
-            otime::RationalTime(50, 24)));
+            RationalTime(86500, 24),
+            RationalTime(50, 24)));
         assertNotEqual(cl->duration(), tr.duration());
         assertNotEqual(cl->trimmed_range(), tr);
         assertEqual(cl->duration(), cl->source_range()->duration());
@@ -76,9 +73,8 @@ main(int argc, char** argv)
     });
 
     tests.add_test("test_clip_v1_to_v2_null", [] {
-        using namespace otio;
 
-        otio::ErrorStatus              status;
+        OTIO_NS::ErrorStatus           status;
         SerializableObject::Retainer<> so =
             SerializableObject::from_json_string(
                 R"(
@@ -99,9 +95,8 @@ main(int argc, char** argv)
     });
 
     tests.add_test("test_clip_v1_to_v2", [] {
-        using namespace otio;
 
-        otio::ErrorStatus              status;
+        OTIO_NS::ErrorStatus           status;
         SerializableObject::Retainer<> so =
             SerializableObject::from_json_string(
                 R"(
@@ -151,7 +146,6 @@ main(int argc, char** argv)
     });
 
     tests.add_test("test_clip_media_representation", [] {
-        using namespace otio;
 
         static constexpr auto time_scalar = 1.5;
 
@@ -173,7 +167,7 @@ main(int argc, char** argv)
         static constexpr auto proxy_quality = "proxy_quality";
 
         SerializableObject::Retainer<MediaReference> media(
-            new otio::ExternalReference());
+            new ExternalReference());
 
         SerializableObject::Retainer<Clip> clip(new Clip(
             "unit_clip",
@@ -189,11 +183,11 @@ main(int argc, char** argv)
         assertEqual(clip->active_media_reference_key().c_str(), high_quality);
 
         SerializableObject::Retainer<MediaReference> ref1(
-            new otio::ExternalReference());
+            new ExternalReference());
         SerializableObject::Retainer<MediaReference> ref2(
-            new otio::ExternalReference());
+            new ExternalReference());
         SerializableObject::Retainer<MediaReference> ref3(
-            new otio::ExternalReference());
+            new ExternalReference());
 
         clip->set_media_references(
             { { Clip::default_media_key, ref1 },
@@ -211,36 +205,36 @@ main(int argc, char** argv)
 
         // setting the active reference to a key that does not exist
         // should return an error
-        otio::ErrorStatus error;
+        OTIO_NS::ErrorStatus error;
         clip->set_active_media_reference_key("cloud", &error);
-        assertTrue(otio::is_error(error));
+        assertTrue(is_error(error));
         assertEqual(
             error.outcome,
-            otio::ErrorStatus::MEDIA_REFERENCES_DO_NOT_CONTAIN_ACTIVE_KEY);
+            OTIO_NS::ErrorStatus::MEDIA_REFERENCES_DO_NOT_CONTAIN_ACTIVE_KEY);
         assertEqual(clip->media_reference(), ref1.value);
 
         // setting the references that doesn't have the active key should
         // also generate an error
         SerializableObject::Retainer<MediaReference> ref4(
-            new otio::ExternalReference());
+            new ExternalReference());
 
-        otio::ErrorStatus error2;
+        OTIO_NS::ErrorStatus error2;
         clip->set_media_references(
             { { "cloud", ref4 } }, high_quality, &error2);
-        assertTrue(otio::is_error(error2));
+        assertTrue(is_error(error2));
         assertEqual(
             error2.outcome,
-            otio::ErrorStatus::MEDIA_REFERENCES_DO_NOT_CONTAIN_ACTIVE_KEY);
+            OTIO_NS::ErrorStatus::MEDIA_REFERENCES_DO_NOT_CONTAIN_ACTIVE_KEY);
 
         assertEqual(clip->media_reference(), ref1.value);
 
         // setting an empty should also generate an error
-        otio::ErrorStatus error3;
+        OTIO_NS::ErrorStatus error3;
         clip->set_media_references({ { "", ref4 } }, "", &error3);
-        assertTrue(otio::is_error(error3));
+        assertTrue(is_error(error3));
         assertEqual(
             error3.outcome,
-            otio::ErrorStatus::MEDIA_REFERENCES_CONTAIN_EMPTY_KEY);
+            OTIO_NS::ErrorStatus::MEDIA_REFERENCES_CONTAIN_EMPTY_KEY);
 
         // setting the references and the active key at the same time
         // should work
@@ -263,21 +257,19 @@ main(int argc, char** argv)
     // test to ensure null error_status pointers are correctly handled
     tests.add_test("test_error_ptr_null", [] {
 
-        using namespace otio;
-
         // tests for no image bounds on media reference on clip
         SerializableObject::Retainer<Clip> clip(new Clip);
 
         // check that there is an error, and that it's the correct error
-        otio::ErrorStatus mr_bounds_error;
+        OTIO_NS::ErrorStatus mr_bounds_error;
         clip->available_image_bounds(&mr_bounds_error);
-        assertTrue(otio::is_error(mr_bounds_error));
+        assertTrue(is_error(mr_bounds_error));
         assertEqual(
             mr_bounds_error.outcome,
-            otio::ErrorStatus::CANNOT_COMPUTE_BOUNDS);
+            OTIO_NS::ErrorStatus::CANNOT_COMPUTE_BOUNDS);
 
         // check that if null ptr, nothing happens
-        otio::ErrorStatus* null_test = nullptr;
+        OTIO_NS::ErrorStatus* null_test = nullptr;
 
         assertEqual(
             clip->available_image_bounds(null_test), std::optional<IMATH_NAMESPACE::Box2d>()
@@ -287,7 +279,6 @@ main(int argc, char** argv)
     // test to ensure null error_status pointers are correctly handled
     // when there's no media reference
     tests.add_test("test_error_ptr_null_no_media", [] {
-        using namespace otio;
 
         SerializableObject::Retainer<Clip> clip(new Clip);
 
@@ -296,17 +287,17 @@ main(int argc, char** argv)
         empty_mrs["empty"] = nullptr;
         clip->set_media_references(empty_mrs, "empty");
 
-        otio::ErrorStatus bounds_error_no_mr;
+        OTIO_NS::ErrorStatus bounds_error_no_mr;
         clip->available_image_bounds(&bounds_error_no_mr);
-        assertTrue(otio::is_error(bounds_error_no_mr));
+        assertTrue(is_error(bounds_error_no_mr));
 
         assertEqual(
             bounds_error_no_mr.outcome,
-            otio::ErrorStatus::CANNOT_COMPUTE_BOUNDS);
+            OTIO_NS::ErrorStatus::CANNOT_COMPUTE_BOUNDS);
 
         // std::cout<< "bounds error details: " << bounds_error_no_mr.details << std::endl;
 
-        otio::ErrorStatus* null_test_no_mr = nullptr;
+        OTIO_NS::ErrorStatus* null_test_no_mr = nullptr;
 
         assertEqual(
             clip->available_image_bounds(null_test_no_mr), std::optional<IMATH_NAMESPACE::Box2d>()

--- a/tests/test_composition.cpp
+++ b/tests/test_composition.cpp
@@ -12,8 +12,7 @@
 
 #include <iostream>
 
-namespace otime = opentime::OPENTIME_VERSION_NS;
-namespace otio  = opentimelineio::OPENTIMELINEIO_VERSION_NS;
+using namespace OTIO_NS;
 
 int
 main(int argc, char** argv)
@@ -23,7 +22,6 @@ main(int argc, char** argv)
     // test a basic case of find_children
     tests.add_test(
         "test_find_children", [] {
-        using namespace otio;
         SerializableObject::Retainer<Composition>  comp  = new Composition;
         SerializableObject::Retainer<Item>  item  = new Item;
 
@@ -37,7 +35,6 @@ main(int argc, char** argv)
     // test stack and track correctly calls find_clips from composition parent class
     tests.add_test(
         "test_find_clips", [] {
-        using namespace otio;
         SerializableObject::Retainer<Stack> stack = new Stack();
         SerializableObject::Retainer<Track> track = new Track;
         SerializableObject::Retainer<Clip>  clip  = new Clip;

--- a/tests/test_editAlgorithm.cpp
+++ b/tests/test_editAlgorithm.cpp
@@ -15,13 +15,8 @@
 // Uncomment this for debugging output
 #define DEBUG
 
-
-namespace otime = opentime::OPENTIME_VERSION_NS;
-namespace otio  = opentimelineio::OPENTIMELINEIO_VERSION_NS;
-
-using otime::RationalTime;
-using otime::TimeRange;
-using otio::algo::ReferencePoint;
+using namespace OTIO_NS;
+using OTIO_NS::algo::ReferencePoint;
 
 #ifdef DEBUG
 
@@ -57,20 +52,20 @@ assert_duration(const RationalTime& new_duration, const RationalTime& duration)
 }
 
 void
-debug_track_ranges(const std::string& title, otio::Track* track)
+debug_track_ranges(const std::string& title, Track* track)
 {
 #ifdef DEBUG
     std::cout << "\t" << title << " TRACK RANGES" << std::endl;
     for (const auto& child: track->children())
     {
-        auto clip = otio::dynamic_retainer_cast<otio::Clip>(child);
+        auto clip = dynamic_retainer_cast<Clip>(child);
         if (clip)
         {
             auto range = track->trimmed_range_of_child(child).value();
             std::cout << "\t\t" << clip->name() << " " << range
                       << std::endl;
         }
-        auto gap = otio::dynamic_retainer_cast<otio::Gap>(child);
+        auto gap = dynamic_retainer_cast<Gap>(child);
         if (gap)
         {
             auto range = track->trimmed_range_of_child(child).value();
@@ -78,7 +73,7 @@ debug_track_ranges(const std::string& title, otio::Track* track)
             if (name.empty()) name = "gap";
             std::cout << "\t\t" << name << " " << range << std::endl;
         }
-        auto transition = otio::dynamic_retainer_cast<otio::Transition>(child);
+        auto transition = dynamic_retainer_cast<Transition>(child);
         if (transition)
         {
             auto range = track->trimmed_range_of_child(child).value();
@@ -92,19 +87,19 @@ debug_track_ranges(const std::string& title, otio::Track* track)
 }
 
 void
-debug_clip_ranges(const std::string& title, otio::Track* track)
+debug_clip_ranges(const std::string& title, Track* track)
 {
 #ifdef DEBUG
     std::cout << "\t" << title << " CLIP TRIMMED RANGES" << std::endl;
     for (const auto& child: track->children())
     {
-        auto clip = otio::dynamic_retainer_cast<otio::Clip>(child);
+        auto clip = dynamic_retainer_cast<Clip>(child);
         if (clip)
         {
             auto range = clip->trimmed_range();
             std::cout << "\t\t" << clip->name() << " " << range << std::endl;
         }
-        auto gap = otio::dynamic_retainer_cast<otio::Gap>(child);
+        auto gap = dynamic_retainer_cast<Gap>(child);
         if (gap)
         {
             auto range = gap->trimmed_range();
@@ -119,14 +114,14 @@ debug_clip_ranges(const std::string& title, otio::Track* track)
 
 void
 assert_clip_ranges(
-    otio::Track*                  track,
+    Track*                        track,
     const std::vector<TimeRange>& expected_ranges)
 {
-    std::vector<otio::TimeRange> ranges;
+    std::vector<TimeRange> ranges;
     size_t children = 0;
     for (const auto& child: track->children())
     {
-        auto item = otio::dynamic_retainer_cast<otio::Item>(child);
+        auto item = dynamic_retainer_cast<Item>(child);
         if (item)
         {
             ranges.push_back(item->trimmed_range());
@@ -140,14 +135,14 @@ assert_clip_ranges(
 
 void
 assert_track_ranges(
-    otio::Track*                  track,
+    Track*                        track,
     const std::vector<TimeRange>& expected_ranges)
 {
-    std::vector<otio::TimeRange> ranges;
+    std::vector<TimeRange> ranges;
     size_t children = 0;
     for (const auto& child: track->children())
     {
-        auto item = otio::dynamic_retainer_cast<otio::Item>(child);
+        auto item = dynamic_retainer_cast<Item>(child);
         if (item)
         {
             ranges.push_back(track->trimmed_range_of_child(child).value());
@@ -166,15 +161,15 @@ test_edit_slice(
     const std::vector<TimeRange>& slice_ranges)
 {
     // Create a track with one clip.
-    otio::SerializableObject::Retainer<otio::Clip> clip_0 =
-        new otio::Clip("clip_0", nullptr, clip_range);
-    otio::SerializableObject::Retainer<otio::Track> track = new otio::Track();
+    SerializableObject::Retainer<Clip> clip_0 =
+        new Clip("clip_0", nullptr, clip_range);
+    SerializableObject::Retainer<Track> track = new Track();
     track->append_child(clip_0); 
 
     debug_track_ranges("START", track);
     
     // Slice.
-    otio::algo::slice(track, slice_time);
+    algo::slice(track, slice_time);
 
     // Asserts.
     assert_track_ranges(track, slice_ranges);
@@ -187,35 +182,35 @@ test_edit_slice_transitions(
     const std::vector<TimeRange>& slice_ranges)
 {
     // Create a track with two clips and one transition.
-    otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+    SerializableObject::Retainer<Clip> clip_0 = new Clip(
         "clip_0",
         nullptr,
         TimeRange(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0)));
-    otio::SerializableObject::Retainer<otio::Clip> clip_1 = new otio::Clip(
+    SerializableObject::Retainer<Clip> clip_1 = new Clip(
         "clip_1",
         nullptr,
         TimeRange(RationalTime(0.0, 24.0), RationalTime(50.0, 24.0)));
-    otio::SerializableObject::Retainer<otio::Clip> clip_2 = new otio::Clip(
+    SerializableObject::Retainer<Clip> clip_2 = new Clip(
         "clip_2",
         nullptr,
         TimeRange(RationalTime(0.0, 24.0), RationalTime(30.0, 24.0)));
-    otio::SerializableObject::Retainer<otio::Clip> clip_3 = new otio::Clip(
+    SerializableObject::Retainer<Clip> clip_3 = new Clip(
         "clip_3",
         nullptr,
         TimeRange(RationalTime(0.0, 24.0), RationalTime(25.0, 24.0)));
-    otio::SerializableObject::Retainer<otio::Transition> transition_0 =
-        new otio::Transition(
+    SerializableObject::Retainer<Transition> transition_0 =
+        new Transition(
             "transition_0",
-            otio::Transition::Type::SMPTE_Dissolve,
+            Transition::Type::SMPTE_Dissolve,
             RationalTime(5.0, 24.0),
             RationalTime(3.0, 24.0));
-    otio::SerializableObject::Retainer<otio::Transition> transition_1 =
-        new otio::Transition(
+    SerializableObject::Retainer<Transition> transition_1 =
+        new Transition(
             "transition_1",
-            otio::Transition::Type::SMPTE_Dissolve,
+            Transition::Type::SMPTE_Dissolve,
             RationalTime(5.0, 24.0),
             RationalTime(3.0, 24.0));
-    otio::SerializableObject::Retainer<otio::Track> track = new otio::Track();
+    SerializableObject::Retainer<Track> track = new Track();
     track->append_child(clip_0); 
     track->append_child(clip_1);
     track->insert_child(1, transition_0);
@@ -226,7 +221,7 @@ test_edit_slice_transitions(
     debug_track_ranges("START", track);
     
     // Slice.
-    otio::algo::slice(track, slice_time);
+    algo::slice(track, slice_time);
 
     // Asserts.
     assert_track_ranges(track, slice_ranges);
@@ -240,18 +235,18 @@ test_edit_slip(
     const TimeRange slip_range)
 {
     // Create one clip with one media.
-    otio::SerializableObject::Retainer<otio::MediaReference>
-        media_0 = new otio::MediaReference(
+    SerializableObject::Retainer<MediaReference>
+        media_0 = new MediaReference(
             "media_0",
             media_range);
-    otio::SerializableObject::Retainer<otio::Clip> clip_0 =
-        new otio::Clip("clip_0", media_0, clip_range);
+    SerializableObject::Retainer<Clip> clip_0 =
+        new Clip("clip_0", media_0, clip_range);
     
     // Slip.
-    otio::algo::slip(clip_0, slip_time);
+    algo::slip(clip_0, slip_time);
 
     // Asserts.
-    const otio::TimeRange& range = clip_0->trimmed_range();
+    const TimeRange& range = clip_0->trimmed_range();
     assertEqual(slip_range, range);
 }
 
@@ -263,36 +258,36 @@ test_edit_slide(
     const std::vector<TimeRange>& slide_ranges)
 {
     // Create a track with three clips.
-    otio::SerializableObject::Retainer<otio::MediaReference>
-        media_0 = new otio::MediaReference(
+    SerializableObject::Retainer<MediaReference>
+        media_0 = new MediaReference(
             "media_0",
             media_range);
-    otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+    SerializableObject::Retainer<Clip> clip_0 = new Clip(
         "clip_0",
         media_0,
-        otio::TimeRange(
-            otio::RationalTime(0.0, 24.0),
-            otio::RationalTime(24.0, 24.0)));
-    otio::SerializableObject::Retainer<otio::Clip> clip_1 = new otio::Clip(
+        TimeRange(
+            RationalTime(0.0, 24.0),
+            RationalTime(24.0, 24.0)));
+    SerializableObject::Retainer<Clip> clip_1 = new Clip(
         "clip_1",
         nullptr,
-        otio::TimeRange(
-            otio::RationalTime(0.0, 24.0),
-            otio::RationalTime(30.0, 24.0)));
-    otio::SerializableObject::Retainer<otio::Clip> clip_2 = new otio::Clip(
+        TimeRange(
+            RationalTime(0.0, 24.0),
+            RationalTime(30.0, 24.0)));
+    SerializableObject::Retainer<Clip> clip_2 = new Clip(
         "clip_2",
         nullptr,
-        otio::TimeRange(
-            otio::RationalTime(0.0, 24.0),
-            otio::RationalTime(40.0, 24.0)));
-    otio::SerializableObject::Retainer<otio::Track> track =
-        new otio::Track();
+        TimeRange(
+            RationalTime(0.0, 24.0),
+            RationalTime(40.0, 24.0)));
+    SerializableObject::Retainer<Track> track =
+        new Track();
     track->append_child(clip_0);
     track->append_child(clip_1);
     track->append_child(clip_2);
 
     // Slide.
-    otio::algo::slide(clip_1, slide_time);
+    algo::slide(clip_1, slide_time);
 
     // Asserts.
     assert_track_ranges(track, slide_ranges);
@@ -306,37 +301,37 @@ void test_edit_ripple(
     )
 {
     // Create a track with one gap and two clips.
-    otio::SerializableObject::Retainer<otio::Gap> clip_0 = new otio::Gap(
-        otio::TimeRange(
-            otio::RationalTime(0.0, 24.0),
-            otio::RationalTime(20.0, 24.0)),
+    SerializableObject::Retainer<Gap> clip_0 = new Gap(
+        TimeRange(
+            RationalTime(0.0, 24.0),
+            RationalTime(20.0, 24.0)),
         "gap_0");
-    otio::SerializableObject::Retainer<otio::Clip> clip_1 = new otio::Clip(
+    SerializableObject::Retainer<Clip> clip_1 = new Clip(
         "clip_1",
         nullptr,
-        otio::TimeRange(
-            otio::RationalTime(5.0, 24.0),
-            otio::RationalTime(25.0, 24.0)));
-    otio::SerializableObject::Retainer<otio::Clip> clip_2 = new otio::Clip(
+        TimeRange(
+            RationalTime(5.0, 24.0),
+            RationalTime(25.0, 24.0)));
+    SerializableObject::Retainer<Clip> clip_2 = new Clip(
         "clip_2",
         nullptr,
-        otio::TimeRange(
-            otio::RationalTime(5.0, 24.0),
-            otio::RationalTime(20.0, 24.0)));
-    otio::SerializableObject::Retainer<otio::Track> track = new otio::Track();
+        TimeRange(
+            RationalTime(5.0, 24.0),
+            RationalTime(20.0, 24.0)));
+    SerializableObject::Retainer<Track> track = new Track();
     track->append_child(clip_0);
     track->append_child(clip_1);
     track->append_child(clip_2);
 
-    otio::ErrorStatus error_status;
-    otio::algo::ripple(
+    OTIO_NS::ErrorStatus error_status;
+    algo::ripple(
         clip_1,
         delta_in,
         delta_out,
         &error_status);
 
     // Asserts.
-    assert(!otio::is_error(error_status));
+    assert(!is_error(error_status));
     assert_track_ranges(track, track_ranges);
     assert_clip_ranges(track, item_ranges);
 }
@@ -349,37 +344,37 @@ void test_edit_roll(
     )
 {
     // Create a track with one gap and two clips.
-    otio::SerializableObject::Retainer<otio::Gap> clip_0 = new otio::Gap(
-        otio::TimeRange(
-            otio::RationalTime(0.0, 24.0),
-            otio::RationalTime(20.0, 24.0)),
+    SerializableObject::Retainer<Gap> clip_0 = new Gap(
+        TimeRange(
+            RationalTime(0.0, 24.0),
+            RationalTime(20.0, 24.0)),
         "gap_0");
-    otio::SerializableObject::Retainer<otio::Clip> clip_1 = new otio::Clip(
+    SerializableObject::Retainer<Clip> clip_1 = new Clip(
         "clip_1",
         nullptr,
-        otio::TimeRange(
-            otio::RationalTime(5.0, 24.0),
-            otio::RationalTime(30.0, 24.0)));
-    otio::SerializableObject::Retainer<otio::Clip> clip_2 = new otio::Clip(
+        TimeRange(
+            RationalTime(5.0, 24.0),
+            RationalTime(30.0, 24.0)));
+    SerializableObject::Retainer<Clip> clip_2 = new Clip(
         "clip_2",
         nullptr,
-        otio::TimeRange(
-            otio::RationalTime(5.0, 24.0),
-            otio::RationalTime(20.0, 24.0)));
-    otio::SerializableObject::Retainer<otio::Track> track = new otio::Track();
+        TimeRange(
+            RationalTime(5.0, 24.0),
+            RationalTime(20.0, 24.0)));
+    SerializableObject::Retainer<Track> track = new Track();
     track->append_child(clip_0);
     track->append_child(clip_1);
     track->append_child(clip_2);
 
-    otio::ErrorStatus error_status;
-    otio::algo::roll(
+    OTIO_NS::ErrorStatus error_status;
+    algo::roll(
         clip_1,
         delta_in,
         delta_out,
         &error_status);
 
     // Asserts.
-    assert(!otio::is_error(error_status));
+    assert(!is_error(error_status));
     assert_track_ranges(track, track_ranges);
     assert_clip_ranges(track, item_ranges);
 }
@@ -393,38 +388,38 @@ void test_edit_fill(
     )
 {
     // Create a track with one gap and two clips.  We leave one clip for fill.
-    otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+    SerializableObject::Retainer<Clip> clip_0 = new Clip(
         "clip_0",
         nullptr,
-        otio::TimeRange(
-            otio::RationalTime(0.0, 24.0),
-            otio::RationalTime(20.0, 24.0)));
-    otio::SerializableObject::Retainer<otio::Gap> clip_1 = new otio::Gap(
-        otio::TimeRange(
-            otio::RationalTime(5.0, 24.0),
-            otio::RationalTime(30.0, 24.0)),
+        TimeRange(
+            RationalTime(0.0, 24.0),
+            RationalTime(20.0, 24.0)));
+    SerializableObject::Retainer<Gap> clip_1 = new Gap(
+        TimeRange(
+            RationalTime(5.0, 24.0),
+            RationalTime(30.0, 24.0)),
         "gap_0");
-    otio::SerializableObject::Retainer<otio::Clip> clip_2 = new otio::Clip(
+    SerializableObject::Retainer<Clip> clip_2 = new Clip(
         "clip_2",
         nullptr,
-        otio::TimeRange(
-            otio::RationalTime(5.0, 24.0),
-            otio::RationalTime(20.0, 24.0)));
+        TimeRange(
+            RationalTime(5.0, 24.0),
+            RationalTime(20.0, 24.0)));
     
-    otio::SerializableObject::Retainer<otio::Clip> clip_3 = new otio::Clip(
+    SerializableObject::Retainer<Clip> clip_3 = new Clip(
         "fill_0",
         nullptr,
         clip_range);
 
-    otio::SerializableObject::Retainer<otio::Track> track = new otio::Track();
+    SerializableObject::Retainer<Track> track = new Track();
     track->append_child(clip_0);
     track->append_child(clip_1);
     track->append_child(clip_2);
 
     auto duration = track->duration();
 
-    otio::ErrorStatus error_status;
-    otio::algo::fill(
+    OTIO_NS::ErrorStatus error_status;
+    algo::fill(
         clip_3,
         track,
         track_time,
@@ -438,7 +433,7 @@ void test_edit_fill(
     {
         assert_duration(new_duration, duration);
     }
-    assert(!otio::is_error(error_status));
+    assert(!is_error(error_status));
     assert_track_ranges(track, track_ranges);
     assert_clip_ranges(track, item_ranges);
 }
@@ -490,40 +485,40 @@ main(int argc, char** argv)
         // Create a track with three clips of different rates
         // Slice the clips several times at different points.
         // Delete an item and slice again at same point.
-        otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_0 = new Clip(
             "clip_0",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 23.98),
-                otio::RationalTime(71.94, 23.98)));
-        otio::SerializableObject::Retainer<otio::Clip> clip_1 = new otio::Clip(
+            TimeRange(
+                RationalTime(0.0, 23.98),
+                RationalTime(71.94, 23.98)));
+        SerializableObject::Retainer<Clip> clip_1 = new Clip(
             "clip_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 23.98),
-                otio::RationalTime(71.94, 23.98)));
-        otio::SerializableObject::Retainer<otio::Clip> clip_2 = new otio::Clip(
+            TimeRange(
+                RationalTime(0.0, 23.98),
+                RationalTime(71.94, 23.98)));
+        SerializableObject::Retainer<Clip> clip_2 = new Clip(
             "clip_2",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(90.0, 30.0),
-                otio::RationalTime(90.0, 30.0)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(90.0, 30.0),
+                RationalTime(90.0, 30.0)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
         track->append_child(clip_1);
         track->append_child(clip_2);
         
         // Slice.
-        otio::ErrorStatus error_status;
-        otio::algo::slice(
+        OTIO_NS::ErrorStatus error_status;
+        algo::slice(
             track,
             RationalTime(121.0, 30.0),
             true,
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         assert_clip_ranges(track,
                             {
                                 TimeRange(
@@ -555,14 +550,14 @@ main(int argc, char** argv)
                                     RationalTime(90.0, 30.0))
                             });
 
-        otio::algo::slice(
+        algo::slice(
             track,
             RationalTime(122.0, 30.0),
             true,
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         assert_clip_ranges(track,
                             {
                                 TimeRange(
@@ -637,14 +632,14 @@ main(int argc, char** argv)
 
         // Slice again at the same points (this slice does nothing at it is at
         // start point).
-        otio::algo::slice(
+        algo::slice(
             track,
             RationalTime(121.0, 30.0),
             true,
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         assert_clip_ranges(track,
                             {
                                 TimeRange(
@@ -678,14 +673,14 @@ main(int argc, char** argv)
                             });
 
         // Slice again for one frame
-        otio::algo::slice(
+        algo::slice(
             track,
             RationalTime(122.0, 30.0),
             true,
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         assert_clip_ranges(track,
                             {
                                 TimeRange(
@@ -724,14 +719,14 @@ main(int argc, char** argv)
                             });
         
         // Slice again for one frame
-        otio::algo::slice(
+        algo::slice(
             track,
             RationalTime(179.0, 30.0),
             true,
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         assert_clip_ranges(track,
                             {
                                 TimeRange(
@@ -793,25 +788,25 @@ main(int argc, char** argv)
     
     tests.add_test("test_edit_overwrite_0", [] {
         // Create a track with one clip.
-        otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_0 = new Clip(
             "clip_0",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(24.0, 24.0)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
 
         // Overwrite past the clip.
-        otio::SerializableObject::Retainer<otio::Clip> clip_1 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_1 = new Clip(
             "clip_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
-        otio::ErrorStatus error_status;
-        otio::algo::overwrite(
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(24.0, 24.0)));
+        OTIO_NS::ErrorStatus error_status;
+        algo::overwrite(
             clip_1,
             track,
             TimeRange(RationalTime(48.0, 24.0), RationalTime(24.0, 24.0)),
@@ -820,40 +815,40 @@ main(int argc, char** argv)
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         assertEqual(track->children().size(), 3);
-        assert(otio::dynamic_retainer_cast<otio::Gap>(track->children()[1]));
+        assert(dynamic_retainer_cast<Gap>(track->children()[1]));
         const RationalTime duration = track->duration();
-        assert(duration == otio::RationalTime(72.0, 24.0));
+        assert(duration == RationalTime(72.0, 24.0));
         auto range = clip_1->trimmed_range_in_parent().value();
         assertEqual(
             range,
-            otio::TimeRange(
-                otio::RationalTime(48.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
+            TimeRange(
+                RationalTime(48.0, 24.0),
+                RationalTime(24.0, 24.0)));
     });
 
     tests.add_test("test_edit_overwrite_1", [] {
         // Create a track with one clip.
-        otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_0 = new Clip(
             "clip_0",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(24.0, 24.0)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
 
         // Overwrite past the clip.
-        otio::SerializableObject::Retainer<otio::Clip> clip_1 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_1 = new Clip(
             "clip_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
-        otio::ErrorStatus error_status;
-        otio::algo::overwrite(
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(24.0, 24.0)));
+        OTIO_NS::ErrorStatus error_status;
+        algo::overwrite(
             clip_1,
             track,
             TimeRange(RationalTime(48.0, 24.0), RationalTime(24.0, 24.0)),
@@ -862,40 +857,40 @@ main(int argc, char** argv)
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         assertEqual(track->children().size(), 3);
-        assert(otio::dynamic_retainer_cast<otio::Gap>(track->children()[1]));
+        assert(dynamic_retainer_cast<Gap>(track->children()[1]));
         const RationalTime duration = track->duration();
-        assert(duration == otio::RationalTime(72.0, 24.0));
+        assert(duration == RationalTime(72.0, 24.0));
         auto range = clip_1->trimmed_range_in_parent().value();
         assertEqual(
             range,
-            otio::TimeRange(
-                otio::RationalTime(48.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
+            TimeRange(
+                RationalTime(48.0, 24.0),
+                RationalTime(24.0, 24.0)));
     });
 
     tests.add_test("test_edit_overwrite_2", [] {
         // Create a track with one clip.
-        otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_0 = new Clip(
             "clip_0",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(1.0, 24.0),
-                otio::RationalTime(100.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(1.0, 24.0),
+                RationalTime(100.0, 24.0)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
 
         // Overwrite a single frame inside the clip.
-        otio::SerializableObject::Retainer<otio::Clip> clip_1 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_1 = new Clip(
             "clip_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(1.0, 24.0),
-                otio::RationalTime(1.0, 24.0)));
-        otio::ErrorStatus error_status;
-        otio::algo::overwrite(
+            TimeRange(
+                RationalTime(1.0, 24.0),
+                RationalTime(1.0, 24.0)));
+        OTIO_NS::ErrorStatus error_status;
+        algo::overwrite(
             clip_1,
             track,
             TimeRange(RationalTime(42.0, 24.0), RationalTime(1.0, 24.0)),
@@ -904,9 +899,9 @@ main(int argc, char** argv)
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         const RationalTime duration = track->duration();
-        assert(duration == otio::RationalTime(100.0, 24.0));
+        assert(duration == RationalTime(100.0, 24.0));
         assert_clip_ranges(track,
                             {
                                 TimeRange(
@@ -935,33 +930,33 @@ main(int argc, char** argv)
 
     tests.add_test("test_edit_overwrite_3", [] {
         // Create a track with two clips and overwrite a portion of both.
-        otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_0 = new Clip(
             "clip_0",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Clip> clip_1 = new otio::Clip(
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(24.0, 24.0)));
+        SerializableObject::Retainer<Clip> clip_1 = new Clip(
             "clip_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(24.0, 24.0)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
         track->append_child(clip_1);
 
         // Overwrite both clips.
-        otio::SerializableObject::Retainer<otio::Clip> clip_2 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_2 = new Clip(
             "clip_2",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(24.0, 24.0)));
         const RationalTime duration = track->duration();
-        otio::ErrorStatus  error_status;
-        otio::algo::overwrite(
+        OTIO_NS::ErrorStatus error_status;
+        algo::overwrite(
             clip_2,
             track,
             TimeRange(RationalTime(12.0, 24.0), RationalTime(24.0, 24.0)),
@@ -970,7 +965,7 @@ main(int argc, char** argv)
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         const RationalTime new_duration = track->duration();
         assert_duration(new_duration, duration);
         assert_track_ranges(track,
@@ -990,26 +985,26 @@ main(int argc, char** argv)
     
     tests.add_test("test_edit_overwrite_4", [] {
         // Create a track with one long clip.
-        otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_0 = new Clip(
             "clip_0",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(704.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(704.0, 24.0)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
 
         // Overwrite one portion of the clip.
-        otio::SerializableObject::Retainer<otio::Clip> over_1 = new otio::Clip(
+        SerializableObject::Retainer<Clip> over_1 = new Clip(
             "over_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(1.0, 24.0)));
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(1.0, 24.0)));
         const RationalTime duration = track->duration();
-        otio::ErrorStatus  error_status;
-        otio::algo::overwrite(
+        OTIO_NS::ErrorStatus error_status;
+        algo::overwrite(
             over_1,
             track,
             TimeRange(RationalTime(272.0, 24.0), RationalTime(1.0, 24.0)),
@@ -1018,7 +1013,7 @@ main(int argc, char** argv)
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         const RationalTime new_duration = track->duration();
         assert_duration(new_duration, duration);
         assert_track_ranges(track,
@@ -1049,33 +1044,33 @@ main(int argc, char** argv)
 
     tests.add_test("test_edit_overwrite_5", [] {
         // Create a track with one long clip.
-        otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_0 = new Clip(
             "clip_0",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 30.0),
-                otio::RationalTime(704.0, 30.0)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(0.0, 30.0),
+                RationalTime(704.0, 30.0)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
 
         // Overwrite one portion of the clip.
-        otio::SerializableObject::Retainer<otio::Clip> over_1 = new otio::Clip(
+        SerializableObject::Retainer<Clip> over_1 = new Clip(
             "over_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 30.0),
-                otio::RationalTime(1.0, 30.0)));
+            TimeRange(
+                RationalTime(0.0, 30.0),
+                RationalTime(1.0, 30.0)));
         const RationalTime duration = track->duration();
-        otio::ErrorStatus  error_status;
-        otio::algo::overwrite(
+        OTIO_NS::ErrorStatus error_status;
+        algo::overwrite(
             over_1,
             track,
             TimeRange(RationalTime(272.0, 30.0), RationalTime(1.0, 30.0)),
             true,
             nullptr,
             &error_status);
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         {
             const RationalTime new_duration = track->duration();
             assert_duration(new_duration, duration);
@@ -1106,14 +1101,14 @@ main(int argc, char** argv)
                             });
 
         // Overwrite another portion of the clip.
-        otio::SerializableObject::Retainer<otio::Clip> over_2 = new otio::Clip(
+        SerializableObject::Retainer<Clip> over_2 = new Clip(
             "over_2",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 30.0),
-                otio::RationalTime(1.0, 30.0)));
+            TimeRange(
+                RationalTime(0.0, 30.0),
+                RationalTime(1.0, 30.0)));
         
-        otio::algo::overwrite(
+        algo::overwrite(
             over_2,
             track,
             TimeRange(RationalTime(360.0, 30.0), RationalTime(1.0, 30.0)),
@@ -1122,7 +1117,7 @@ main(int argc, char** argv)
             &error_status);
         
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         {
             const RationalTime new_duration = track->duration();
             assert_duration(new_duration, duration);
@@ -1165,14 +1160,14 @@ main(int argc, char** argv)
                             });
 
         // Overwrite the same portion of the clip.
-        otio::SerializableObject::Retainer<otio::Clip> over_3 = new otio::Clip(
+        SerializableObject::Retainer<Clip> over_3 = new Clip(
             "over_3",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 30.0),
-                otio::RationalTime(1.0, 30.0)));
+            TimeRange(
+                RationalTime(0.0, 30.0),
+                RationalTime(1.0, 30.0)));
         
-        otio::algo::overwrite(
+        algo::overwrite(
             over_3,
             track,
             TimeRange(RationalTime(360.0, 30.0), RationalTime(1.0, 30.0)),
@@ -1181,7 +1176,7 @@ main(int argc, char** argv)
             &error_status);
         
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         {
             const RationalTime new_duration = track->duration();
             assert_duration(new_duration, duration);
@@ -1226,41 +1221,41 @@ main(int argc, char** argv)
 
     tests.add_test("test_edit_overwrite_6", [] {
         // Create a track with three clips of different rates.
-        otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_0 = new Clip(
             "clip_0",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 23.98),
-                otio::RationalTime(71.94, 23.98)));
-        otio::SerializableObject::Retainer<otio::Clip> clip_1 = new otio::Clip(
+            TimeRange(
+                RationalTime(0.0, 23.98),
+                RationalTime(71.94, 23.98)));
+        SerializableObject::Retainer<Clip> clip_1 = new Clip(
             "clip_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 23.98),
-                otio::RationalTime(71.94, 23.98)));
-        otio::SerializableObject::Retainer<otio::Clip> clip_2 = new otio::Clip(
+            TimeRange(
+                RationalTime(0.0, 23.98),
+                RationalTime(71.94, 23.98)));
+        SerializableObject::Retainer<Clip> clip_2 = new Clip(
             "clip_2",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(90.0, 30),
-                otio::RationalTime(90.0, 30)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(90.0, 30),
+                RationalTime(90.0, 30)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
         track->append_child(clip_1);
         track->append_child(clip_2);
 
         // Overwrite one portion of the clip.
-        otio::SerializableObject::Retainer<otio::Clip> over_1 = new otio::Clip(
+        SerializableObject::Retainer<Clip> over_1 = new Clip(
             "over_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 30.0),
-                otio::RationalTime(1.0, 30.0)));
+            TimeRange(
+                RationalTime(0.0, 30.0),
+                RationalTime(1.0, 30.0)));
         
         const RationalTime duration = track->duration();
-        otio::ErrorStatus  error_status;
-        otio::algo::overwrite(
+        OTIO_NS::ErrorStatus error_status;
+        algo::overwrite(
             over_1,
             track,
             TimeRange(RationalTime(137.0, 30.0), RationalTime(1.0, 30.0)),
@@ -1268,7 +1263,7 @@ main(int argc, char** argv)
             nullptr,
             &error_status);
 
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         const RationalTime new_duration = track->duration();
         assert_duration(new_duration, duration);
         assert_track_ranges(track,
@@ -1312,26 +1307,26 @@ main(int argc, char** argv)
     
     tests.add_test("test_edit_overwrite_7", [] {
         // Create a track with one long clip.
-        otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_0 = new Clip(
             "clip_0",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(704.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(704.0, 24.0)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
 
         // Overwrite past the clip, creating a gap.
-        otio::SerializableObject::Retainer<otio::Clip> over_1 = new otio::Clip(
+        SerializableObject::Retainer<Clip> over_1 = new Clip(
             "over_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(1.0, 24.0)));
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(1.0, 24.0)));
         const RationalTime duration = track->duration();
-        otio::ErrorStatus  error_status;
-        otio::algo::overwrite(
+        OTIO_NS::ErrorStatus error_status;
+        algo::overwrite(
             over_1,
             track,
             TimeRange(RationalTime(800.0, 24.0), RationalTime(1.0, 24.0)),
@@ -1340,7 +1335,7 @@ main(int argc, char** argv)
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         const RationalTime new_duration = track->duration();
         assert_duration(new_duration, RationalTime(801.0, 24.0));
         assert_track_ranges(track,
@@ -1372,26 +1367,26 @@ main(int argc, char** argv)
     
     tests.add_test("test_edit_overwrite_8", [] {
         // Create a track with one long clip.
-        otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_0 = new Clip(
             "clip_0",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(704.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(704.0, 24.0)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
 
         // Overwrite before the clip, creating a gap.
-        otio::SerializableObject::Retainer<otio::Clip> over_1 = new otio::Clip(
+        SerializableObject::Retainer<Clip> over_1 = new Clip(
             "over_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(1.0, 24.0)));
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(1.0, 24.0)));
         const RationalTime duration = track->duration();
-        otio::ErrorStatus  error_status;
-        otio::algo::overwrite(
+        OTIO_NS::ErrorStatus error_status;
+        algo::overwrite(
             over_1,
             track,
             TimeRange(RationalTime(-30.0, 24.0), RationalTime(1.0, 24.0)),
@@ -1400,7 +1395,7 @@ main(int argc, char** argv)
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         const RationalTime new_duration = track->duration();
         assert_duration(new_duration, RationalTime(734.0, 24.0));
         assert_track_ranges(track,
@@ -1433,26 +1428,26 @@ main(int argc, char** argv)
     
     tests.add_test("test_edit_overwrite_9", [] {
         // Create a track with one long clip.
-        otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_0 = new Clip(
             "clip_0",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(704.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(704.0, 24.0)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
 
         // Overwrite before the clip, creating a gap.
-        otio::SerializableObject::Retainer<otio::Clip> over_1 = new otio::Clip(
+        SerializableObject::Retainer<Clip> over_1 = new Clip(
             "over_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(100.0, 24.0)));
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(100.0, 24.0)));
         const RationalTime duration = track->duration();
-        otio::ErrorStatus  error_status;
-        otio::algo::overwrite(
+        OTIO_NS::ErrorStatus error_status;
+        algo::overwrite(
             over_1,
             track,
             TimeRange(RationalTime(-30.0, 24.0), RationalTime(70.0, 24.0)),
@@ -1461,7 +1456,7 @@ main(int argc, char** argv)
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         const RationalTime new_duration = track->duration();
         assert_duration(new_duration, duration);
         assert_track_ranges(track,
@@ -1486,26 +1481,26 @@ main(int argc, char** argv)
  
     tests.add_test("test_edit_overwrite_10", [] {
         // Create a track with one long clip.
-        otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_0 = new Clip(
             "clip_0",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(704.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(704.0, 24.0)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
 
         // Overwrite before the clip, creating a gap.
-        otio::SerializableObject::Retainer<otio::Clip> over_1 = new otio::Clip(
+        SerializableObject::Retainer<Clip> over_1 = new Clip(
             "over_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(100.0, 24.0)));
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(100.0, 24.0)));
         const RationalTime duration = track->duration();
-        otio::ErrorStatus  error_status;
-        otio::algo::overwrite(
+        OTIO_NS::ErrorStatus error_status;
+        algo::overwrite(
             over_1,
             track,
             TimeRange(RationalTime(20.0, 24.0), RationalTime(70.0, 24.0)),
@@ -1514,7 +1509,7 @@ main(int argc, char** argv)
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         const RationalTime new_duration = track->duration();
         //assert_duration(new_duration, duration);
         assert_track_ranges(track,
@@ -1547,32 +1542,32 @@ main(int argc, char** argv)
     // Insert at middle of clip_0
     tests.add_test("test_edit_insert_1", [] {
         // Create a track with two clips.
-        otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_0 = new Clip(
             "clip_0",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Clip> clip_1 = new otio::Clip(
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(24.0, 24.0)));
+        SerializableObject::Retainer<Clip> clip_1 = new Clip(
             "clip_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(24.0, 24.0)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
         track->append_child(clip_1);
 
         // Insert in clip 0.
-        otio::SerializableObject::Retainer<otio::Clip> insert_1 = new otio::Clip(
+        SerializableObject::Retainer<Clip> insert_1 = new Clip(
             "insert_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(12.0, 24.0)));
-        otio::ErrorStatus  error_status;
-        otio::algo::insert(
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(12.0, 24.0)));
+        OTIO_NS::ErrorStatus error_status;
+        algo::insert(
             insert_1,
             track,
             RationalTime(12.0, 24.0),
@@ -1581,10 +1576,10 @@ main(int argc, char** argv)
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         assertEqual(track->children().size(), 4);
         const RationalTime duration = track->duration();
-        assert_duration(duration, otime::RationalTime(60.0,24.0));
+        assert_duration(duration, RationalTime(60.0,24.0));
         assert_track_ranges(track,
                             {
                                 TimeRange(
@@ -1605,32 +1600,32 @@ main(int argc, char** argv)
     // Insert at start of clip_0.
     tests.add_test("test_edit_insert_2", [] {
         // Create a track with two clips.
-        otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_0 = new Clip(
             "clip_0",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Clip> clip_1 = new otio::Clip(
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(24.0, 24.0)));
+        SerializableObject::Retainer<Clip> clip_1 = new Clip(
             "clip_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(24.0, 24.0)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
         track->append_child(clip_1);
 
         // Insert in clip 0.
-        otio::SerializableObject::Retainer<otio::Clip> insert_1 = new otio::Clip(
+        SerializableObject::Retainer<Clip> insert_1 = new Clip(
             "insert_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(12.0, 24.0)));
-        otio::ErrorStatus  error_status;
-        otio::algo::insert(
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(12.0, 24.0)));
+        OTIO_NS::ErrorStatus error_status;
+        algo::insert(
             insert_1,
             track,
             RationalTime(0.0, 24.0),
@@ -1639,11 +1634,11 @@ main(int argc, char** argv)
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         assertEqual(track->children().size(), 3);
         
         const RationalTime duration = track->duration();
-        assert_duration(duration, otime::RationalTime(60.0,24.0));
+        assert_duration(duration, RationalTime(60.0,24.0));
         assert_track_ranges(track,
                             {
                                 TimeRange(
@@ -1661,32 +1656,32 @@ main(int argc, char** argv)
     // Insert at start of clip_1 (insert at 0 index).
     tests.add_test("test_edit_insert_3", [] {
         // Create a track with two clips.
-        otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_0 = new Clip(
             "clip_0",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Clip> clip_1 = new otio::Clip(
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(24.0, 24.0)));
+        SerializableObject::Retainer<Clip> clip_1 = new Clip(
             "clip_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(24.0, 24.0)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
         track->append_child(clip_1);
 
         // Insert in clip 0.
-        otio::SerializableObject::Retainer<otio::Clip> insert_1 = new otio::Clip(
+        SerializableObject::Retainer<Clip> insert_1 = new Clip(
             "insert_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(12.0, 24.0)));
-        otio::ErrorStatus  error_status;
-        otio::algo::insert(
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(12.0, 24.0)));
+        OTIO_NS::ErrorStatus error_status;
+        algo::insert(
             insert_1,
             track,
             RationalTime(-1.0, 24.0),
@@ -1695,60 +1690,60 @@ main(int argc, char** argv)
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         assertEqual(track->children().size(), 3);
         
         const RationalTime duration = track->duration();
-        assertEqual(duration, otime::RationalTime(60.0,24.0));
+        assertEqual(duration, RationalTime(60.0,24.0));
         auto range = clip_0->trimmed_range_in_parent().value();
         assertEqual(
             range,
-            otio::TimeRange(
-                otio::RationalTime(12.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
+            TimeRange(
+                RationalTime(12.0, 24.0),
+                RationalTime(24.0, 24.0)));
         range = clip_1->trimmed_range_in_parent().value();
         assertEqual(
             range,
-            otio::TimeRange(
-                otio::RationalTime(36.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
+            TimeRange(
+                RationalTime(36.0, 24.0),
+                RationalTime(24.0, 24.0)));
         range = insert_1->trimmed_range_in_parent().value();
         assertEqual(
             range,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(12.0, 24.0)));
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(12.0, 24.0)));
     });
     
     // Insert at start of clip_1.
     tests.add_test("test_edit_insert_4", [] {
         // Create a track with two clips.
-        otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_0 = new Clip(
             "clip_0",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Clip> clip_1 = new otio::Clip(
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(24.0, 24.0)));
+        SerializableObject::Retainer<Clip> clip_1 = new Clip(
             "clip_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(24.0, 24.0)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
         track->append_child(clip_1);
 
         // Insert in clip 0.
-        otio::SerializableObject::Retainer<otio::Clip> insert_1 = new otio::Clip(
+        SerializableObject::Retainer<Clip> insert_1 = new Clip(
             "insert_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(12.0, 24.0)));
-        otio::ErrorStatus  error_status;
-        otio::algo::insert(
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(12.0, 24.0)));
+        OTIO_NS::ErrorStatus error_status;
+        algo::insert(
             insert_1,
             track,
             RationalTime(24.0, 24.0),
@@ -1757,9 +1752,9 @@ main(int argc, char** argv)
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         const RationalTime duration = track->duration();
-        assert_duration(duration, otime::RationalTime(60.0,24.0));
+        assert_duration(duration, RationalTime(60.0,24.0));
         assert_track_ranges(track,
                             {
                                 TimeRange(
@@ -1777,32 +1772,32 @@ main(int argc, char** argv)
     // Insert at end of clip_1 (append at end).
     tests.add_test("test_edit_insert_4", [] {
         // Create a track with two clips.
-        otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_0 = new Clip(
             "clip_0",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Clip> clip_1 = new otio::Clip(
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(24.0, 24.0)));
+        SerializableObject::Retainer<Clip> clip_1 = new Clip(
             "clip_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(24.0, 24.0)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
         track->append_child(clip_1);
 
         // Insert in clip 0.
-        otio::SerializableObject::Retainer<otio::Clip> insert_1 = new otio::Clip(
+        SerializableObject::Retainer<Clip> insert_1 = new Clip(
             "insert_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(12.0, 24.0)));
-        otio::ErrorStatus  error_status;
-        otio::algo::insert(
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(12.0, 24.0)));
+        OTIO_NS::ErrorStatus error_status;
+        algo::insert(
             insert_1,
             track,
             RationalTime(48.0, 24.0),
@@ -1811,9 +1806,9 @@ main(int argc, char** argv)
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         const RationalTime duration = track->duration();
-        assert_duration(duration, otime::RationalTime(60.0,24.0));
+        assert_duration(duration, RationalTime(60.0,24.0));
         assert_track_ranges(track,
                             {
                                 TimeRange(
@@ -1831,32 +1826,32 @@ main(int argc, char** argv)
     // Insert near the beginning of clip_0.
     tests.add_test("test_edit_insert_5", [] {
         // Create a track with two clips.
-        otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_0 = new Clip(
             "clip_0",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Clip> clip_1 = new otio::Clip(
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(24.0, 24.0)));
+        SerializableObject::Retainer<Clip> clip_1 = new Clip(
             "clip_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(24.0, 24.0)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
         track->append_child(clip_1);
 
         // Insert in clip 0.
-        otio::SerializableObject::Retainer<otio::Clip> insert_1 = new otio::Clip(
+        SerializableObject::Retainer<Clip> insert_1 = new Clip(
             "insert_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(12.0, 24.0)));
-        otio::ErrorStatus  error_status;
-        otio::algo::insert(
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(12.0, 24.0)));
+        OTIO_NS::ErrorStatus error_status;
+        algo::insert(
             insert_1,
             track,
             RationalTime(1.0, 24.0),
@@ -1865,9 +1860,9 @@ main(int argc, char** argv)
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         const RationalTime duration = track->duration();
-        assert_duration(duration, otime::RationalTime(60.0,24.0));
+        assert_duration(duration, RationalTime(60.0,24.0));
         assert_track_ranges(track,
                             {
                                 TimeRange(
@@ -1888,32 +1883,32 @@ main(int argc, char** argv)
     // Insert near the end of clip_1.
     tests.add_test("test_edit_insert_6", [] {
         // Create a track with two clips.
-        otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_0 = new Clip(
             "clip_0",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Clip> clip_1 = new otio::Clip(
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(24.0, 24.0)));
+        SerializableObject::Retainer<Clip> clip_1 = new Clip(
             "clip_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(24.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(24.0, 24.0)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
         track->append_child(clip_1);
 
         // Insert in clip 0.
-        otio::SerializableObject::Retainer<otio::Clip> insert_1 = new otio::Clip(
+        SerializableObject::Retainer<Clip> insert_1 = new Clip(
             "insert_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(12.0, 24.0)));
-        otio::ErrorStatus  error_status;
-        otio::algo::insert(
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(12.0, 24.0)));
+        OTIO_NS::ErrorStatus error_status;
+        algo::insert(
             insert_1,
             track,
             RationalTime(47.0, 24.0),
@@ -1922,51 +1917,51 @@ main(int argc, char** argv)
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         const RationalTime duration = track->duration();
-        assert_duration(duration, otime::RationalTime(60.0,24.0));
+        assert_duration(duration, RationalTime(60.0,24.0));
         assert_track_ranges(track,
                             {
-                                otio::TimeRange(
-                                    otio::RationalTime(0.0, 24.0),
-                                    otio::RationalTime(24.0, 24.0)),
-                                otio::TimeRange(
-                                    otio::RationalTime(24.0, 24.0),
-                                    otio::RationalTime(23.0, 24.0)),
-                                otio::TimeRange(
-                                    otio::RationalTime(47.0, 24.0),
-                                    otio::RationalTime(12.0, 24.0)),
-                                otio::TimeRange(
-                                    otio::RationalTime(59.0, 24.0),
-                                    otio::RationalTime(1.0, 24.0)),
+                                TimeRange(
+                                    RationalTime(0.0, 24.0),
+                                    RationalTime(24.0, 24.0)),
+                                TimeRange(
+                                    RationalTime(24.0, 24.0),
+                                    RationalTime(23.0, 24.0)),
+                                TimeRange(
+                                    RationalTime(47.0, 24.0),
+                                    RationalTime(12.0, 24.0)),
+                                TimeRange(
+                                    RationalTime(59.0, 24.0),
+                                    RationalTime(1.0, 24.0)),
                             });
     });
     
     // Insert at the end of clip_1.
     tests.add_test("test_edit_insert_7", [] {
-        otio::ErrorStatus  error_status;
+        OTIO_NS::ErrorStatus error_status;
         
         // Create a track with three clips.
-        otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_0 = new Clip(
             "PSR63_2012-06-02",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 23.98),
-                otio::RationalTime(71.94, 23.98)));
-        otio::SerializableObject::Retainer<otio::Clip> clip_1 = new otio::Clip(
+            TimeRange(
+                RationalTime(0.0, 23.98),
+                RationalTime(71.94, 23.98)));
+        SerializableObject::Retainer<Clip> clip_1 = new Clip(
             "Dinky_2015-06-11",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 23.98),
-                otio::RationalTime(71.94, 23.98)));
-        otio::SerializableObject::Retainer<otio::Clip> clip_2 = new otio::Clip(
+            TimeRange(
+                RationalTime(0.0, 23.98),
+                RationalTime(71.94, 23.98)));
+        SerializableObject::Retainer<Clip> clip_2 = new Clip(
             "BART_2021-02-07",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(90.0, 30.0),
-                otio::RationalTime(90.0, 30.0)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(90.0, 30.0),
+                RationalTime(90.0, 30.0)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
         track->append_child(clip_1);
         track->append_child(clip_2);
@@ -1979,18 +1974,18 @@ main(int argc, char** argv)
         
         assert_clip_ranges(track,
                             {
-                                otio::TimeRange(
-                                    otio::RationalTime(0.0, 23.98),
-                                    otio::RationalTime(71.94, 23.98)),
-                                otio::TimeRange(
-                                    otio::RationalTime(90.0, 30.0),
-                                    otio::RationalTime(90.0, 30.0)),
+                                TimeRange(
+                                    RationalTime(0.0, 23.98),
+                                    RationalTime(71.94, 23.98)),
+                                TimeRange(
+                                    RationalTime(90.0, 30.0),
+                                    RationalTime(90.0, 30.0)),
                             });
 
         
         
         // Insert at end of clip 2.
-        otio::algo::insert(
+        algo::insert(
             clip_1,
             track,
             RationalTime(180.0, 30.0),
@@ -1999,22 +1994,22 @@ main(int argc, char** argv)
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         {
             const RationalTime new_duration = track->duration();
             assert_duration(new_duration, duration);
         }
         assert_clip_ranges(track,
                             {
-                                otio::TimeRange(
-                                    otio::RationalTime(0.0, 23.98),
-                                    otio::RationalTime(71.94, 23.98)),
-                                otio::TimeRange(
-                                    otio::RationalTime(90.0, 30.0),
-                                    otio::RationalTime(90.0, 30.0)),
-                                otio::TimeRange(
-                                    otio::RationalTime(0.0, 23.98),
-                                    otio::RationalTime(71.94, 23.98)),
+                                TimeRange(
+                                    RationalTime(0.0, 23.98),
+                                    RationalTime(71.94, 23.98)),
+                                TimeRange(
+                                    RationalTime(90.0, 30.0),
+                                    RationalTime(90.0, 30.0)),
+                                TimeRange(
+                                    RationalTime(0.0, 23.98),
+                                    RationalTime(71.94, 23.98)),
                             });
 
         track->remove_child(2);
@@ -2026,16 +2021,16 @@ main(int argc, char** argv)
         
         assert_clip_ranges(track,
                             {
-                                otio::TimeRange(
-                                    otio::RationalTime(0.0, 23.98),
-                                    otio::RationalTime(71.94, 23.98)),
-                                otio::TimeRange(
-                                    otio::RationalTime(90.0, 30.0),
-                                    otio::RationalTime(90.0, 30.0)),
+                                TimeRange(
+                                    RationalTime(0.0, 23.98),
+                                    RationalTime(71.94, 23.98)),
+                                TimeRange(
+                                    RationalTime(90.0, 30.0),
+                                    RationalTime(90.0, 30.0)),
                             });
         
         // Insert at end of clip 1.
-        otio::algo::insert(
+        algo::insert(
             clip_1,
             track,
             RationalTime(90.0, 30.0),
@@ -2049,44 +2044,44 @@ main(int argc, char** argv)
         }
         assert_clip_ranges(track,
                             {
-                                otio::TimeRange(
-                                    otio::RationalTime(0.0, 23.98),
-                                    otio::RationalTime(71.94, 23.98)),
-                                otio::TimeRange(
-                                    otio::RationalTime(0.0, 23.98),
-                                    otio::RationalTime(71.94, 23.98)),
-                                otio::TimeRange(
-                                    otio::RationalTime(90.0, 30.0),
-                                    otio::RationalTime(90.0, 30.0)),
+                                TimeRange(
+                                    RationalTime(0.0, 23.98),
+                                    RationalTime(71.94, 23.98)),
+                                TimeRange(
+                                    RationalTime(0.0, 23.98),
+                                    RationalTime(71.94, 23.98)),
+                                TimeRange(
+                                    RationalTime(90.0, 30.0),
+                                    RationalTime(90.0, 30.0)),
                             });
         
     });
     
     // Insert at the middle of clip 0
     tests.add_test("test_edit_insert_8", [] {
-        otio::ErrorStatus  error_status;
+        OTIO_NS::ErrorStatus error_status;
         
         // Create a track with three clips.
-        otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_0 = new Clip(
             "spiderman",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(1575360, 23.976024),
-                otio::RationalTime(3809.0, 23.976024)));
-        otio::SerializableObject::Retainer<otio::Clip> clip_1 = new otio::Clip(
+            TimeRange(
+                RationalTime(1575360, 23.976024),
+                RationalTime(3809.0, 23.976024)));
+        SerializableObject::Retainer<Clip> clip_1 = new Clip(
             "spider insert",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(1575360, 23.976024),
-                otio::RationalTime(1.0, 23.976024)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(1575360, 23.976024),
+                RationalTime(1.0, 23.976024)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
         
         debug_track_ranges("START", track);
     
         // Insert at end of clip 2.
-        otio::algo::insert(
+        algo::insert(
             clip_1,
             track,
             RationalTime(141.0, 23.976024),
@@ -2095,35 +2090,35 @@ main(int argc, char** argv)
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         // {
         //     const RationalTime new_duration = track->duration();
         //     assert_duration(new_duration, duration);
         // }
         assert_clip_ranges(track,
                             {
-                                otio::TimeRange(
-                                    otio::RationalTime(1575360.0, 23.976024),
-                                    otio::RationalTime(141.0, 23.976024)),
-                                otio::TimeRange(
-                                    otio::RationalTime(1575360, 23.976024),
-                                    otio::RationalTime(1.0, 23.976024)),
-                                otio::TimeRange(
-                                    otio::RationalTime(1575502.0, 23.976024),
-                                    otio::RationalTime(3668.0, 23.976024)),
+                                TimeRange(
+                                    RationalTime(1575360.0, 23.976024),
+                                    RationalTime(141.0, 23.976024)),
+                                TimeRange(
+                                    RationalTime(1575360, 23.976024),
+                                    RationalTime(1.0, 23.976024)),
+                                TimeRange(
+                                    RationalTime(1575502.0, 23.976024),
+                                    RationalTime(3668.0, 23.976024)),
                             });
         
         assert_track_ranges(track,
                             {
-                                otio::TimeRange(
-                                    otio::RationalTime(0.0, 23.976024),
-                                    otio::RationalTime(141.0, 23.976024)),
-                                otio::TimeRange(
-                                    otio::RationalTime(141.0, 23.976024),
-                                    otio::RationalTime(1, 23.976024)),
-                                otio::TimeRange(
-                                    otio::RationalTime(142.0, 23.976024),
-                                    otio::RationalTime(3668.0, 23.976024)),
+                                TimeRange(
+                                    RationalTime(0.0, 23.976024),
+                                    RationalTime(141.0, 23.976024)),
+                                TimeRange(
+                                    RationalTime(141.0, 23.976024),
+                                    RationalTime(1, 23.976024)),
+                                TimeRange(
+                                    RationalTime(142.0, 23.976024),
+                                    RationalTime(3668.0, 23.976024)),
                             });
         
     });
@@ -2230,32 +2225,32 @@ main(int argc, char** argv)
     tests.add_test("test_edit_trim_1", [] {
         
         // Create a track with one gap and two clips.
-        otio::SerializableObject::Retainer<otio::Gap> clip_0 = new otio::Gap(
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(20.0, 24.0)),
+        SerializableObject::Retainer<Gap> clip_0 = new Gap(
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(20.0, 24.0)),
             "gap_0");
-        otio::SerializableObject::Retainer<otio::Clip> clip_1 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_1 = new Clip(
             "clip_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(5.0, 24.0),
-                otio::RationalTime(50.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Clip> clip_2 = new otio::Clip(
+            TimeRange(
+                RationalTime(5.0, 24.0),
+                RationalTime(50.0, 24.0)));
+        SerializableObject::Retainer<Clip> clip_2 = new Clip(
             "clip_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(10.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(10.0, 24.0)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
         track->append_child(clip_1);
         track->append_child(clip_2);
         const RationalTime duration = track->duration();
 
-        otio::ErrorStatus  error_status;
-        otio::algo::trim(
+        OTIO_NS::ErrorStatus error_status;
+        algo::trim(
             clip_1,
             RationalTime(5.0, 24.0),
             RationalTime(0.0, 24.0),
@@ -2263,7 +2258,7 @@ main(int argc, char** argv)
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         const RationalTime new_duration = track->duration();
         assert_duration(new_duration, duration);
         assert_track_ranges(track,
@@ -2283,33 +2278,33 @@ main(int argc, char** argv)
     // Test trim delta_out right (no change due to clip).
     tests.add_test("test_edit_trim_2", [] {
         // Create a track with one gap and two clips.
-        otio::SerializableObject::Retainer<otio::Gap> clip_0 = new otio::Gap(
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(20.0, 24.0)),
+        SerializableObject::Retainer<Gap> clip_0 = new Gap(
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(20.0, 24.0)),
             "gap_0");
-        otio::SerializableObject::Retainer<otio::Clip> clip_1 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_1 = new Clip(
             "clip_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(5.0, 24.0),
-                otio::RationalTime(50.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Clip> clip_2 = new otio::Clip(
+            TimeRange(
+                RationalTime(5.0, 24.0),
+                RationalTime(50.0, 24.0)));
+        SerializableObject::Retainer<Clip> clip_2 = new Clip(
             "clip_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(10.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(10.0, 24.0)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
         track->append_child(clip_1);
         track->append_child(clip_2);
         
         const RationalTime duration = track->duration();
 
-        otio::ErrorStatus  error_status;
-        otio::algo::trim(
+        OTIO_NS::ErrorStatus error_status;
+        algo::trim(
             clip_1,
             RationalTime(0.0, 24.0),
             RationalTime(5.0, 24.0),
@@ -2317,7 +2312,7 @@ main(int argc, char** argv)
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         const RationalTime new_duration = track->duration();
         assert_duration(new_duration, duration);
         assert_track_ranges(track,
@@ -2349,33 +2344,33 @@ main(int argc, char** argv)
     // Test trim delta_out left (create a gap)
     tests.add_test("test_edit_trim_3", [] {
         // Create a track with one gap and two clips.
-        otio::SerializableObject::Retainer<otio::Gap> clip_0 = new otio::Gap(
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(20.0, 24.0)),
+        SerializableObject::Retainer<Gap> clip_0 = new Gap(
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(20.0, 24.0)),
             "gap_0");
-        otio::SerializableObject::Retainer<otio::Clip> clip_1 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_1 = new Clip(
             "clip_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(5.0, 24.0),
-                otio::RationalTime(50.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Clip> clip_2 = new otio::Clip(
+            TimeRange(
+                RationalTime(5.0, 24.0),
+                RationalTime(50.0, 24.0)));
+        SerializableObject::Retainer<Clip> clip_2 = new Clip(
             "clip_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(10.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(10.0, 24.0)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
         track->append_child(clip_1);
         track->append_child(clip_2);
         
         const RationalTime duration = track->duration();
 
-        otio::ErrorStatus  error_status;
-        otio::algo::trim(
+        OTIO_NS::ErrorStatus error_status;
+        algo::trim(
             clip_1,
             RationalTime(0.0, 24.0),
             RationalTime(-5.0, 24.0),
@@ -2383,7 +2378,7 @@ main(int argc, char** argv)
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         const RationalTime new_duration = track->duration();
         assert_duration(new_duration, duration);
         assert_track_ranges(track,
@@ -2969,43 +2964,43 @@ main(int argc, char** argv)
     // Test remove middle clip
     tests.add_test("test_edit_remove_0", [] {
         // Create a track with three clips.
-        otio::SerializableObject::Retainer<otio::Clip> clip_0 = new otio::Clip(
+        SerializableObject::Retainer<Clip> clip_0 = new Clip(
             "clip_0",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(50.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Clip> clip_1 = new otio::Clip(
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(50.0, 24.0)));
+        SerializableObject::Retainer<Clip> clip_1 = new Clip(
             "clip_1",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(5.0, 24.0),
-                otio::RationalTime(50.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Clip> clip_2 = new otio::Clip(
+            TimeRange(
+                RationalTime(5.0, 24.0),
+                RationalTime(50.0, 24.0)));
+        SerializableObject::Retainer<Clip> clip_2 = new Clip(
             "clip_2",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(10.0, 24.0)));
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(10.0, 24.0)));
         
-        otio::SerializableObject::Retainer<otio::Clip> fill_0 = new otio::Clip(
+        SerializableObject::Retainer<Clip> fill_0 = new Clip(
             "fill_0",
             nullptr,
-            otio::TimeRange(
-                otio::RationalTime(0.0, 24.0),
-                otio::RationalTime(10.0, 24.0)));
-        otio::SerializableObject::Retainer<otio::Track> track =
-            new otio::Track();
+            TimeRange(
+                RationalTime(0.0, 24.0),
+                RationalTime(10.0, 24.0)));
+        SerializableObject::Retainer<Track> track =
+            new Track();
         track->append_child(clip_0);
         track->append_child(clip_1);
         track->append_child(clip_2);
         
         const RationalTime duration = track->duration();
 
-        otio::ErrorStatus  error_status;
+        OTIO_NS::ErrorStatus error_status;
 
         // Remove second clip (creates a gap)
-        otio::algo::remove(
+        algo::remove(
             track,
             RationalTime(55.0, 24.0),
             true,
@@ -3013,7 +3008,7 @@ main(int argc, char** argv)
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         {
             const RationalTime new_duration = track->duration();
             assert_duration(new_duration, duration);
@@ -3044,7 +3039,7 @@ main(int argc, char** argv)
                           });
         
         // Remove second clip (which is now a gap, replacing it with fill_0)
-        otio::algo::remove(
+        algo::remove(
             track,
             RationalTime(55.0, 24.0),
             true,
@@ -3052,7 +3047,7 @@ main(int argc, char** argv)
             &error_status);
 
         // Asserts.
-        assert(!otio::is_error(error_status));
+        assert(!is_error(error_status));
         {
             const RationalTime new_duration = track->duration();
             assert_duration(new_duration, RationalTime(70.0, 24.0));

--- a/tests/test_opentime.cpp
+++ b/tests/test_opentime.cpp
@@ -6,7 +6,7 @@
 #include <opentime/rationalTime.h>
 #include <opentime/timeRange.h>
 
-namespace otime = opentime::OPENTIME_VERSION_NS;
+using namespace opentime::OPENTIME_VERSION_NS;
 
 int
 main(int argc, char** argv)
@@ -14,155 +14,155 @@ main(int argc, char** argv)
     Tests tests;
 
     tests.add_test("test_create", [] {
-        double              t_val = 30.2;
-        otime::RationalTime t(t_val);
+        double       t_val = 30.2;
+        RationalTime t(t_val);
         assertEqual(t.value(), t_val);
 
-        t = otime::RationalTime();
+        t = RationalTime();
         assertEqual(t.value(), 0.0);
         assertEqual(t.rate(), 1.0);
     });
 
     tests.add_test("test_valid", [] {
-        otime::RationalTime t1(0.0, 0.0);
+        RationalTime t1(0.0, 0.0);
         assertTrue(t1.is_invalid_time());
         assertFalse(t1.is_valid_time());
-        otime::RationalTime t2(0.0, 24.0);
+        RationalTime t2(0.0, 24.0);
         assertTrue(t2.is_valid_time());
         assertFalse(t2.is_invalid_time());
     });
 
     tests.add_test("test_equality", [] {
-        otime::RationalTime t1(30.2);
+        RationalTime t1(30.2);
         assertEqual(t1, t1);
-        otime::RationalTime t2(30.2);
+        RationalTime t2(30.2);
         assertEqual(t1, t2);
-        otime::RationalTime t3(60.4, 2.0);
+        RationalTime t3(60.4, 2.0);
         assertEqual(t1, t3);
     });
 
     tests.add_test("test_inequality", [] {
-        otime::RationalTime t1(30.2);
+        RationalTime t1(30.2);
         assertEqual(t1, t1);
-        otime::RationalTime t2(33.2);
+        RationalTime t2(33.2);
         assertNotEqual(t1, t2);
-        otime::RationalTime t3(30.2);
+        RationalTime t3(30.2);
         assertFalse(t1 != t3);
     });
 
     tests.add_test("test_strict_equality", [] {
-        otime::RationalTime t1(30.2);
+        RationalTime t1(30.2);
         assertTrue(t1.strictly_equal(t1));
-        otime::RationalTime t2(30.2);
+        RationalTime t2(30.2);
         assertTrue(t1.strictly_equal(t2));
-        otime::RationalTime t3(60.4, 2.0);
+        RationalTime t3(60.4, 2.0);
         assertFalse(t1.strictly_equal(t3));
     });
 
     tests.add_test("test_rounding", [] {
-        otime::RationalTime t1(30.2);
-        assertEqual(t1.floor(), otime::RationalTime(30.0));
-        assertEqual(t1.ceil(), otime::RationalTime(31.0));
-        assertEqual(t1.round(), otime::RationalTime(30.0));
-        otime::RationalTime t2(30.8);
-        assertEqual(t2.floor(), otime::RationalTime(30.0));
-        assertEqual(t2.ceil(), otime::RationalTime(31.0));
-        assertEqual(t2.round(), otime::RationalTime(31.0));
+        RationalTime t1(30.2);
+        assertEqual(t1.floor(), RationalTime(30.0));
+        assertEqual(t1.ceil(), RationalTime(31.0));
+        assertEqual(t1.round(), RationalTime(30.0));
+        RationalTime t2(30.8);
+        assertEqual(t2.floor(), RationalTime(30.0));
+        assertEqual(t2.ceil(), RationalTime(31.0));
+        assertEqual(t2.round(), RationalTime(31.0));
     });
 
     tests.add_test("test_from_time_string", [] {
          std::string time_string = "0:12:04";
-         auto t = otime::RationalTime(24 * (12 * 60 + 4), 24);
-         auto time_obj = otime::RationalTime::from_time_string(time_string, 24);
+         auto t = RationalTime(24 * (12 * 60 + 4), 24);
+         auto time_obj = RationalTime::from_time_string(time_string, 24);
          assertTrue(t.almost_equal(time_obj, 0.001));
      });
 
     tests.add_test("test_from_time_string24", [] {
         std::string time_string = "00:00:00.041667";
-        auto t = otime::RationalTime(1, 24);
-        auto time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        auto t = RationalTime(1, 24);
+        auto time_obj = RationalTime::from_time_string(time_string, 24);
         assertTrue(t.almost_equal(time_obj, 0.001));
         time_string = "00:00:01";
-        t = otime::RationalTime(24, 24);
-        time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        t = RationalTime(24, 24);
+        time_obj = RationalTime::from_time_string(time_string, 24);
         assertTrue(t.almost_equal(time_obj, 0.001));
         time_string = "00:01:00";
-        t = otime::RationalTime(60 * 24, 24);
-        time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        t = RationalTime(60 * 24, 24);
+        time_obj = RationalTime::from_time_string(time_string, 24);
         assertTrue(t.almost_equal(time_obj, 0.001));
         time_string = "01:00:00";
-        t = otime::RationalTime(60 * 60 * 24, 24);
-        time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        t = RationalTime(60 * 60 * 24, 24);
+        time_obj = RationalTime::from_time_string(time_string, 24);
         assertTrue(t.almost_equal(time_obj, 0.001));
         time_string = "24:00:00";
-        t = otime::RationalTime(24 * 60 * 60 * 24, 24);
-        time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        t = RationalTime(24 * 60 * 60 * 24, 24);
+        time_obj = RationalTime::from_time_string(time_string, 24);
         assertTrue(t.almost_equal(time_obj, 0.001));
         time_string = "23:59:59.92";
-        t = otime::RationalTime((23 * 60 * 60 + 59 * 60 + 59.92) * 24, 24);
-        time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        t = RationalTime((23 * 60 * 60 + 59 * 60 + 59.92) * 24, 24);
+        time_obj = RationalTime::from_time_string(time_string, 24);
         assertTrue(t.almost_equal(time_obj, 0.001));
     });
 
     tests.add_test("test_from_time_string25", [] {
         std::string time_string = "0:12:04.929792";
-        auto t = otime::RationalTime((12 * 60 + 4.929792) * 25, 25);
-        auto time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        auto t = RationalTime((12 * 60 + 4.929792) * 25, 25);
+        auto time_obj = RationalTime::from_time_string(time_string, 24);
         assertTrue(t.almost_equal(time_obj, 0.001));
         time_string = "00:00:01";
-        t = otime::RationalTime(25, 25);
-        time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        t = RationalTime(25, 25);
+        time_obj = RationalTime::from_time_string(time_string, 24);
         assertTrue(t.almost_equal(time_obj, 0.001));
         time_string = "0:1";
-        t = otime::RationalTime(25, 25);
-        time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        t = RationalTime(25, 25);
+        time_obj = RationalTime::from_time_string(time_string, 24);
         assertTrue(t.almost_equal(time_obj, 0.001));
         time_string = "1";
-        t = otime::RationalTime(25, 25);
-        time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        t = RationalTime(25, 25);
+        time_obj = RationalTime::from_time_string(time_string, 24);
         assertTrue(t.almost_equal(time_obj, 0.001));
         time_string = "00:01:00";
-        t = otime::RationalTime(60 * 25, 25);
-        time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        t = RationalTime(60 * 25, 25);
+        time_obj = RationalTime::from_time_string(time_string, 24);
         assertTrue(t.almost_equal(time_obj, 0.001));
         time_string = "01:00:00";
-        t = otime::RationalTime(60 * 60 * 25, 25);
-        time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        t = RationalTime(60 * 60 * 25, 25);
+        time_obj = RationalTime::from_time_string(time_string, 24);
         assertTrue(t.almost_equal(time_obj, 0.001));
         time_string = "24:00:00";
-        t = otime::RationalTime(24 * 60 * 60 * 25, 25);
-        time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        t = RationalTime(24 * 60 * 60 * 25, 25);
+        time_obj = RationalTime::from_time_string(time_string, 24);
         assertTrue(t.almost_equal(time_obj, 0.001));
         time_string = "23:59:59.92";
-        t = otime::RationalTime((23 * 60 * 60 + 59 * 60 + 59.92) * 25, 25);
-        time_obj = otime::RationalTime::from_time_string(time_string, 24);
+        t = RationalTime((23 * 60 * 60 + 59 * 60 + 59.92) * 25, 25);
+        time_obj = RationalTime::from_time_string(time_string, 24);
         assertTrue(t.almost_equal(time_obj, 0.001));
     });
 
     tests.add_test("test_create_range", [] {
-        otime::RationalTime start(0.0, 24.0);
-        otime::RationalTime duration(24.0, 24.0);
-        otime::TimeRange r(start, duration);
+        RationalTime start(0.0, 24.0);
+        RationalTime duration(24.0, 24.0);
+        TimeRange r(start, duration);
         assertEqual(r.start_time(), start);
         assertEqual(r.duration(), duration);
 
-        r = otime::TimeRange(0.0, 24.0, 24.0);
+        r = TimeRange(0.0, 24.0, 24.0);
         assertEqual(r.start_time(), start);
         assertEqual(r.duration(), duration);
 
-        r = otime::TimeRange();
-        assertEqual(r.start_time(), otime::RationalTime());
-        assertEqual(r.duration(), otime::RationalTime());
+        r = TimeRange();
+        assertEqual(r.start_time(), RationalTime());
+        assertEqual(r.duration(), RationalTime());
     });
 
     tests.add_test("test_valid_range", [] {
-        otime::TimeRange r1(0.0, 0.0, 0.0);
+        TimeRange r1(0.0, 0.0, 0.0);
         assertTrue(r1.is_invalid_range());
         assertFalse(r1.is_valid_range());
-        otime::TimeRange r2(0.0, 24.0, 24.0);
+        TimeRange r2(0.0, 24.0, 24.0);
         assertTrue(r2.is_valid_range());
         assertFalse(r2.is_invalid_range());
-        otime::TimeRange r3(0.0, -24.0, 24.0);
+        TimeRange r3(0.0, -24.0, 24.0);
         assertFalse(r3.is_valid_range());
         assertTrue(r3.is_invalid_range());
     });

--- a/tests/test_serializableCollection.cpp
+++ b/tests/test_serializableCollection.cpp
@@ -10,8 +10,7 @@
 
 #include <iostream>
 
-namespace otime = opentime::OPENTIME_VERSION_NS;
-namespace otio  = opentimelineio::OPENTIMELINEIO_VERSION_NS;
+using namespace OTIO_NS;
 
 int
 main(int argc, char** argv)
@@ -20,70 +19,56 @@ main(int argc, char** argv)
 
     tests.add_test(
         "test_find_children", [] {
-        using namespace otio;
-        otio::SerializableObject::Retainer<otio::Clip> cl =
-            new otio::Clip();
-        otio::SerializableObject::Retainer<otio::Track> tr =
-            new otio::Track();
+        SerializableObject::Retainer<Clip> cl = new Clip();
+        SerializableObject::Retainer<Track> tr = new Track();
         tr->append_child(cl);
-        otio::SerializableObject::Retainer<otio::Timeline> tl =
-            new otio::Timeline();
+        SerializableObject::Retainer<Timeline> tl = new Timeline();
         tl->tracks()->append_child(tr);
-        otio::SerializableObject::Retainer<otio::SerializableCollection>
-            sc = new otio::SerializableCollection();
+        SerializableObject::Retainer<SerializableCollection>
+            sc = new SerializableCollection();
         sc->insert_child(0, tl);
         OTIO_NS::ErrorStatus err;
-        auto result = sc->find_children<otio::Clip>(&err, {}, false);
+        auto result = sc->find_children<Clip>(&err, {}, false);
         assertEqual(result.size(), 1);
         assertEqual(result[0].value, cl.value);
     });
     tests.add_test(
         "test_find_children_search_range", [] {
-        using namespace otio;
         const TimeRange range(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0));
-        otio::SerializableObject::Retainer<otio::Clip> cl0 =
-            new otio::Clip();
+        SerializableObject::Retainer<Clip> cl0 = new Clip();
         cl0->set_source_range(range);
-        otio::SerializableObject::Retainer<otio::Clip> cl1 =
-            new otio::Clip();
+        SerializableObject::Retainer<Clip> cl1 = new Clip();
         cl1->set_source_range(range);
-        otio::SerializableObject::Retainer<otio::Clip> cl2 =
-            new otio::Clip();
+        SerializableObject::Retainer<Clip> cl2 = new Clip();
         cl2->set_source_range(range);
-        otio::SerializableObject::Retainer<otio::Track> tr =
-            new otio::Track();
+        SerializableObject::Retainer<Track> tr = new Track();
         tr->append_child(cl0);
         tr->append_child(cl1);
         tr->append_child(cl2);
-        otio::SerializableObject::Retainer<otio::Timeline> tl =
-            new otio::Timeline();
+        SerializableObject::Retainer<Timeline> tl = new Timeline();
         tl->tracks()->append_child(tr);
-        otio::SerializableObject::Retainer<otio::SerializableCollection>
-            sc = new otio::SerializableCollection();
+        SerializableObject::Retainer<SerializableCollection>
+            sc = new SerializableCollection();
         sc->insert_child(0, tl);
         OTIO_NS::ErrorStatus err;
-        auto result = sc->find_children<otio::Clip>(&err, range);
+        auto result = sc->find_children<Clip>(&err, range);
         assertEqual(result.size(), 1);
         assertEqual(result[0].value, cl0.value);
     });
     tests.add_test(
         "test_find_children_shallow_search", [] {
-        using namespace otio;
-        otio::SerializableObject::Retainer<otio::Clip> cl =
-            new otio::Clip();
-        otio::SerializableObject::Retainer<otio::Track> tr =
-            new otio::Track();
+        SerializableObject::Retainer<Clip> cl = new Clip();
+        SerializableObject::Retainer<Track> tr = new Track();
         tr->append_child(cl);
-        otio::SerializableObject::Retainer<otio::Timeline> tl =
-            new otio::Timeline();
+        SerializableObject::Retainer<Timeline> tl = new Timeline();
         tl->tracks()->append_child(tr);
-        otio::SerializableObject::Retainer<otio::SerializableCollection>
-            sc = new otio::SerializableCollection();
+        SerializableObject::Retainer<SerializableCollection>
+            sc = new SerializableCollection();
         sc->insert_child(0, tl);
         OTIO_NS::ErrorStatus err;
-        auto result = sc->find_children<otio::Clip>(&err, std::nullopt, true);
+        auto result = sc->find_children<Clip>(&err, std::nullopt, true);
         assertEqual(result.size(), 0);
-        result = sc->find_children<otio::Clip>(&err, std::nullopt, false);
+        result = sc->find_children<Clip>(&err, std::nullopt, false);
         assertEqual(result.size(), 1);
         assertEqual(result[0].value, cl.value);
     });

--- a/tests/test_serialization.cpp
+++ b/tests/test_serialization.cpp
@@ -14,8 +14,7 @@
 #include <iostream>
 #include <string>
 
-namespace otime = opentime::OPENTIME_VERSION_NS;
-namespace otio  = opentimelineio::OPENTIMELINEIO_VERSION_NS;
+using namespace OTIO_NS;
 
 int
 main(int argc, char** argv)
@@ -24,18 +23,15 @@ main(int argc, char** argv)
 
     tests.add_test(
         "success with default indent", [] {
-        otio::SerializableObject::Retainer<otio::Clip> cl =
-            new otio::Clip();
-        otio::SerializableObject::Retainer<otio::Track> tr =
-            new otio::Track();
+        SerializableObject::Retainer<Clip> cl = new Clip();
+        SerializableObject::Retainer<Track> tr = new Track();
         tr->append_child(cl);
-        otio::SerializableObject::Retainer<otio::Timeline> tl =
-            new otio::Timeline();
+        SerializableObject::Retainer<Timeline> tl = new Timeline();
         tl->tracks()->append_child(tr);
 
-        otio::ErrorStatus err;
+        OTIO_NS::ErrorStatus err;
         auto output = tl.value->to_json_string(&err, {});
-        assertFalse(otio::is_error(err));
+        assertFalse(is_error(err));
         assertEqual(output.c_str(), R"CONTENT({
     "OTIO_SCHEMA": "Timeline.1",
     "metadata": {},
@@ -91,23 +87,23 @@ main(int argc, char** argv)
 
     tests.add_test(
         "success with indent set to 0", [] {
-        otio::SerializableObject::Retainer<otio::SerializableObjectWithMetadata> so =
-            new otio::SerializableObjectWithMetadata();
+        SerializableObject::Retainer<SerializableObjectWithMetadata> so =
+            new SerializableObjectWithMetadata();
 
-        otio::ErrorStatus err;
+        OTIO_NS::ErrorStatus err;
         auto output = so.value->to_json_string(&err, {}, 0);
-        assertFalse(otio::is_error(err));
+        assertFalse(is_error(err));
         assertEqual(output.c_str(), R"CONTENT({"OTIO_SCHEMA":"SerializableObjectWithMetadata.1","metadata":{},"name":""})CONTENT");
     });
 
     tests.add_test(
         "success with indent set to 2", [] {
-        otio::SerializableObject::Retainer<otio::SerializableObjectWithMetadata> so =
-            new otio::SerializableObjectWithMetadata();
+        SerializableObject::Retainer<SerializableObjectWithMetadata> so =
+            new SerializableObjectWithMetadata();
 
-        otio::ErrorStatus err;
+        OTIO_NS::ErrorStatus err;
         auto output = so.value->to_json_string(&err, {}, 2);
-        assertFalse(otio::is_error(err));
+        assertFalse(is_error(err));
         assertEqual(output.c_str(), R"CONTENT({
   "OTIO_SCHEMA": "SerializableObjectWithMetadata.1",
   "metadata": {},

--- a/tests/test_stack_algo.cpp
+++ b/tests/test_stack_algo.cpp
@@ -11,8 +11,7 @@
 
 #include <iostream>
 
-namespace otime = opentime::OPENTIME_VERSION_NS;
-namespace otio  = opentimelineio::OPENTIMELINEIO_VERSION_NS;
+using namespace OTIO_NS;
 
 int
 main(int argc, char** argv)
@@ -21,11 +20,10 @@ main(int argc, char** argv)
 
     tests.add_test(
         "test_flatten_stack_01", [] {
-        using namespace otio;
 
-        otio::RationalTime rt_0_24{0, 24};
-        otio::RationalTime rt_150_24{150, 24};
-        otio::TimeRange tr_0_150_24{rt_0_24, rt_150_24};
+        RationalTime rt_0_24{0, 24};
+        RationalTime rt_150_24{150, 24};
+        TimeRange tr_0_150_24{rt_0_24, rt_150_24};
 
         // all three clips are identical, but placed such that A is over B and
         // has no gap or end over C
@@ -36,24 +34,21 @@ main(int argc, char** argv)
         // should flatten to:
         // [    A     |     C     ]
 
-        otio::SerializableObject::Retainer<otio::Clip> cl_A =
-            new otio::Clip("track1_A", nullptr, tr_0_150_24);
-        otio::SerializableObject::Retainer<otio::Clip> cl_B =
-            new otio::Clip("track1_B", nullptr, tr_0_150_24);
-        otio::SerializableObject::Retainer<otio::Clip> cl_C =
-            new otio::Clip("track1_C", nullptr, tr_0_150_24);
+        SerializableObject::Retainer<Clip> cl_A =
+            new Clip("track1_A", nullptr, tr_0_150_24);
+        SerializableObject::Retainer<Clip> cl_B =
+            new Clip("track1_B", nullptr, tr_0_150_24);
+        SerializableObject::Retainer<Clip> cl_C =
+            new Clip("track1_C", nullptr, tr_0_150_24);
 
-        otio::SerializableObject::Retainer<otio::Track> tr_over =
-            new otio::Track();
+        SerializableObject::Retainer<Track> tr_over = new Track();
         tr_over->append_child(cl_A);
 
-        otio::SerializableObject::Retainer<otio::Track> tr_under =
-            new otio::Track();
+        SerializableObject::Retainer<Track> tr_under = new Track();
         tr_under->append_child(cl_B);
         tr_under->append_child(cl_C);
 
-        otio::SerializableObject::Retainer<otio::Stack> st =
-            new otio::Stack();
+        SerializableObject::Retainer<Stack> st = new Stack();
         st->append_child(tr_under);
         st->append_child(tr_over);
 
@@ -66,11 +61,10 @@ main(int argc, char** argv)
 
     tests.add_test(
         "test_flatten_stack_02", [] {
-        using namespace otio;
 
-        otio::RationalTime rt_0_24{0, 24};
-        otio::RationalTime rt_150_24{150, 24};
-        otio::TimeRange tr_0_150_24{rt_0_24, rt_150_24};
+        RationalTime rt_0_24{0, 24};
+        RationalTime rt_150_24{150, 24};
+        TimeRange tr_0_150_24{rt_0_24, rt_150_24};
 
         // all four clips are identical, but placed such that A is over B and
         // has no gap or end over C. The bottom track is also shorter.
@@ -82,31 +76,27 @@ main(int argc, char** argv)
         // should flatten to:
         // [    A     |     C     ]
 
-        otio::SerializableObject::Retainer<otio::Clip> cl_A =
-            new otio::Clip("track1_A", nullptr, tr_0_150_24);
-        otio::SerializableObject::Retainer<otio::Clip> cl_B =
-            new otio::Clip("track1_B", nullptr, tr_0_150_24);
-        otio::SerializableObject::Retainer<otio::Clip> cl_C =
-            new otio::Clip("track1_C", nullptr, tr_0_150_24);
-        otio::SerializableObject::Retainer<otio::Clip> cl_D =
-            new otio::Clip("track1_D", nullptr, tr_0_150_24);
+        SerializableObject::Retainer<Clip> cl_A =
+            new Clip("track1_A", nullptr, tr_0_150_24);
+        SerializableObject::Retainer<Clip> cl_B =
+            new Clip("track1_B", nullptr, tr_0_150_24);
+        SerializableObject::Retainer<Clip> cl_C =
+            new Clip("track1_C", nullptr, tr_0_150_24);
+        SerializableObject::Retainer<Clip> cl_D =
+            new Clip("track1_D", nullptr, tr_0_150_24);
 
-        otio::SerializableObject::Retainer<otio::Track> tr_top =
-            new otio::Track();
+        SerializableObject::Retainer<Track> tr_top = new Track();
         tr_top->append_child(cl_A);
 
-        otio::SerializableObject::Retainer<otio::Track> tr_middle =
-            new otio::Track();
+        SerializableObject::Retainer<Track> tr_middle = new Track();
         tr_middle->append_child(cl_B);
         tr_middle->append_child(cl_C);
 
-        otio::SerializableObject::Retainer<otio::Track> tr_bottom =
-            new otio::Track();
+        SerializableObject::Retainer<Track> tr_bottom = new Track();
 
         tr_bottom->append_child(cl_D);
 
-        otio::SerializableObject::Retainer<otio::Stack> st =
-            new otio::Stack();
+        SerializableObject::Retainer<Stack> st = new Stack();
         st->append_child(tr_bottom);
         st->append_child(tr_middle);
         st->append_child(tr_top);
@@ -120,11 +110,10 @@ main(int argc, char** argv)
 
     tests.add_test(
         "test_flatten_stack_03", [] {
-        using namespace otio;
 
-        otio::RationalTime rt_0_24{0, 24};
-        otio::RationalTime rt_150_24{150, 24};
-        otio::TimeRange tr_0_150_24{rt_0_24, rt_150_24};
+        RationalTime rt_0_24{0, 24};
+        RationalTime rt_150_24{150, 24};
+        TimeRange tr_0_150_24{rt_0_24, rt_150_24};
 
         // all three clips are identical but the middle track is empty
         // 0         150          300
@@ -135,29 +124,25 @@ main(int argc, char** argv)
         // should flatten to:
         // [    A     |     C     ]
 
-        otio::SerializableObject::Retainer<otio::Clip> cl_A =
-            new otio::Clip("track1_A", nullptr, tr_0_150_24);
-        otio::SerializableObject::Retainer<otio::Clip> cl_B =
-            new otio::Clip("track1_B", nullptr, tr_0_150_24);
-        otio::SerializableObject::Retainer<otio::Clip> cl_C =
-            new otio::Clip("track1_C", nullptr, tr_0_150_24);
+        SerializableObject::Retainer<Clip> cl_A =
+            new Clip("track1_A", nullptr, tr_0_150_24);
+        SerializableObject::Retainer<Clip> cl_B =
+            new Clip("track1_B", nullptr, tr_0_150_24);
+        SerializableObject::Retainer<Clip> cl_C =
+            new Clip("track1_C", nullptr, tr_0_150_24);
 
-        otio::SerializableObject::Retainer<otio::Track> tr_top =
-            new otio::Track();
+        SerializableObject::Retainer<Track> tr_top = new Track();
         tr_top->append_child(cl_A);
 
-        otio::SerializableObject::Retainer<otio::Track> tr_middle =
-            new otio::Track();
+        SerializableObject::Retainer<Track> tr_middle = new Track();
 
-        otio::SerializableObject::Retainer<otio::Track> tr_bottom =
-            new otio::Track();
+        SerializableObject::Retainer<Track> tr_bottom = new Track();
 
         tr_bottom->append_child(cl_B);
         tr_bottom->append_child(cl_C);
 
 
-        otio::SerializableObject::Retainer<otio::Stack> st =
-            new otio::Stack();
+        SerializableObject::Retainer<Stack> st = new Stack();
         st->append_child(tr_bottom);
         st->append_child(tr_middle);
         st->append_child(tr_top);
@@ -171,11 +156,10 @@ main(int argc, char** argv)
 
     tests.add_test(
         "test_flatten_vector_01", [] {
-        using namespace otio;
 
-        otio::RationalTime rt_0_24{0, 24};
-        otio::RationalTime rt_150_24{150, 24};
-        otio::TimeRange tr_0_150_24{rt_0_24, rt_150_24};
+        RationalTime rt_0_24{0, 24};
+        RationalTime rt_150_24{150, 24};
+        TimeRange tr_0_150_24{rt_0_24, rt_150_24};
 
         // all three clips are identical, but placed such that A is over B and
         // has no gap or end over C, tests vector version
@@ -186,19 +170,17 @@ main(int argc, char** argv)
         // should flatten to:
         // [    A     |     C     ]
 
-        otio::SerializableObject::Retainer<otio::Clip> cl_A =
-            new otio::Clip("track1_A", nullptr, tr_0_150_24);
-        otio::SerializableObject::Retainer<otio::Clip> cl_B =
-            new otio::Clip("track1_B", nullptr, tr_0_150_24);
-        otio::SerializableObject::Retainer<otio::Clip> cl_C =
-            new otio::Clip("track1_C", nullptr, tr_0_150_24);
+        SerializableObject::Retainer<Clip> cl_A =
+            new Clip("track1_A", nullptr, tr_0_150_24);
+        SerializableObject::Retainer<Clip> cl_B =
+            new Clip("track1_B", nullptr, tr_0_150_24);
+        SerializableObject::Retainer<Clip> cl_C =
+            new Clip("track1_C", nullptr, tr_0_150_24);
 
-        otio::SerializableObject::Retainer<otio::Track> tr_over =
-            new otio::Track();
+        SerializableObject::Retainer<Track> tr_over = new Track();
         tr_over->append_child(cl_A);
 
-        otio::SerializableObject::Retainer<otio::Track> tr_under =
-            new otio::Track();
+        SerializableObject::Retainer<Track> tr_under = new Track();
         tr_under->append_child(cl_B);
         tr_under->append_child(cl_C);
 

--- a/tests/test_timeline.cpp
+++ b/tests/test_timeline.cpp
@@ -9,8 +9,7 @@
 
 #include <iostream>
 
-namespace otime = opentime::OPENTIME_VERSION_NS;
-namespace otio  = opentimelineio::OPENTIMELINEIO_VERSION_NS;
+using namespace OTIO_NS;
 
 int
 main(int argc, char** argv)
@@ -19,61 +18,47 @@ main(int argc, char** argv)
 
     tests.add_test(
         "test_find_children", [] {
-        using namespace otio;
-        otio::SerializableObject::Retainer<otio::Clip> cl =
-            new otio::Clip();
-        otio::SerializableObject::Retainer<otio::Track> tr =
-            new otio::Track();
+        SerializableObject::Retainer<Clip> cl = new Clip();
+        SerializableObject::Retainer<Track> tr = new Track();
         tr->append_child(cl);
-        otio::SerializableObject::Retainer<otio::Timeline> tl =
-            new otio::Timeline();
+        SerializableObject::Retainer<Timeline> tl = new Timeline();
         tl->tracks()->append_child(tr);
         OTIO_NS::ErrorStatus err;
-        auto result = tl->find_children<otio::Clip>(&err);
+        auto result = tl->find_children<Clip>(&err);
         assertEqual(result.size(), 1);
         assertEqual(result[0].value, cl.value);
     });
     tests.add_test(
         "test_find_children_search_range", [] {
-        using namespace otio;
         const TimeRange range(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0));
-        otio::SerializableObject::Retainer<otio::Clip> cl0 =
-            new otio::Clip();
+        SerializableObject::Retainer<Clip> cl0 = new Clip();
         cl0->set_source_range(range);
-        otio::SerializableObject::Retainer<otio::Clip> cl1 =
-            new otio::Clip();
+        SerializableObject::Retainer<Clip> cl1 = new Clip();
         cl1->set_source_range(range);
-        otio::SerializableObject::Retainer<otio::Clip> cl2 =
-            new otio::Clip();
+        SerializableObject::Retainer<Clip> cl2 = new Clip();
         cl2->set_source_range(range);
-        otio::SerializableObject::Retainer<otio::Track> tr =
-            new otio::Track();
+        SerializableObject::Retainer<Track> tr = new Track();
         tr->append_child(cl0);
         tr->append_child(cl1);
         tr->append_child(cl2);
-        otio::SerializableObject::Retainer<otio::Timeline> tl =
-            new otio::Timeline();
+        SerializableObject::Retainer<Timeline> tl = new Timeline();
         tl->tracks()->append_child(tr);
         OTIO_NS::ErrorStatus err;
-        auto result = tl->find_children<otio::Clip>(&err, range);
+        auto result = tl->find_children<Clip>(&err, range);
         assertEqual(result.size(), 1);
         assertEqual(result[0].value, cl0.value);
     });
     tests.add_test(
         "test_find_children_shallow_search", [] {
-        using namespace otio;
-        otio::SerializableObject::Retainer<otio::Clip> cl =
-            new otio::Clip();
-        otio::SerializableObject::Retainer<otio::Track> tr =
-            new otio::Track();
+        SerializableObject::Retainer<Clip> cl = new Clip();
+        SerializableObject::Retainer<Track> tr = new Track();
         tr->append_child(cl);
-        otio::SerializableObject::Retainer<otio::Timeline> tl =
-            new otio::Timeline();
+        SerializableObject::Retainer<Timeline> tl = new Timeline();
         tl->tracks()->append_child(tr);
         OTIO_NS::ErrorStatus err;
-        auto result = tl->find_children<otio::Clip>(&err, std::nullopt, true);
+        auto result = tl->find_children<Clip>(&err, std::nullopt, true);
         assertEqual(result.size(), 0);
-        result = tl->find_children<otio::Clip>(&err, std::nullopt, false);
+        result = tl->find_children<Clip>(&err, std::nullopt, false);
         assertEqual(result.size(), 1);
         assertEqual(result[0].value, cl.value);
     });

--- a/tests/test_track.cpp
+++ b/tests/test_track.cpp
@@ -9,8 +9,7 @@
 
 #include <iostream>
 
-namespace otime = opentime::OPENTIME_VERSION_NS;
-namespace otio  = opentimelineio::OPENTIMELINEIO_VERSION_NS;
+using namespace OTIO_NS;
 
 int
 main(int argc, char** argv)
@@ -19,64 +18,56 @@ main(int argc, char** argv)
 
     tests.add_test(
         "test_find_children", [] {
-        using namespace otio;
-        otio::SerializableObject::Retainer<otio::Clip> cl =
-            new otio::Clip();
-        otio::SerializableObject::Retainer<otio::Track> tr =
-            new otio::Track();
+        SerializableObject::Retainer<Clip> cl = new Clip();
+        SerializableObject::Retainer<Track> tr = new Track();
         tr->append_child(cl);
         OTIO_NS::ErrorStatus err;
-        auto result = tr->find_children<otio::Clip>(&err);
+        auto result = tr->find_children<Clip>(&err);
         assertEqual(result.size(), 1);
         assertEqual(result[0].value, cl.value);
     });
     tests.add_test(
         "test_find_children_search_range", [] {
-        using namespace otio;
         const TimeRange range(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0));
-        otio::SerializableObject::Retainer<otio::Clip> cl0 =
-            new otio::Clip();
+        SerializableObject::Retainer<Clip> cl0 = new Clip();
         cl0->set_source_range(range);
-        otio::SerializableObject::Retainer<otio::Clip> cl1 =
-            new otio::Clip();
+        SerializableObject::Retainer<Clip> cl1 = new Clip();
         cl1->set_source_range(range);
-        otio::SerializableObject::Retainer<otio::Clip> cl2 =
-            new otio::Clip();
+        SerializableObject::Retainer<Clip> cl2 = new Clip();
         cl2->set_source_range(range);
-        otio::SerializableObject::Retainer<otio::Track> tr =
-            new otio::Track();
+        SerializableObject::Retainer<Track> tr = new Track();
         tr->append_child(cl0);
         tr->append_child(cl1);
         tr->append_child(cl2);
         OTIO_NS::ErrorStatus err;
-        auto result = tr->find_children<otio::Clip>(
+        auto result = tr->find_children<Clip>(
             &err,
             TimeRange(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0)));
         assertEqual(result.size(), 1);
         assertEqual(result[0].value, cl0.value);
-        result = tr->find_children<otio::Clip>(
+        result = tr->find_children<Clip>(
             &err,
             TimeRange(RationalTime(24.0, 24.0), RationalTime(24.0, 24.0)));
         assertEqual(result.size(), 1);
         assertEqual(result[0].value, cl1.value);
-        result = tr->find_children<otio::Clip>(
+        result = tr->find_children<Clip>(
             &err,
             TimeRange(RationalTime(48.0, 24.0), RationalTime(24.0, 24.0)));
         assertEqual(result.size(), 1);
         assertEqual(result[0].value, cl2.value);
-        result = tr->find_children<otio::Clip>(
+        result = tr->find_children<Clip>(
             &err,
             TimeRange(RationalTime(0.0, 24.0), RationalTime(48.0, 24.0)));
         assertEqual(result.size(), 2);
         assertEqual(result[0].value, cl0.value);
         assertEqual(result[1].value, cl1.value);
-        result = tr->find_children<otio::Clip>(
+        result = tr->find_children<Clip>(
             &err,
             TimeRange(RationalTime(24.0, 24.0), RationalTime(48.0, 24.0)));
         assertEqual(result.size(), 2);
         assertEqual(result[0].value, cl1.value);
         assertEqual(result[1].value, cl2.value);
-        result = tr->find_children<otio::Clip>(
+        result = tr->find_children<Clip>(
             &err,
             TimeRange(RationalTime(0.0, 24.0), RationalTime(72.0, 24.0)));
         assertEqual(result.size(), 3);
@@ -86,23 +77,18 @@ main(int argc, char** argv)
     });
     tests.add_test(
         "test_find_children_shallow_search", [] {
-        using namespace otio;
-        otio::SerializableObject::Retainer<otio::Clip> cl0 =
-            new otio::Clip();
-        otio::SerializableObject::Retainer<otio::Clip> cl1 =
-            new otio::Clip();
-        otio::SerializableObject::Retainer<otio::Stack> st =
-            new otio::Stack();
+        SerializableObject::Retainer<Clip> cl0 = new Clip();
+        SerializableObject::Retainer<Clip> cl1 = new Clip();
+        SerializableObject::Retainer<Stack> st = new Stack();
         st->append_child(cl1);
-        otio::SerializableObject::Retainer<otio::Track> tr =
-            new otio::Track();
+        SerializableObject::Retainer<Track> tr = new Track();
         tr->append_child(cl0);
         tr->append_child(st);
         OTIO_NS::ErrorStatus err;
-        auto result = tr->find_children<otio::Clip>(&err, std::nullopt, true);
+        auto result = tr->find_children<Clip>(&err, std::nullopt, true);
         assertEqual(result.size(), 1);
         assertEqual(result[0].value, cl0.value);
-        result = tr->find_children<otio::Clip>(&err, std::nullopt, false);
+        result = tr->find_children<Clip>(&err, std::nullopt, false);
         assertEqual(result.size(), 2);
         assertEqual(result[0].value, cl0.value);
         assertEqual(result[1].value, cl1.value);
@@ -110,7 +96,6 @@ main(int argc, char** argv)
 
     tests.add_test(
         "test_find_children_stack", [] {
-        using namespace otio;
 
         SerializableObject::Retainer<Stack> stack = new Stack();
         SerializableObject::Retainer<Track> track = new Track;
@@ -121,7 +106,7 @@ main(int argc, char** argv)
         // Simple find.
         clip->set_source_range(
             TimeRange(RationalTime(0.0, 24.0), RationalTime(3.0, 24.0)));
-        otio::ErrorStatus err;
+        OTIO_NS::ErrorStatus err;
         auto items = stack->find_children(
             &err,
             TimeRange(RationalTime(0.0, 24.0), RationalTime(1.0, 24.0)));


### PR DESCRIPTION
This PR cleans up the use of namespaces in the C++ tests, making the code more consistent and using the recommended OTIO_NS macro. There are no functional changes.
