### PR TITLE
Fix for minizip-ng targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,6 +295,20 @@ endif()
 # set up the internally hosted dependencies
 add_subdirectory(src/deps)
 
+# Needed when OTIO is built against an external minizip-ng, which names its
+# target minizip-ng when built without the compatibility layer.
+if(TARGET MINIZIP::minizip-ng)
+    set(OTIO_MINIZIP_TARGET MINIZIP::minizip-ng)
+else()
+    set(OTIO_MINIZIP_TARGET MINIZIP::minizip)
+endif()
+
+# install(TARGETS) does not accept an alias.
+get_target_property(OTIO_MINIZIP_LIB ${OTIO_MINIZIP_TARGET} ALIASED_TARGET)
+if(NOT OTIO_MINIZIP_LIB)
+    set(OTIO_MINIZIP_LIB ${OTIO_MINIZIP_TARGET})
+endif()
+
 add_subdirectory(src/opentime)
 add_subdirectory(src/opentimelineio)
 

--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -94,7 +94,7 @@ endif()
 
 target_link_libraries(opentimelineio
     PUBLIC opentime Imath::Imath
-    PRIVATE MINIZIP::minizip)
+    PRIVATE ${OTIO_MINIZIP_TARGET})
 
 set_target_properties(opentimelineio PROPERTIES
     DEBUG_POSTFIX "${OTIO_DEBUG_POSTFIX}"
@@ -137,7 +137,7 @@ if(OTIO_CXX_INSTALL)
     set(OPENTIMELINEIO_INCLUDES ${OTIO_RESOLVED_CXX_INSTALL_DIR}/include)
 
     if(NOT OTIO_FIND_MINIZIP_NG)
-        install(TARGETS minizip
+        install(TARGETS ${OTIO_MINIZIP_LIB}
             EXPORT OpenTimelineIOTargets
             ARCHIVE DESTINATION "${OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR}"
             LIBRARY DESTINATION "${OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR}"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,4 +40,4 @@ foreach(test ${tests_opentimelineio})
            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endforeach()
 
-target_link_libraries(test_bundle MINIZIP::minizip)
+target_link_libraries(test_bundle ${OTIO_MINIZIP_TARGET})


### PR DESCRIPTION
External builds of minizip-ng can have different target names (`MINIZIP::minizip` or `MINIZIP::minizip-ng), so check which one is valid.

Assisted-by: Claude:claude-opus-5 [debugging]
