### PR TITLE
Fix edit algorithms deleting the wrong child via remove_child(<pointer>)

### DIFF
--- a/src/opentimelineio/algo/editAlgorithm.cpp
+++ b/src/opentimelineio/algo/editAlgorithm.cpp
@@ -119,7 +119,7 @@ overwrite(
                         || static_cast<size_t>(index)
                                >= composition->children().size())
                         continue;
-                    composition->remove_child(transition);
+                    composition->remove_child(index);
                 }
             }
         }
@@ -254,7 +254,8 @@ overwrite(
             // Remove the completely overwritten items.
             while (!items.empty())
             {
-                composition->remove_child(items.back());
+                composition->remove_child(
+                    composition->index_of_child(items.back()));
                 items.pop_back();
             }
 
@@ -291,7 +292,7 @@ insert(
                     || static_cast<size_t>(index)
                            >= composition->children().size())
                     continue;
-                composition->remove_child(transition);
+                composition->remove_child(index);
             }
         }
     }

--- a/src/opentimelineio/serializableObject.h
+++ b/src/opentimelineio/serializableObject.h
@@ -626,7 +626,7 @@ public:
 
         T* operator->() const noexcept { return value; }
 
-        operator bool() const noexcept { return value != nullptr; }
+        explicit operator bool() const noexcept { return value != nullptr; }
 
         Retainer(T const* so = nullptr)
             : value((T*) so)

--- a/tests/test_editAlgorithm.cpp
+++ b/tests/test_editAlgorithm.cpp
@@ -734,6 +734,58 @@ main(int argc, char** argv)
               TimeRange(RationalTime(36.0, 24.0), RationalTime(12.0, 24.0)) });
     });
 
+    tests.add_test("test_edit_overwrite_partial_first_full_last", [] {
+        // Overwrite that partially covers one clip and fully covers the next,
+        // ending exactly at the composition end. Regression test: the loop that
+        // removes the fully-overwritten items called remove_child() with a
+        // pointer, but Composition only declares remove_child(int), so the
+        // pointer decayed to bool->int(1) and the WRONG child was deleted (the
+        // partially-overwritten clip survived in place of the fully-covered one).
+        SerializableObject::Retainer<Clip> clip_0 = new Clip(
+            "clip_0",
+            nullptr,
+            TimeRange(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0)));
+        SerializableObject::Retainer<Clip> clip_1 = new Clip(
+            "clip_1",
+            nullptr,
+            TimeRange(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0)));
+        SerializableObject::Retainer<Clip> clip_2 = new Clip(
+            "clip_2",
+            nullptr,
+            TimeRange(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0)));
+        SerializableObject::Retainer<Track> track = new Track();
+        track->append_child(clip_0);
+        track->append_child(clip_1);
+        track->append_child(clip_2);
+
+        SerializableObject::Retainer<Clip> over = new Clip(
+            "over",
+            nullptr,
+            TimeRange(RationalTime(0.0, 24.0), RationalTime(100.0, 24.0)));
+        OTIO_NS::ErrorStatus error_status;
+        algo::overwrite(
+            over,
+            track,
+            TimeRange(RationalTime(36.0, 24.0), RationalTime(36.0, 24.0)),
+            true,
+            nullptr,
+            &error_status);
+
+        // clip_0 unchanged, clip_1 trimmed to its first half, clip_2 fully
+        // overwritten (removed), over inserted last.
+        assert(!is_error(error_status));
+        assert(track->children().size() == 3);
+        assert(dynamic_cast<Clip*>(track->children()[1].value)->name()
+               == "clip_1");
+        assert(dynamic_cast<Clip*>(track->children()[2].value)->name()
+               == "over");
+        assert_track_ranges(
+            track,
+            { TimeRange(RationalTime(0.0, 24.0), RationalTime(24.0, 24.0)),
+              TimeRange(RationalTime(24.0, 24.0), RationalTime(12.0, 24.0)),
+              TimeRange(RationalTime(36.0, 24.0), RationalTime(36.0, 24.0)) });
+    });
+
     tests.add_test("test_edit_overwrite_4", [] {
         // Create a track with one long clip.
         SerializableObject::Retainer<Clip> clip_0 = new Clip(


### PR DESCRIPTION
Composition only declares `remove_child(int index, ErrorStatus*)`, but `overwrite()` and `insert()` in `editAlgorithm.cpp` call it with a `Composable*` / `Retainer`:

```cpp
composition->remove_child(transition);     // overwrite() and insert()
composition->remove_child(items.back());   // overwrite()
```

The pointer argument decays to `bool` (always `true`) → `int(1)`, so these calls remove the child at **index 1** (or, via `adjusted_vector_index`, the last child when `size() == 1`), **not** the item that was passed.

### Impact
- `overwrite()` over a multi-item span deletes the wrong clips: the partially-overwritten clip is removed while a fully-overwritten clip survives in place.
- Transition removal in `overwrite()`/`insert()` removes index 1 instead of the intended transition.

### Repro
Track `A|M|B` (each 5/8/5 frames), `overwrite(X, track, [8, 18))` — a span that partially covers `M` and fully covers `B` to the track end:

```
before (buggy):  A[0+5] B[20+5] X[2+10]   # M removed, B kept — wrong
after  (fixed):  A[0+5] M[10+3] X[2+10]   # M trimmed, B removed — correct
```

### Fix
Pass the already-computed (and bounds-checked) `index` for transitions, and `index_of_child(items.back())` in the removal loop.

### Tests
- Adds `test_edit_overwrite_partial_first_full_last`, which fails before this change and passes after.
- The existing `test_editAlgorithm` suite continues to pass.

I verified the fix and the regression test by building the library locally (the test fails on the unfixed tree, passes on the fixed tree).