### PR TITLE
updated ubuntu version to one with python 3.10 support

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ sphinx:
   configuration: docs/conf.py
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-22.04"
   tools:
     python: "3.10"
 


### PR DESCRIPTION
updated ubuntu version to one with python 3.10 support to get rtd build to work

**Link the Issue(s) this Pull Request is related to.**

If there is an associated issue, link it in the form:

Should unblock PRs #2023 and #1799 

**Summarize your change.**

Read the Docs automation fails due to outdated Ubuntu version. Updated to a supported version. 

**Reference associated tests.**

No tests other than the CI passing

<!--
Important: If this is your first contribution to OpenTimelineIO, you will need to submit a Contributor License Agreement. For a step-by-step instructions on the pull request process, see
https://github.com/AcademySoftwareFoundation/OpenTimelineIO/tree/main/CONTRIBUTING.md
-->
