### PR TITLE
Check if we are dividing by zero when rescaling

### DIFF
--- a/src/opentime/rationalTime.h
+++ b/src/opentime/rationalTime.h
@@ -69,7 +69,9 @@ public:
     /// @brief Returns the time value converted to a new rate.
     constexpr double value_rescaled_to(double new_rate) const noexcept
     {
-        return new_rate == _rate ? _value : (_value * new_rate) / _rate;
+        return new_rate == _rate
+                   ? _value
+                   : (_rate > 0 ? (_value * new_rate) / _rate : 0);
     }
 
     /// @brief Returns the time value converted to a new rate.

--- a/tests/test_opentime.cpp
+++ b/tests/test_opentime.cpp
@@ -32,6 +32,18 @@ main(int argc, char** argv)
         assertFalse(t2.is_invalid_time());
     });
 
+    tests.add_test("test_rescale", [] {
+        RationalTime t1(1.0, 1.0);
+        RationalTime t2 = t1.rescaled_to(24);
+        assertEqual(t2.value(), 24);
+        assertEqual(t2.rate(), 24);
+
+        // Try rescaling an invalid time:
+        t2 = RationalTime(1.0, 0.0).rescaled_to(24);
+        assertEqual(t2.value(), 0);
+        assertEqual(t2.rate(), 24);
+    });
+
     tests.add_test("test_equality", [] {
         RationalTime t1(30.2);
         assertEqual(t1, t1);


### PR DESCRIPTION
Add a check to make sure we are not dividing by zero when rescaling.
