### PR TITLE
Make the Windows debug postfix optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,10 +192,9 @@ else()
 endif()
 
 if(WIN32)
-    # Windows debug builds for Python require a d in order for the module to
-    # load. This also helps ensure that debug builds in general are matched
-    # to the Microsoft debug CRT.
-    set(OTIO_DEBUG_POSTFIX "_d")
+    # Windows builds for Python can use a postfix to find Debug versions.
+    set(OTIO_DEBUG_POSTFIX "_d" CACHE STRING
+        "Postfix for the names of debug libraries and Python modules")
 endif()
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)


### PR DESCRIPTION
This PR makes the Windows debug postfix an option, so either debug or release libraries can be used.

Assisted-by: Claude:claude-opus-5 [implementation, testing]