### PR TITLE
Fixes for API exports

### DIFF
--- a/src/opentime/CMakeLists.txt
+++ b/src/opentime/CMakeLists.txt
@@ -30,7 +30,7 @@ if(OTIO_SHARED_LIBS)
         VERSION ${OTIO_VERSION})
     target_compile_definitions(
         opentime
-        PUBLIC
+        PRIVATE
         OPENTIME_EXPORTS)
 else()
     target_compile_definitions(

--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -107,7 +107,7 @@ if(OTIO_SHARED_LIBS)
         VERSION ${OTIO_VERSION})
     target_compile_definitions(
         opentimelineio
-        PUBLIC
+        PRIVATE
         OTIO_EXPORTS)
 else()
     target_compile_definitions(

--- a/src/opentimelineio/bundle.h
+++ b/src/opentimelineio/bundle.h
@@ -37,7 +37,7 @@ namespace bundle {
     };
 
     /// @brief Get a file from a URL.
-    std::optional<std::string> file_from_url(std::string const& url);
+    OTIO_API std::optional<std::string> file_from_url(std::string const& url);
 
     /// @brief Options for writing bundles.
     struct OTIO_API_TYPE WriteOptions

--- a/src/opentimelineio/color.h
+++ b/src/opentimelineio/color.h
@@ -39,23 +39,23 @@ public:
 
     OTIO_API Color(Color const& other);
 
-    static const Color pink;
-    static const Color red;
-    static const Color orange;
-    static const Color yellow;
-    static const Color green;
-    static const Color cyan;
-    static const Color blue;
-    static const Color purple;
-    static const Color magenta;
-    static const Color black;
-    static const Color white;
-    static const Color transparent;
+    OTIO_API static const Color pink;
+    OTIO_API static const Color red;
+    OTIO_API static const Color orange;
+    OTIO_API static const Color yellow;
+    OTIO_API static const Color green;
+    OTIO_API static const Color cyan;
+    OTIO_API static const Color blue;
+    OTIO_API static const Color purple;
+    OTIO_API static const Color magenta;
+    OTIO_API static const Color black;
+    OTIO_API static const Color white;
+    OTIO_API static const Color transparent;
 
-    static Color* from_hex(std::string const& color);
-    static Color* from_int_list(std::vector<int> const& color, int bit_depth);
-    static Color* from_agbr_int(unsigned int agbr) noexcept;
-    static Color* from_float_list(std::vector<double> const& color);
+    OTIO_API static Color* from_hex(std::string const& color);
+    OTIO_API static Color* from_int_list(std::vector<int> const& color, int bit_depth);
+    OTIO_API static Color* from_agbr_int(unsigned int agbr) noexcept;
+    OTIO_API static Color* from_float_list(std::vector<double> const& color);
 
     friend bool operator==(Color lhs, Color rhs) noexcept
     {

--- a/src/opentimelineio/composition.h
+++ b/src/opentimelineio/composition.h
@@ -157,7 +157,7 @@ public:
     /// @param shallow_search The search is recursive unless shallow_search is
     /// set to true.
     template <typename T = Composable>
-    OTIO_API std::vector<Retainer<T>> find_children(
+    std::vector<Retainer<T>> find_children(
         ErrorStatus*             error_status   = nullptr,
         std::optional<TimeRange> search_range   = std::nullopt,
         bool                     shallow_search = false) const;

--- a/src/opentimelineio/deserialization.cpp
+++ b/src/opentimelineio/deserialization.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenTimelineIO project
 
+#include "opentimelineio/deserialization.h"
+
 #include "opentime/rationalTime.h"
 #include "opentime/timeRange.h"
 #include "opentime/timeTransform.h"

--- a/src/opentimelineio/imageSequenceReference.h
+++ b/src/opentimelineio/imageSequenceReference.h
@@ -136,23 +136,23 @@ public:
     }
 
     /// @brief Return the end frame.
-    int end_frame() const;
+    OTIO_API int end_frame() const;
 
     /// @brief Return the number of images in the sequence.
-    int number_of_images_in_sequence() const;
+    OTIO_API int number_of_images_in_sequence() const;
 
     /// @brief Return the frame for the given time.
-    int frame_for_time(
+    OTIO_API int frame_for_time(
         RationalTime const& time,
         ErrorStatus*        error_status = nullptr) const;
 
     /// @brief Return the target URL for the given image number.
-    std::string target_url_for_image_number(
+    OTIO_API std::string target_url_for_image_number(
         int          image_number,
         ErrorStatus* error_status = nullptr) const;
 
     /// @brief Return the presentation time for the given image number.
-    RationalTime presentation_time_for_image_number(
+    OTIO_API RationalTime presentation_time_for_image_number(
         int          image_number,
         ErrorStatus* error_status = nullptr) const;
 

--- a/src/opentimelineio/safely_typed_any.h
+++ b/src/opentimelineio/safely_typed_any.h
@@ -19,6 +19,7 @@
 /// common library. That's why the seemingly silly code in safely_typed_any.cpp
 /// exists.
 
+#include "opentimelineio/export.h"
 #include "opentime/rationalTime.h"
 #include "opentime/timeRange.h"
 #include "opentime/timeTransform.h"
@@ -31,48 +32,48 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION_NS {
 /// @name Any Create
 ///@{
 
-std::any create_safely_typed_any(bool&&);
-std::any create_safely_typed_any(int&&);
-std::any create_safely_typed_any(int64_t&&);
-std::any create_safely_typed_any(uint64_t&&);
-std::any create_safely_typed_any(double&&);
-std::any create_safely_typed_any(std::string&&);
-std::any create_safely_typed_any(RationalTime&&);
-std::any create_safely_typed_any(TimeRange&&);
-std::any create_safely_typed_any(Color&&);
-std::any create_safely_typed_any(TimeTransform&&);
-std::any create_safely_typed_any(IMATH_NAMESPACE::V2d&&);
-std::any create_safely_typed_any(IMATH_NAMESPACE::Box2d&&);
-std::any create_safely_typed_any(AnyVector&&);
-std::any create_safely_typed_any(AnyDictionary&&);
-std::any create_safely_typed_any(SerializableObject*);
+OTIO_API std::any create_safely_typed_any(bool&&);
+OTIO_API std::any create_safely_typed_any(int&&);
+OTIO_API std::any create_safely_typed_any(int64_t&&);
+OTIO_API std::any create_safely_typed_any(uint64_t&&);
+OTIO_API std::any create_safely_typed_any(double&&);
+OTIO_API std::any create_safely_typed_any(std::string&&);
+OTIO_API std::any create_safely_typed_any(RationalTime&&);
+OTIO_API std::any create_safely_typed_any(TimeRange&&);
+OTIO_API std::any create_safely_typed_any(Color&&);
+OTIO_API std::any create_safely_typed_any(TimeTransform&&);
+OTIO_API std::any create_safely_typed_any(IMATH_NAMESPACE::V2d&&);
+OTIO_API std::any create_safely_typed_any(IMATH_NAMESPACE::Box2d&&);
+OTIO_API std::any create_safely_typed_any(AnyVector&&);
+OTIO_API std::any create_safely_typed_any(AnyDictionary&&);
+OTIO_API std::any create_safely_typed_any(SerializableObject*);
 
 ///@}
 
 /// @name Any Casting
 ///@{
 
-bool                   safely_cast_bool_any(std::any const& a);
-int                    safely_cast_int_any(std::any const& a);
-int64_t                safely_cast_int64_any(std::any const& a);
-uint64_t               safely_cast_uint64_any(std::any const& a);
-double                 safely_cast_double_any(std::any const& a);
-std::string            safely_cast_string_any(std::any const& a);
-RationalTime           safely_cast_rational_time_any(std::any const& a);
-TimeRange              safely_cast_time_range_any(std::any const& a);
-TimeTransform          safely_cast_time_transform_any(std::any const& a);
-Color                  safely_cast_color_any(std::any const& a);
-IMATH_NAMESPACE::V2d   safely_cast_point_any(std::any const& a);
-IMATH_NAMESPACE::Box2d safely_cast_box_any(std::any const& a);
+OTIO_API bool                   safely_cast_bool_any(std::any const& a);
+OTIO_API int                    safely_cast_int_any(std::any const& a);
+OTIO_API int64_t                safely_cast_int64_any(std::any const& a);
+OTIO_API uint64_t               safely_cast_uint64_any(std::any const& a);
+OTIO_API double                 safely_cast_double_any(std::any const& a);
+OTIO_API std::string            safely_cast_string_any(std::any const& a);
+OTIO_API RationalTime           safely_cast_rational_time_any(std::any const& a);
+OTIO_API TimeRange              safely_cast_time_range_any(std::any const& a);
+OTIO_API TimeTransform          safely_cast_time_transform_any(std::any const& a);
+OTIO_API Color                  safely_cast_color_any(std::any const& a);
+OTIO_API IMATH_NAMESPACE::V2d   safely_cast_point_any(std::any const& a);
+OTIO_API IMATH_NAMESPACE::Box2d safely_cast_box_any(std::any const& a);
 
-SerializableObject* safely_cast_retainer_any(std::any const& a);
+OTIO_API SerializableObject* safely_cast_retainer_any(std::any const& a);
 
-AnyDictionary safely_cast_any_dictionary_any(std::any const& a);
+OTIO_API AnyDictionary safely_cast_any_dictionary_any(std::any const& a);
 AnyVector     safely_cast_any_vector_any(std::any const& a);
 
 /// @bug Don't use these unless you know what you're doing...
-AnyDictionary& temp_safely_cast_any_dictionary_any(std::any const& a);
-AnyVector&     temp_safely_cast_any_vector_any(std::any const& a);
+OTIO_API AnyDictionary& temp_safely_cast_any_dictionary_any(std::any const& a);
+OTIO_API AnyVector&     temp_safely_cast_any_vector_any(std::any const& a);
 
 ///@}
 

--- a/src/opentimelineio/serializableCollection.h
+++ b/src/opentimelineio/serializableCollection.h
@@ -98,7 +98,7 @@ public:
     /// @param shallow_search The search is recursive unless shallow_search is
     /// set to true.
     template <typename T = Composable>
-    OTIO_API std::vector<Retainer<T>> find_children(
+    std::vector<Retainer<T>> find_children(
         ErrorStatus*             error_status   = nullptr,
         std::optional<TimeRange> search_range   = std::nullopt,
         bool                     shallow_search = false) const;

--- a/src/opentimelineio/serializableObject.h
+++ b/src/opentimelineio/serializableObject.h
@@ -604,13 +604,13 @@ public:
     };
 
     /// @brief Deserialize from the given reader.
-    virtual bool read_from(Reader&);
+    OTIO_API virtual bool read_from(Reader&);
 
     /// @brief Serialize to the given writer.
-    virtual void write_to(Writer&) const;
+    OTIO_API virtual void write_to(Writer&) const;
 
     /// @brief Return whether this schema is unknown.
-    virtual bool is_unknown_schema() const;
+    OTIO_API virtual bool is_unknown_schema() const;
 
     /// @brief Return the schema name.
     std::string schema_name() const { return _type_record()->schema_name; }
@@ -675,9 +675,9 @@ public:
 protected:
     virtual ~SerializableObject();
 
-    virtual bool _is_deletable();
+    OTIO_API virtual bool _is_deletable();
 
-    virtual std::string _schema_name_for_reference() const;
+    OTIO_API virtual std::string _schema_name_for_reference() const;
 
 private:
     SerializableObject(SerializableObject const&)            = delete;
@@ -700,12 +700,12 @@ public:
     };
 
     /// @todo Add comment.
-    void install_external_keepalive_monitor(
+    OTIO_API void install_external_keepalive_monitor(
         std::function<void()> monitor,
         bool                  apply_now);
 
     /// @brief Return the current reference count.
-    int current_ref_count() const;
+    OTIO_API int current_ref_count() const;
 
     /// @brief This struct provides an unknown type.
     struct UnknownType
@@ -719,7 +719,7 @@ private:
         _cached_type_record = type_record;
     }
 
-    TypeRegistry::_TypeRecord const* _type_record() const;
+    OTIO_API TypeRegistry::_TypeRecord const* _type_record() const;
 
     mutable TypeRegistry::_TypeRecord const* _cached_type_record;
     int                                      _managed_ref_count;

--- a/src/opentimelineio/serializableObjectWithMetadata.h
+++ b/src/opentimelineio/serializableObjectWithMetadata.h
@@ -42,10 +42,10 @@ public:
     AnyDictionary metadata() const noexcept { return _metadata; }
 
 protected:
-    virtual ~SerializableObjectWithMetadata();
+    OTIO_API virtual ~SerializableObjectWithMetadata();
 
-    bool read_from(Reader&) override;
-    void write_to(Writer&) const override;
+    OTIO_API bool read_from(Reader&) override;
+    OTIO_API void write_to(Writer&) const override;
 
 private:
     std::string   _name;

--- a/src/opentimelineio/stringUtils.cpp
+++ b/src/opentimelineio/stringUtils.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenTimelineIO project
 
+#include "stringUtils.h"
+
 #include "opentimelineio/serializableObject.h"
 #include <cstdlib>
 #include <memory>

--- a/src/opentimelineio/stringUtils.h
+++ b/src/opentimelineio/stringUtils.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "opentime/stringPrintf.h"
+#include "opentimelineio/export.h"
 #include "opentimelineio/version.h"
 using opentime::string_printf;
 
@@ -17,9 +18,9 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION_NS {
 
 void fatal_error(std::string const& errMsg);
 
-std::string type_name_for_error_message(std::type_info const&);
-std::string type_name_for_error_message(std::any const& a);
-std::string type_name_for_error_message(class SerializableObject*);
+OTIO_API std::string type_name_for_error_message(std::type_info const&);
+OTIO_API std::string type_name_for_error_message(std::any const& a);
+OTIO_API std::string type_name_for_error_message(class SerializableObject*);
 
 template <typename T>
 std::string

--- a/src/opentimelineio/timeline.h
+++ b/src/opentimelineio/timeline.h
@@ -44,7 +44,7 @@ public:
     }*/
 
     /// @brief Set the timeline stack.
-    void set_tracks(Stack* stack);
+    OTIO_API void set_tracks(Stack* stack);
 
     /// @brief Return the global start time.
     std::optional<RationalTime> global_start_time() const noexcept
@@ -97,7 +97,7 @@ public:
     /// @param shallow_search The search is recursive unless shallow_search is
     /// set to true.
     template <typename T = Composable>
-    OTIO_API std::vector<Retainer<T>> find_children(
+    std::vector<Retainer<T>> find_children(
         ErrorStatus*             error_status   = nullptr,
         std::optional<TimeRange> search_range   = std::nullopt,
         bool                     shallow_search = false) const;

--- a/src/opentimelineio/transition.h
+++ b/src/opentimelineio/transition.h
@@ -82,11 +82,11 @@ public:
     RationalTime duration(ErrorStatus* error_status = nullptr) const override;
 
     /// @brief Return the range in the parent's time.
-    std::optional<TimeRange>
+    OTIO_API std::optional<TimeRange>
     range_in_parent(ErrorStatus* error_status = nullptr) const;
 
     /// @brief Return the range trimmed in the parent's time.
-    std::optional<TimeRange>
+    OTIO_API std::optional<TimeRange>
     trimmed_range_in_parent(ErrorStatus* error_status = nullptr) const;
 
 protected:

--- a/src/opentimelineio/typeRegistry.h
+++ b/src/opentimelineio/typeRegistry.h
@@ -33,7 +33,7 @@ using label_to_schema_version_map =
 
 ///@}
 
-extern const label_to_schema_version_map CORE_VERSION_MAP;
+extern OTIO_API const label_to_schema_version_map CORE_VERSION_MAP;
 
 /// @brief Type registry.
 class OTIO_API_TYPE TypeRegistry
@@ -42,7 +42,7 @@ public:
     /// @brief Get the type registry singleton.
     ///
     /// Access to functions are thread-safe.
-    static TypeRegistry& instance();
+    OTIO_API static TypeRegistry& instance();
 
     /// @brief Register a new schema.
     ///
@@ -51,7 +51,7 @@ public:
     /// the templated form of this call.
     ///
     /// If the specified schema_name has already been registered, this function does nothing and returns false.
-    bool register_type(
+    OTIO_API bool register_type(
         std::string const&                   schema_name,
         int                                  schema_version,
         std::type_info const*                type,
@@ -79,7 +79,7 @@ public:
     /// case a schema name is changed and the old name needs to be allowed as well.
     ///
     /// On success, returns true; otherwise, returns false and sets error_status if non-null.
-    bool register_type_from_existing_type(
+    OTIO_API bool register_type_from_existing_type(
         std::string const& schema_name,
         int                schema_version,
         std::string const& existing_schema_name,
@@ -98,7 +98,7 @@ public:
     ///
     /// Returns false if an upgrade function has been registered for this (schema_name, version)
     /// pair, or if schema_name itself has not been registered, and true otherwise.
-    bool register_upgrade_function(
+    OTIO_API bool register_upgrade_function(
         std::string const&                  schema_name,
         int                                 version_to_upgrade_to,
         std::function<void(AnyDictionary*)> upgrade_function);
@@ -119,7 +119,7 @@ public:
 
     /// @brief Downgrade function from version_to_downgrade_from to
     /// version_to_downgrade_from - 1
-    bool register_downgrade_function(
+    OTIO_API bool register_downgrade_function(
         std::string const&                  schema_name,
         int                                 version_to_downgrade_from,
         std::function<void(AnyDictionary*)> downgrade_function);
@@ -154,13 +154,13 @@ public:
     }
 
     /// @brief For use by external bridging systems.
-    bool set_type_record(
+    OTIO_API bool set_type_record(
         SerializableObject*,
         std::string const& schema_name,
         ErrorStatus*       error_status = nullptr);
 
     /// @brief For inspecting the type registry, build a map of schema name to version.
-    void type_version_map(schema_version_map& result);
+    OTIO_API void type_version_map(schema_version_map& result);
 
 private:
     TypeRegistry();
@@ -204,7 +204,7 @@ private:
         return it == _type_records.end() ? nullptr : it->second;
     }
 
-    SerializableObject* _instance_from_schema(
+    OTIO_API SerializableObject* _instance_from_schema(
         std::string    schema_name,
         int            schema_version,
         AnyDictionary& dict,


### PR DESCRIPTION
This PR has various fixes for the API exports:
* Change OTIO_EXPORTS and OPENTIME_EXPORTS to PRIVATE
* Add missing exports
* Remove the exports from templates which are inlined
* Add missing includes

Assisted-by: Claude:claude-opus-5 [debugging]
